### PR TITLE
HeaderCellDefault fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+﻿# 1.14.1
+* On ResultTable, fixed the HeaderCellDefault to receive only
+  activeFilter, style, and children.
+
 # 1.14.0
 * Add geo filter.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -42,9 +42,7 @@ let popoverStyle = {
 }
 
 let HeaderCellDefault = observer(({ activeFilter, style, children }) => (
-  <th
-    style={{ ...(activeFilter ? { fontWeight: 900 } : {}), ...style }}
-	>
+  <th style={{ ...(activeFilter ? { fontWeight: 900 } : {}), ...style }}>
     {children}
   </th>
 ))

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -41,11 +41,12 @@ let popoverStyle = {
   userSelect: 'none',
 }
 
-let HeaderCellDefault = observer(({ activeFilter, style, ...props }) => (
+let HeaderCellDefault = observer(({ activeFilter, style, children }) => (
   <th
     style={{ ...(activeFilter ? { fontWeight: 900 } : {}), ...style }}
-    {...props}
-  />
+	>
+    {children}
+  </th>
 ))
 HeaderCellDefault.displayName = 'HeaderCellDefault'
 


### PR DESCRIPTION
On ResultTable, fixed the HeaderCellDefault to receive only activeFilter, style, and children.