### PR TITLE
Results Table now sends the whole object to display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-﻿# 1.10.0
+﻿# 1.10.1
+* Added support for the display function of types (used by the results
+  table) to receive the whole result object, which includes the _id.
+
+# 1.10.0
 * Add support for collapsing and pausing facet components in FilterList.
 
 # 1.9.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ﻿# 1.10.1
-* Added support for the display function of types (used by the results
-  table) to receive the whole result object, which includes the _id.
+* Added the availability to access the record's _id as part of the
+  results obtained from the getRecord function of ResultTable.
 
 # 1.10.0
 * Add support for collapsing and pausing facet components in FilterList.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -10,12 +10,10 @@ import { loading } from '../styles/generic'
 import { applyDefaults } from '../utils/schema'
 import { flattenPlainObject, moveIndex } from '../utils/futil'
 
-let getRecord = x => (
-  _.get('_source', x) ? {
-    ..._.get('_source', x),
-    _id: _.get('_id', x)
-  } : x
-)
+let getRecord = F.when('_source', x => ({
+  _id: x._id,
+  ...x._source,
+}))
 
 let getResults = _.get('context.response.results')
 let inferSchema = _.flow(getResults, _.head, getRecord, flattenPlainObject)

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -10,7 +10,13 @@ import { loading } from '../styles/generic'
 import { applyDefaults } from '../utils/schema'
 import { flattenPlainObject, moveIndex } from '../utils/futil'
 
-let getRecord = F.getOrReturn('_source')
+let getRecord = x => (
+  _.get('_source', x) ? {
+    ..._.get('_source', x),
+    _id: _.get('_id', x)
+  } : x
+)
+
 let getResults = _.get('context.response.results')
 let inferSchema = _.flow(getResults, _.head, getRecord, flattenPlainObject)
 let getIncludes = (schema, node) =>
@@ -146,7 +152,7 @@ let TableBody = observer(({ node, visibleFields }) => (
             {_.map(
               ({ field, display = x => x, Cell = 'td' }) => (
                 <Cell key={field}>
-                  {display(_.get(field, getRecord(x)), getRecord(x), x)}
+                  {display(_.get(field, getRecord(x)), getRecord(x))}
                 </Cell>
               ),
               visibleFields

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -146,7 +146,7 @@ let TableBody = observer(({ node, visibleFields }) => (
             {_.map(
               ({ field, display = x => x, Cell = 'td' }) => (
                 <Cell key={field}>
-                  {display(_.get(field, getRecord(x)), getRecord(x))}
+                  {display(_.get(field, getRecord(x)), getRecord(x), x)}
                 </Cell>
               ),
               visibleFields


### PR DESCRIPTION
~This is by far the most stable solution. Besides, the other two properties we're already sending are part of the object we're adding as a new property. This should be safe and makes sense.~

Changed due to feedback :D