### PR TITLE
Result table improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.7.0
+* Add support for column filtering and reordering to `ResultTable`
+* Add support for `loadingAware` flag on injectTreeNode
+* Make `ResultTable` loading indicator only apply to the body and not the headers
+* Make `ResultTable` HeaderCell configurable (includes `activeFilter` prop)
+
 # 1.6.0
 * Add support for adding columns to `ResultTable` (note that it doesn't work with `infer`ed fields)
 * Improve ResultTable field drop down styling

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "React components for building contexture interfaces",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "React components for building contexture interfaces",
   "main": "index.js",
   "scripts": {
+    "start": "npm run storybook",
     "pre-build": "rm -rf ./dist",
     "build": "babel ./src --out-dir ./dist --source-maps",
     "prepublish": "npm run build",

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -54,6 +54,10 @@ let popoverStyle = {
   userSelect: 'none',
 }
 
+let HeaderCellDefault = observer(({ activeFilter, style, ...props }) => (
+  <a style={{...activeFilter ? { fontWeight: 900 } : {}, ...style}} {...props} />
+))
+
 let Header = withStateLens({ popover: false, adding: false, filtering: false })(
   observer(
     ({
@@ -68,6 +72,7 @@ let Header = withStateLens({ popover: false, adding: false, filtering: false })(
       FieldPicker,
       ListGroupItem: Item,
       typeComponents,
+      HeaderCell = HeaderCellDefault,
       
       // Contextual
       field: { field, label },
@@ -86,14 +91,13 @@ let Header = withStateLens({ popover: false, adding: false, filtering: false })(
       }
       return (
         <th style={{ cursor: 'pointer' }}>
-          <a onClick={F.flip(popover)} style={filterNode && filterNode.hasValue ? {
-            // TODO: make configurable
-            color: 'rgb(0, 118, 222)'
-            
-          } : {}}>
+          <HeaderCellDefault
+            onClick={F.flip(popover)}
+            activeFilter={_.get('hasValue', filterNode)}
+          >
             {label}{' '}
             {field === node.sortField && (node.sortDir === 'asc' ? '▲' : '▼')}
-          </a>
+          </HeaderCellDefault>
           <Popover isOpen={popover} style={popoverStyle}>
             <Item onClick={() => mutate({ sortField: field, sortDir: 'asc' })}>
               <Icon icon="▲" />
@@ -196,6 +200,7 @@ let ResultTable = InjectTreeNode(
 
       // Theme/Components      
       Table = 'table',
+      HeaderCell,
       Modal,
       ListGroupItem,
       FieldPicker,
@@ -220,6 +225,7 @@ let ResultTable = InjectTreeNode(
         FieldPicker,
         ListGroupItem,
         typeComponents,
+        HeaderCell,
         
         includes,
         addOptions: fieldsToOptions(hiddenFields),

--- a/src/exampleTypes/index.js
+++ b/src/exampleTypes/index.js
@@ -25,6 +25,7 @@ export default (
     Table = 'table',
     Modal = ModalDefault,
     FieldPicker,
+    ListGroupItem = 'div'
   } = {}
 ) => {
   let Components = {
@@ -34,7 +35,7 @@ export default (
     DateRangePicker,
     Query: partial({ TextInput }, Query),
     TagsQuery: partial({ TagsInput }, TagsQuery),
-    ResultTable: partial({ Table, Modal, FieldPicker }, ResultTable),
+    ResultTable: partial({ Table, Modal, FieldPicker, ListGroupItem }, ResultTable),
     ResultCount,
     ResultPager,
     DateHistogram,

--- a/src/styles/generic.js
+++ b/src/styles/generic.js
@@ -43,6 +43,11 @@ export let bgStriped = {
   backgroundSize: '1rem 1rem',
 }
 
+export let loading = {
+  ...bgStriped,
+  opacity: 0.5
+}
+
 // Search
 export let joinColor = join =>
   ({

--- a/src/themes/greyVest.js
+++ b/src/themes/greyVest.js
@@ -223,5 +223,6 @@ export let ExampleTypes = ExampleTypeConstructor({
     { Input, Highlight, Item: ListGroupItem },
     FilteredPicker
   ),
+  ListGroupItem
 })
 export let Pager = partial({ Item: PagerItem }, ExampleTypes.ResultPager)

--- a/src/utils/StripedLoader.js
+++ b/src/utils/StripedLoader.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import { observer } from 'mobx-react'
-import { bgStriped } from '../styles/generic'
+import { loading } from '../styles/generic'
 
 export default Component =>
   observer(props => (
-    <div style={props.loading ? { ...bgStriped, opacity: '0.5' } : {}}>
+    <div style={props.loading ? loading : {}}>
       <Component {...props} />
     </div>
   ))

--- a/src/utils/injectTreeNode.js
+++ b/src/utils/injectTreeNode.js
@@ -4,7 +4,7 @@ import StripedLoader from './StripedLoader'
 
 export default (
   render,
-  { type, reactors, nodeProps = _.keys(reactors) } = {}
+  { type, reactors, nodeProps = _.keys(reactors), loadingAware = false } = {}
 ) =>
   injectDefaults(({ tree, node, group, path, ...props }) => {
     node = node || tree.getNode(path)
@@ -33,5 +33,9 @@ export default (
     } else if (!node)
       throw Error(`Node not provided, and couldn't find node at ${path}`)
 
-    return { tree, node, loading: node.markedForUpdate || node.updating }
+    return {
+      tree,
+      node,
+      ...loadingAware ? {} :{ loading: node.markedForUpdate || node.updating }
+    }
   })(StripedLoader(render))

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -128,7 +128,7 @@ let schemas = fromPromise(
 export default () => (
   <div className="gv-body">
     <link
-      href="https://fonts.googleapis.com/css?family=Lato"
+      href="https://fonts.googleapis.com/css?family=Lato:400,700,900"
       rel="stylesheet"
     />
     <GVStyle />

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -215,6 +215,8 @@ export default () => (
                 <ResultTable
                   path={['root', 'results']}
                   fields={schemas[tree.tree.schema].fields}
+                  criteria={['root', 'criteria']}
+                  typeComponents={TypeMap}
                 />
                 <Flex
                   style={{ justifyContent: 'space-around', padding: '10px' }}


### PR DESCRIPTION
* Add support for column filtering and reordering to `ResultTable`
* Add support for `loadingAware` flag on injectTreeNode
* Make `ResultTable` loading indicator only apply to the body and not the headers
* Make `ResultTable` HeaderCell configurable (includes `activeFilter` prop)