### PR TITLE
Map node to props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.8.0
+* Add support for `mapNodeToProps` on `FilterList`
+* Add support for `displayBlank` on `Facet`, which defaults to <i>Not Specified</i>
+* Make the main npm script be `dist` to support importing direct from contexture-react
+
 # 1.7.2
 * Made Grey Vest able to compose styles.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 * Add support for `mapNodeToProps` on `FilterList`
 * Add support for `displayBlank` on `Facet`, which defaults to <i>Not Specified</i>
 * Make the main npm script be `dist` to support importing direct from contexture-react
+* Make inject tree node generate deterministic nodeKey if not provided
+* Make ResultCount be inline-block and add inject tree node style support
 
 # 1.7.2
 * Made Grey Vest able to compose styles.

--- a/__tests__/__snapshots__/Snaphot.js.snap
+++ b/__tests__/__snapshots__/Snaphot.js.snap
@@ -107,7 +107,7 @@ exports[`Storyshots Docs CHANGELOG.md 1`] = `
     </div>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots Docs README.md 1`] = `
 <div>
@@ -216,7 +216,7 @@ exports[`Storyshots Docs README.md 1`] = `
     </div>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots Example Types Full Demo 1`] = `
 <div
@@ -527,6 +527,37 @@ exports[`Storyshots Example Types Full Demo 1`] = `
                     }
                   }
                 >
+                  <i>
+                    Not Specified
+                  </i>
+                </div>
+                <div>
+                  4
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "alignItems": "baseline",
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <input
+                  checked={false}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <div
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "flex": 2,
+                      "padding": "0 5px",
+                    }
+                  }
+                >
                   b
                 </div>
                 <div>
@@ -691,6 +722,37 @@ exports[`Storyshots Example Types Full Demo 1`] = `
                 </div>
                 <div>
                   15
+                </div>
+              </div>
+              <div
+                style={
+                  Object {
+                    "alignItems": "baseline",
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <input
+                  checked={false}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <div
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "flex": 2,
+                      "padding": "0 5px",
+                    }
+                  }
+                >
+                  <i>
+                    Not Specified
+                  </i>
+                </div>
+                <div>
+                  4
                 </div>
               </div>
               <div
@@ -1048,7 +1110,11 @@ exports[`Storyshots Example Types Full Demo 1`] = `
           }
         >
           <div
-            style={Object {}}
+            style={
+              Object {
+                "display": "inline-block",
+              }
+            }
           >
             <span>
               1 - 1 out of 1
@@ -1213,7 +1279,7 @@ exports[`Storyshots Example Types Full Demo 1`] = `
     </div>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots Example Types ResultTable Customizations 1`] = `
 <div>
@@ -1394,7 +1460,7 @@ exports[`Storyshots Example Types ResultTable Customizations 1`] = `
     </table>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots FilterAdder Example 1`] = `
 <div>
@@ -1420,7 +1486,7 @@ exports[`Storyshots FilterAdder Example 1`] = `
     Check action log to see adding being dispatched
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots FilterAdder With FilteredPickerModal 1`] = `
 <div
@@ -1434,7 +1500,7 @@ exports[`Storyshots FilterAdder With FilteredPickerModal 1`] = `
     </button>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots FilterList Example 1`] = `
 <div
@@ -1518,13 +1584,13 @@ exports[`Storyshots FilterList Example 1`] = `
     </div>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots IMDB Advanced Search 1`] = `
 <div>
   Loading...
 </div>
-`
+`;
 
 exports[`Storyshots IMDB Filter List 1`] = `
 <div
@@ -1541,7 +1607,7 @@ exports[`Storyshots IMDB Filter List 1`] = `
     Loading...
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots IMDB Grey Vest Theme 1`] = `
 <div
@@ -1640,7 +1706,7 @@ exports[`Storyshots IMDB Grey Vest Theme 1`] = `
     Loading...
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots IMDB Quick Start 1`] = `
 <div
@@ -1693,17 +1759,14 @@ exports[`Storyshots IMDB Quick Start 1`] = `
     <div
       style={
         Object {
-          "display": "flex",
+          "display": "grid",
+          "gridGap": "5px",
+          "gridTemplateColumns": "1fr 4fr",
+          "msGridTemplateColumns": "1fr 4fr",
         }
       }
     >
-      <div
-        style={
-          Object {
-            "flex": 1,
-          }
-        }
-      >
+      <div>
         <div
           style={
             Object {
@@ -1988,21 +2051,7 @@ exports[`Storyshots IMDB Quick Start 1`] = `
           </div>
         </div>
       </div>
-      <div
-        style={
-          Object {
-            "flex": 4,
-            "maxWidth": "80%",
-          }
-        }
-      >
-        <div
-          style={Object {}}
-        >
-          <span>
-            No Results
-          </span>
-        </div>
+      <div>
         <div
           style={Object {}}
         >
@@ -2015,6 +2064,28 @@ exports[`Storyshots IMDB Quick Start 1`] = `
               }
             }
           />
+        </div>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "justifyContent": "space-around",
+            }
+          }
+        >
+          <h3>
+            <div
+              style={
+                Object {
+                  "display": "inline-block",
+                }
+              }
+            >
+              <span>
+                No Results
+              </span>
+            </div>
+          </h3>
         </div>
         <div
           style={Object {}}
@@ -2041,21 +2112,60 @@ exports[`Storyshots IMDB Quick Start 1`] = `
             style={Object {}}
           >
             <div>
-              <span>
+              <span
+                disabled={true}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                style={
+                  Object {
+                    "background": "white",
+                    "border": "solid 1px #ccc",
+                    "color": "#444",
+                    "cursor": "pointer",
+                    "padding": "5px",
+                  }
+                }
+              >
                 <a
                   onClick={[Function]}
                 >
                   ←
                 </a>
               </span>
-              <span>
+              <span
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                style={
+                  Object {
+                    "background": "white",
+                    "border": "solid 1px #ccc",
+                    "color": "#444",
+                    "cursor": "pointer",
+                    "fontWeight": "bold",
+                    "padding": "5px",
+                  }
+                }
+              >
                 <a
                   onClick={undefined}
                 >
                   1
                 </a>
               </span>
-              <span>
+              <span
+                disabled={true}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                style={
+                  Object {
+                    "background": "white",
+                    "border": "solid 1px #ccc",
+                    "color": "#444",
+                    "cursor": "pointer",
+                    "padding": "5px",
+                  }
+                }
+              >
                 <a
                   onClick={[Function]}
                 >
@@ -2069,13 +2179,13 @@ exports[`Storyshots IMDB Quick Start 1`] = `
     </div>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots IMDB Search Button 1`] = `
 <div>
   Loading...
 </div>
-`
+`;
 
 exports[`Storyshots Index Explorer Advanced Search 1`] = `
 <div>
@@ -2104,7 +2214,7 @@ exports[`Storyshots Index Explorer Advanced Search 1`] = `
     Loading...
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots Index Explorer Basic Search 1`] = `
 <div
@@ -2139,7 +2249,7 @@ exports[`Storyshots Index Explorer Basic Search 1`] = `
     Loading...
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots Layout Awaiter 1`] = `
 <div>
@@ -2157,7 +2267,7 @@ exports[`Storyshots Layout Awaiter 1`] = `
     Reject
   </button>
 </div>
-`
+`;
 
 exports[`Storyshots Layout FilteredPicker 1`] = `
 <div>
@@ -2181,7 +2291,7 @@ exports[`Storyshots Layout FilteredPicker 1`] = `
     cdef
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots Layout Highlight 1`] = `
 <div>
@@ -2193,7 +2303,7 @@ exports[`Storyshots Layout Highlight 1`] = `
   </div>
   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 </div>
-`
+`;
 
 exports[`Storyshots Layout Modal 1`] = `
 <div>
@@ -2203,7 +2313,7 @@ exports[`Storyshots Layout Modal 1`] = `
     Open Modal
   </button>
 </div>
-`
+`;
 
 exports[`Storyshots Layout ModalPicker 1`] = `
 <div>
@@ -2213,7 +2323,7 @@ exports[`Storyshots Layout ModalPicker 1`] = `
     Pick
   </button>
 </div>
-`
+`;
 
 exports[`Storyshots Layout Popover 1`] = `
 <div>
@@ -2223,7 +2333,7 @@ exports[`Storyshots Layout Popover 1`] = `
     Open Popover
   </button>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
 <div
@@ -4950,7 +5060,7 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
     Add Filter
   </button>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Examples One Filter 1`] = `
 <div
@@ -5174,7 +5284,7 @@ exports[`Storyshots QueryBuilder/Examples One Filter 1`] = `
     Add Filter
   </button>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Examples One Filter on a misplaced root 1`] = `
 <div
@@ -5398,7 +5508,7 @@ exports[`Storyshots QueryBuilder/Examples One Filter on a misplaced root 1`] = `
     Add Filter
   </button>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Examples One Filter with facet options 1`] = `
 <div
@@ -5748,7 +5858,7 @@ exports[`Storyshots QueryBuilder/Examples One Filter with facet options 1`] = `
     Add Filter
   </button>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Examples One Filter with fields 1`] = `
 <div
@@ -6003,7 +6113,7 @@ exports[`Storyshots QueryBuilder/Examples One Filter with fields 1`] = `
     Add Filter
   </button>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/AddPreview and 1`] = `
 <div
@@ -6043,7 +6153,7 @@ exports[`Storyshots QueryBuilder/Internals/AddPreview and 1`] = `
     </b>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/AddPreview not 1`] = `
 <div
@@ -6083,7 +6193,7 @@ exports[`Storyshots QueryBuilder/Internals/AddPreview not 1`] = `
     </b>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/AddPreview or 1`] = `
 <div
@@ -6123,7 +6233,7 @@ exports[`Storyshots QueryBuilder/Internals/AddPreview or 1`] = `
     </b>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/FilterContents FilterContents 1`] = `
 <div
@@ -6142,7 +6252,7 @@ exports[`Storyshots QueryBuilder/Internals/FilterContents FilterContents 1`] = `
     </button>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/Group Multiple Filters 1`] = `
 <div>
@@ -8399,7 +8509,7 @@ exports[`Storyshots QueryBuilder/Internals/Group Multiple Filters 1`] = `
     </div>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/Group One Filter 1`] = `
 <div>
@@ -8574,7 +8684,7 @@ exports[`Storyshots QueryBuilder/Internals/Group One Filter 1`] = `
     </div>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/Indentable and 1`] = `
 <div
@@ -8656,7 +8766,7 @@ exports[`Storyshots QueryBuilder/Internals/Indentable and 1`] = `
     </div>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/Indentable not 1`] = `
 <div
@@ -8738,7 +8848,7 @@ exports[`Storyshots QueryBuilder/Internals/Indentable not 1`] = `
     </div>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/Indentable or 1`] = `
 <div
@@ -8820,7 +8930,7 @@ exports[`Storyshots QueryBuilder/Internals/Indentable or 1`] = `
     </div>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/Operator and 1`] = `
 <div>
@@ -8863,7 +8973,7 @@ exports[`Storyshots QueryBuilder/Internals/Operator and 1`] = `
     <div />
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/Operator first and 1`] = `
 <div>
@@ -8900,7 +9010,7 @@ exports[`Storyshots QueryBuilder/Internals/Operator first and 1`] = `
     <div />
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/Operator first not 1`] = `
 <div>
@@ -8943,7 +9053,7 @@ exports[`Storyshots QueryBuilder/Internals/Operator first not 1`] = `
     <div />
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/Operator first or 1`] = `
 <div>
@@ -8980,7 +9090,7 @@ exports[`Storyshots QueryBuilder/Internals/Operator first or 1`] = `
     <div />
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/Operator not 1`] = `
 <div>
@@ -9023,7 +9133,7 @@ exports[`Storyshots QueryBuilder/Internals/Operator not 1`] = `
     <div />
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/Operator or 1`] = `
 <div>
@@ -9066,7 +9176,7 @@ exports[`Storyshots QueryBuilder/Internals/Operator or 1`] = `
     <div />
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/OperatorMenu OperatorMenu 1`] = `
 <div>
@@ -9151,7 +9261,7 @@ exports[`Storyshots QueryBuilder/Internals/OperatorMenu OperatorMenu 1`] = `
     </div>
   </div>
 </div>
-`
+`;
 
 exports[`Storyshots QueryBuilder/Internals/Rule index 1`] = `
 <div>
@@ -9276,4 +9386,4 @@ exports[`Storyshots QueryBuilder/Internals/Rule index 1`] = `
     </div>
   </div>
 </div>
-`
+`;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "contexture-react",
   "version": "1.7.2",
   "description": "React components for building contexture interfaces",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "start": "npm run storybook",
     "pre-build": "rm -rf ./dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "babel-preset-stage-1": "^6.24.1",
     "contexture": "^0.2.1",
     "contexture-client": "^2.13.6",
-    "contexture-elasticsearch": "^0.10.0",
+    "contexture-elasticsearch": "^0.10.1",
     "duti": "^0.9.3",
     "elasticsearch-browser": "^14.2.2",
     "eslint": "^4.12.1",

--- a/src/FilterList.js
+++ b/src/FilterList.js
@@ -15,12 +15,16 @@ export let FieldLabel = InjectTreeNode(
 )
 
 export let FilterList = InjectTreeNode(
-  observer(({ node, typeComponents: types, fields }) => (
+  observer(({ node, typeComponents: types, fields, mapNodeToProps = _.noop }) => (
     <SpacedList>
       {node.children.map(child => (
         <div key={child.path}>
           <FieldLabel node={child} fields={fields} />
-          <Dynamic component={types[child.type]} path={[...child.path]} />
+          <Dynamic
+            component={types[child.type]}
+            path={[...child.path]}
+            {...mapNodeToProps(child, fields, types)}
+          />
         </div>
       ))}
     </SpacedList>

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -60,6 +60,7 @@ let Facet = injectTreeNode(
       Checkbox = CheckboxDefault,
       RadioList = RadioListDefault,
       display = x => x,
+      displayBlank = () => <i>Not Specified</i>,
     }) => (
       <div className="contexture-facet">
         <RadioList
@@ -103,7 +104,7 @@ let Facet = injectTreeNode(
             >
               <Checkbox onChange={toggle} checked={checked} />
               <div style={{ flex: 2, padding: '0 5px' }} onClick={toggle}>
-                {display(name)}
+                {display(name) || displayBlank()}
               </div>
               <div>{count}</div>
             </Flex>

--- a/src/exampleTypes/ResultCount.js
+++ b/src/exampleTypes/ResultCount.js
@@ -13,7 +13,11 @@ let ResultCount = injectTreeNode(
         : 'No Results'}
     </span>
   )),
-  exampleTypes.results
+  {
+    ...exampleTypes.results,
+    style: { display: 'inline-block' }
+  }
+    
 )
 ResultCount.displayName = 'ResultCount'
 

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -7,6 +7,7 @@ import { Popover, Dynamic } from '../layout'
 import { withStateLens } from '../utils/mobx-react-utils'
 import { fieldsToOptions } from '../FilterAdder'
 import { loading } from '../styles/generic'
+import { applyDefaults } from '../utils/schema'
 
 // For futil?
 let onlyWhen = f => F.unless(f, () => {})
@@ -24,13 +25,6 @@ let moveIndex = (from, to, arr) =>
 
 let getRecord = F.getOrReturn('_source')
 let getResults = _.get('context.response.results')
-let applyDefaults = F.mapValuesIndexed((val, field) => ({
-  field,
-  label: F.autoLabel(field),
-  order: 0,
-  display: x => F.when(_.get('push'), _.join(', '))(x),
-  ...val,
-}))
 let inferSchema = _.flow(getResults, _.head, getRecord, flattenPlainObject)
 let getIncludes = (schema, node) =>
   F.when(_.isEmpty, _.map('field', schema))(node.include)

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -8,20 +8,7 @@ import { withStateLens } from '../utils/mobx-react-utils'
 import { fieldsToOptions } from '../FilterAdder'
 import { loading } from '../styles/generic'
 import { applyDefaults } from '../utils/schema'
-
-// For futil?
-let onlyWhen = f => F.unless(f, () => {})
-let FlattenTreeLeaves = Tree => _.flow(Tree.flatten(), _.omitBy(Tree.traverse))
-let PlainObjectTree = F.tree(onlyWhen(_.isPlainObject))
-let flattenPlainObject = F.whenExists(FlattenTreeLeaves(PlainObjectTree))
-
-let pushAt = _.curry((index, val, arr) => {
-  let result = _.clone(arr)
-  result.splice(index, 0, val)
-  return result
-})
-let moveIndex = (from, to, arr) =>
-  _.flow(_.pullAt(from), pushAt(to, arr[from]))(arr)
+import { flattenPlainObject, moveIndex } from '../utils/futil'
 
 let getRecord = F.getOrReturn('_source')
 let getResults = _.get('context.response.results')

--- a/src/utils/StripedLoader.js
+++ b/src/utils/StripedLoader.js
@@ -2,9 +2,9 @@ import React from 'react'
 import { observer } from 'mobx-react'
 import { loading } from '../styles/generic'
 
-export default Component =>
+export default (Component, style={}) =>
   observer(props => (
-    <div style={props.loading ? loading : {}}>
+    <div style={{...style, ...props.loading && loading}}>
       <Component {...props} />
     </div>
   ))

--- a/src/utils/dsl.js
+++ b/src/utils/dsl.js
@@ -1,0 +1,6 @@
+import * as F from 'futil-js'
+
+export let autoKey = x => F.compactJoin(
+  '-',
+  [x.field, x.key_field, x.value_field, x.type]
+)

--- a/src/utils/futil.js
+++ b/src/utils/futil.js
@@ -1,0 +1,21 @@
+import _ from 'lodash/fp'
+import * as F from 'futil-js'
+
+// For futil?
+
+// Logic
+export let onlyWhen = f => F.unless(f, () => {})
+
+// Tree
+export let FlattenTreeLeaves = Tree => _.flow(Tree.flatten(), _.omitBy(Tree.traverse))
+export let PlainObjectTree = F.tree(onlyWhen(_.isPlainObject))
+export let flattenPlainObject = F.whenExists(FlattenTreeLeaves(PlainObjectTree))
+
+// Arrays
+export let pushAt = _.curry((index, val, arr) => {
+  let result = _.clone(arr)
+  result.splice(index, 0, val)
+  return result
+})
+export let moveIndex = (from, to, arr) =>
+  _.flow(_.pullAt(from), pushAt(to, arr[from]))(arr)

--- a/src/utils/injectTreeNode.js
+++ b/src/utils/injectTreeNode.js
@@ -10,7 +10,7 @@ let autoKey = x => F.compactJoin(
 
 export default (
   render,
-  { type, reactors, nodeProps = _.keys(reactors), loadingAware = false } = {}
+  { type, reactors, nodeProps = _.keys(reactors), loadingAware = false, style } = {}
 ) =>
   injectDefaults(({ tree, node, group, path, ...props }) => {
     node = node || tree.getNode(path)
@@ -49,4 +49,4 @@ export default (
         ? {}
         : { loading: node.markedForUpdate || node.updating }),
     }
-  })(StripedLoader(render))
+  })(StripedLoader(render, style))

--- a/src/utils/injectTreeNode.js
+++ b/src/utils/injectTreeNode.js
@@ -1,6 +1,12 @@
+import * as F from 'futil-js'
 import _ from 'lodash/fp'
 import { injectDefaults } from './mobx-react-utils'
 import StripedLoader from './StripedLoader'
+
+let autoKey = x => F.compactJoin(
+  '-',
+  [x.field, x.key_field, x.value_field, x.type]
+)
 
 export default (
   render,
@@ -9,16 +15,19 @@ export default (
   injectDefaults(({ tree, node, group, path, ...props }) => {
     node = node || tree.getNode(path)
 
+    // Not Found
+    if (!node && path) throw Error(`Node not found at ${path}`)
+    
     // Dynamic add
     if (!node && type) {
+      let key = props.nodeKey ||  autoKey({type, ...props})
       group = group || _.get('tree.path', tree)
 
       // Lookup if already added
-      if (!node && props.nodeKey) node = tree.getNode([...group, props.nodeKey])
+      if (!node) node = tree.getNode([...group, key])
 
       // Add node if missing
       if (!node) {
-        let key = props.nodeKey || _.uniqueId(type)
         let newNode = {
           key,
           type,

--- a/src/utils/injectTreeNode.js
+++ b/src/utils/injectTreeNode.js
@@ -2,11 +2,7 @@ import * as F from 'futil-js'
 import _ from 'lodash/fp'
 import { injectDefaults } from './mobx-react-utils'
 import StripedLoader from './StripedLoader'
-
-let autoKey = x => F.compactJoin(
-  '-',
-  [x.field, x.key_field, x.value_field, x.type]
-)
+import { autoKey } from './dsl'
 
 export default (
   render,
@@ -20,7 +16,7 @@ export default (
     
     // Dynamic add
     if (!node && type) {
-      let key = props.nodeKey ||  autoKey({type, ...props})
+      let key = props.nodeKey || autoKey({type, ...props})
       group = group || _.get('tree.path', tree)
 
       // Lookup if already added

--- a/stories/exampleTypes/index.js
+++ b/stories/exampleTypes/index.js
@@ -26,6 +26,10 @@ let tree = observable({
           count: 15,
         },
         {
+          name: '',
+          count: 4
+        },
+        {
           name: 'b',
           count: 3,
         },

--- a/stories/explorer/advanced.js
+++ b/stories/explorer/advanced.js
@@ -6,11 +6,10 @@ import { fromPromise } from 'mobx-utils'
 import { Provider, observer } from 'mobx-react'
 
 import { Awaiter, Flex, QueryBuilder } from '../../src/'
-import { getESSchemas } from '../../src/utils/schema'
 import { Input, ExampleTypes } from '../DemoControls'
 let { ResultCount, ResultTable, TypeMap } = ExampleTypes
 
-import Contexture, { es, schemas, updateClient } from './contexture'
+import Contexture, { updateClient } from './contexture'
 
 let state = observable({
   url: '',
@@ -51,14 +50,10 @@ let changeSchema = schema => {
 
 let updateEs = host => {
   state.url = host
-  updateClient({ host })
-  state.schemas = fromPromise(
-    getESSchemas(es.client).then(x => {
-      F.extendOn(schemas, x)
-      changeSchema(_.keys(x)[0])
-      return x
-    })
-  )
+  state.schemas = fromPromise(updateClient({ host }).then(x => {
+    changeSchema(_.keys(x)[0])
+    return x
+  }))
 }
 
 updateEs('https://public-es-demo.smartprocure.us/')

--- a/stories/explorer/basic.js
+++ b/stories/explorer/basic.js
@@ -6,11 +6,10 @@ import { fromPromise } from 'mobx-utils'
 import { Provider, observer } from 'mobx-react'
 
 import { QueryBuilder, FilterList, Awaiter, Flex } from '../../src/'
-import { getESSchemas } from '../../src/utils/schema'
 import { Input, ClampedHTML, Adder, Pager, ExampleTypes } from '../DemoControls'
 let { ResultCount, ResultTable, TypeMap } = ExampleTypes
 
-import Contexture, { es, schemas, updateClient } from './contexture'
+import Contexture, { updateClient } from './contexture'
 
 let state = observable({
   url: '',
@@ -69,14 +68,10 @@ let overrideLookups = _.each(schema => {
 
 let updateEs = host => {
   state.url = host
-  updateClient({ host })
-  state.schemas = fromPromise(
-    getESSchemas(es.client).then(x => {
-      F.extendOn(schemas, x)
-      changeSchema(_.keys(x)[0])
-      return x
-    })
-  )
+  state.schemas = fromPromise(updateClient({ host }).then(x => {
+    changeSchema(_.keys(x)[0])
+    return x
+  }))
 }
 
 updateEs('https://public-es-demo.smartprocure.us/')

--- a/stories/explorer/contexture.js
+++ b/stories/explorer/contexture.js
@@ -1,26 +1,38 @@
+import _ from 'lodash/fp'
+import * as F from 'futil-js'
 import Contexture from 'contexture'
 import { exampleTypes } from 'contexture-client'
 import elasticsearch from 'elasticsearch-browser'
 import contextureES from 'contexture-elasticsearch'
 import contextureESTypes from 'contexture-elasticsearch/src/types'
+import typeMap from 'contexture-elasticsearch/src/example-types/schemaMapping'
 import ContextureMobx from '../../src/utils/contexture-mobx'
 
+export let es = { client: {} }
 export let updateClient = config => {
   es.client = elasticsearch.Client(config)
+  return updateSchemas()
 }
-// Mutable objects so we can update later
-export let es = { client: {} }
+let elasticsearchProvider = contextureES({
+  getClient: () => es.client,
+  types: contextureESTypes(),
+})
+
 export let schemas = {}
+export let updateSchemas = async () => {
+  console.log('Dynamically reading elasticsearch schemas')
+  let result = typeMap.exampleTypeSchemaMapping(
+    await elasticsearchProvider.getSchemas()
+  ) 
+  F.mergeOn(schemas, result)
+  return result
+}
+
 export default ContextureMobx({
   // debug: true,
   types: exampleTypes,
   service: Contexture({
     schemas,
-    providers: {
-      elasticsearch: contextureES({
-        getClient: () => es.client,
-        types: contextureESTypes(),
-      }),
-    },
+    providers: { elasticsearch: elasticsearchProvider },
   }),
 })

--- a/stories/imdb/stories/advanced.js
+++ b/stories/imdb/stories/advanced.js
@@ -3,8 +3,7 @@ import React from 'react'
 import { Provider } from 'mobx-react'
 import { fromPromise } from 'mobx-utils'
 import { QueryBuilder, Awaiter } from '../../../src'
-import Contexture, { esClient } from '../utils/contexture'
-import { getESSchemas } from '../../../src/utils/schema'
+import Contexture, { updateSchemas } from '../utils/contexture'
 import { ExampleTypes } from '../../DemoControls'
 let { ResultCount, ResultTable, TypeMap } = ExampleTypes
 
@@ -41,7 +40,7 @@ let tree = Contexture({
 })
 
 let schemas = fromPromise(
-  getESSchemas(esClient).then(
+  updateSchemas().then(
     _.merge(_, {
       movies: {
         fields: {

--- a/stories/imdb/stories/filterList.js
+++ b/stories/imdb/stories/filterList.js
@@ -2,8 +2,7 @@ import _ from 'lodash/fp'
 import React from 'react'
 import { fromPromise } from 'mobx-utils'
 import { Provider } from 'mobx-react'
-import Contexture, { esClient } from '../utils/contexture'
-import { getESSchemas } from '../../../src/utils/schema'
+import Contexture, { updateSchemas } from '../utils/contexture'
 import { FilterList, Flex, Awaiter, SpacedList } from '../../../src'
 import { DarkBox, Adder, Pager, ExampleTypes } from '../../DemoControls'
 let {
@@ -72,7 +71,7 @@ let tree = Contexture({
 })
 
 let schemas = fromPromise(
-  getESSchemas(esClient).then(
+  updateSchemas().then(
     _.merge(_, {
       movies: {
         fields: {

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -45,7 +45,6 @@ let tree = Contexture({
       type: 'date',
       useDateMath: true,
     },
-
     {
       key: 'titleContains',
       type: 'tagsQuery',

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -191,12 +191,7 @@ export default () => (
                   alignItems: 'center',
                 }}
               >
-                <h1>
-                  <Flex>
-                    {/* Wrapping in Flex makes ResultCount not break lines when updaing */}
-                    Results (<ResultCount path={['root', 'results']} />)
-                  </Flex>
-                </h1>
+                <h1>Results (<ResultCount path={['root', 'results']} />)</h1>
                 <Flex>
                   <ButtonRadio
                     options={[

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -3,8 +3,7 @@ import React from 'react'
 import { observable } from 'mobx'
 import { fromPromise } from 'mobx-utils'
 import { Provider } from 'mobx-react'
-import Contexture, { esClient } from '../utils/contexture'
-import { getESSchemas } from '../../../src/utils/schema'
+import Contexture, { updateSchemas } from '../utils/contexture'
 import {
   FilterList,
   Label,
@@ -105,7 +104,7 @@ let state = observable({
 
 let divs = _.map(x => <div key={x}>{x}</div>)
 let schemas = fromPromise(
-  getESSchemas(esClient)
+  updateSchemas()
     .then(
       _.merge(_, {
         movies: {

--- a/stories/imdb/stories/quickStart.js
+++ b/stories/imdb/stories/quickStart.js
@@ -1,18 +1,10 @@
 import React from 'react'
 import ContextureProvider from '../../../src/ContextureProvider'
-import { Flex, SpacedList } from '../../../src/layout/'
-import ExampleTypes from '../../../src/exampleTypes/'
+import { Flex, Grid, SpacedList } from '../../../src/layout/'
 import { types, service } from '../utils/contexture'
 import IMDBCards from '../components/IMDBCards'
-import { Input, DarkBox } from '../../DemoControls'
-let {
-  Facet,
-  Number,
-  Query,
-  ResultCount,
-  ResultPager,
-  DateHistogram,
-} = ExampleTypes({ Input })
+import { DarkBox, Pager, ExampleTypes } from '../../DemoControls'
+let { Facet, Number, Query, ResultCount, DateHistogram } = ExampleTypes
 
 let formatYear = x => new Date(x).getFullYear() + 1
 
@@ -21,8 +13,8 @@ export default () => (
     <DarkBox>
       <SpacedList>
         <Query field="title" />
-        <Flex>
-          <div style={{ flex: 1 }}>
+        <Grid gap="5px" columns="1fr 4fr">
+          <div>
             <SpacedList>
               <div>
                 <b>MetaScore</b>
@@ -38,20 +30,22 @@ export default () => (
               </div>
             </SpacedList>
           </div>
-          <div style={{ flex: 4, maxWidth: '80%' }}>
-            <ResultCount pageSize={6} />
+          <div>
             <DateHistogram
               key_field="released"
               value_field="imdbVotes"
               interval="3650d"
               format={formatYear}
             />
+            <Flex style={{ justifyContent: 'space-around' }}>
+              <h3><ResultCount pageSize={6} /></h3>
+            </Flex>
             <IMDBCards path={['root', 'results']} />
             <Flex style={{ justifyContent: 'space-around' }}>
-              <ResultPager path={['root', 'results']} />
+              <Pager path={['root', 'results']} />
             </Flex>
           </div>
-        </Flex>
+        </Grid>
       </SpacedList>
     </DarkBox>
   </ContextureProvider>

--- a/stories/imdb/stories/quickStart.js
+++ b/stories/imdb/stories/quickStart.js
@@ -26,7 +26,7 @@ export default () => (
             <SpacedList>
               <div>
                 <b>MetaScore</b>
-                <Number nodeKey="num" field="metaScore" min={0} max={100} />
+                <Number field="metaScore" min={0} max={100} />
               </div>
               <div>
                 <b>Genre</b>
@@ -39,7 +39,7 @@ export default () => (
             </SpacedList>
           </div>
           <div style={{ flex: 4, maxWidth: '80%' }}>
-            <ResultCount pageSize={6} nodeKey="results" />
+            <ResultCount pageSize={6} />
             <DateHistogram
               key_field="released"
               value_field="imdbVotes"

--- a/stories/imdb/stories/searchButton.js
+++ b/stories/imdb/stories/searchButton.js
@@ -3,8 +3,7 @@ import React from 'react'
 import { observable } from 'mobx'
 import { fromPromise } from 'mobx-utils'
 import { Provider } from 'mobx-react'
-import Contexture, { esClient } from '../utils/contexture'
-import { getESSchemas } from '../../../src/utils/schema'
+import Contexture, { updateSchemas } from '../utils/contexture'
 import { Flex, Awaiter, SpacedList, FilterList } from '../../../src'
 import { Button, Adder, Pager, ExampleTypes } from '../../DemoControls'
 let {
@@ -78,7 +77,7 @@ let state = observable({
 })
 
 let schemas = fromPromise(
-  getESSchemas(esClient).then(
+  updateSchemas().then(
     _.merge(_, {
       movies: {
         fields: {

--- a/stories/imdb/utils/contexture.js
+++ b/stories/imdb/utils/contexture.js
@@ -1,8 +1,11 @@
+import _ from 'lodash/fp'
+import * as F from 'futil-js'
 import Contexture from 'contexture'
 import { exampleTypes } from 'contexture-client'
 import elasticsearch from 'elasticsearch-browser'
 import contextureES from 'contexture-elasticsearch'
 import contextureESTypes from 'contexture-elasticsearch/src/types'
+import typeMap from 'contexture-elasticsearch/src/example-types/schemaMapping'
 import ContextureMobx from '../../../src/utils/contexture-mobx'
 
 export let esClient = elasticsearch.Client({
@@ -10,25 +13,36 @@ export let esClient = elasticsearch.Client({
   host: 'https://public-es-demo.smartprocure.us/',
 })
 export let types = exampleTypes
-export let service = Contexture({
-  schemas: {
-    movies: {
-      elasticsearch: {
-        index: 'movies',
-        type: 'movie',
-      },
-      modeMap: {
-        word: '',
-        autocomplete: '.keyword',
-      },
+
+let elasticsearchProvider = contextureES({
+  getClient: () => esClient,
+  types: contextureESTypes(),
+})
+
+export let schemas = {
+  movies: {
+    elasticsearch: {
+      index: 'movies',
+      type: 'movie',
+    },
+    modeMap: {
+      word: '',
+      autocomplete: '.keyword',
     },
   },
-  providers: {
-    elasticsearch: contextureES({
-      getClient: () => esClient,
-      types: contextureESTypes(),
-    }),
-  },
+}
+export let updateSchemas = _.memoize(async () => {
+  console.log('Dynamically reading elasticsearch schemas')
+  let result = typeMap.exampleTypeSchemaMapping(
+    await elasticsearchProvider.getSchemas()
+  ) 
+  F.mergeOn(schemas, result)
+  return result
+})
+
+export let service = Contexture({
+  schemas,
+  providers: { elasticsearch: elasticsearchProvider },
 })
 export default ContextureMobx({
   // debug: true,


### PR DESCRIPTION
* Add support for `mapNodeToProps` on `FilterList`
* Add support for `displayBlank` on `Facet`, which defaults to <i>Not Specified</i>
* Make the main npm script be `dist` to support importing direct from contexture-react
* Make inject tree node generate deterministic nodeKey if not provided
* Make ResultCount be inline-block and add inject tree node style support