### PR TITLE
Other IE11 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-﻿# 1.20.1
+﻿# 1.20.2
+* IE11 fixes. Our last build was using map wrong in one of the
+  occurrences (I messed up the parenthesis). Besides that, I found that
+  the compiled code out of `[...child.path]` (where child.path is an
+  array) would break on IE11. This is due to `child.path` being an
+  observable array.
+
+# 1.20.1
 * IE11 fixes. On IE11, React's children object doesn't have a `map`
   method.
 

--- a/__tests__/__snapshots__/Snaphot.js.snap
+++ b/__tests__/__snapshots__/Snaphot.js.snap
@@ -228,7 +228,1285 @@ exports[`Storyshots Example Types Full Demo 1`] = `
       "padding": "20px",
     }
   }
-/>
+>
+  <div
+    style={
+      Object {
+        "marginBottom": "25px",
+      }
+    }
+  >
+    <div
+      style={Object {}}
+    >
+      <input
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder="Search"
+        style={
+          Object {
+            "background": "rgba(255, 255, 255, 0.7)",
+            "border": "solid 1px #efefef",
+            "borderRadius": "30px",
+            "boxSizing": "border-box",
+            "display": "block",
+            "margin": "0 auto",
+            "outline": "none",
+            "padding": "5px",
+            "textIndent": "5px",
+            "transition": "background 0.3s",
+            "width": "100%",
+          }
+        }
+        value=""
+      />
+    </div>
+  </div>
+  <div
+    style={Object {}}
+  >
+    <div
+      style={
+        Object {
+          "display": "flex",
+        }
+      }
+    >
+      <div
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "marginBottom": "25px",
+            }
+          }
+        >
+          <div
+            style={Object {}}
+          >
+            <div>
+              <label
+                className="tags-input"
+                style={
+                  Object {
+                    "display": "block",
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "cursor": "text",
+                      "display": "flex",
+                      "flexWrap": "wrap",
+                    }
+                  }
+                >
+                  <input
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onKeyDown={[Function]}
+                    placeholder="Search..."
+                    style={
+                      Object {
+                        "border": "none",
+                        "outline": "none",
+                        "width": "auto",
+                      }
+                    }
+                    value=""
+                  />
+                </div>
+              </label>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "marginBottom": "25px",
+            }
+          }
+        >
+          <div
+            style={Object {}}
+          >
+            <input
+              loading={undefined}
+              node={
+                Object {
+                  "field": "title",
+                  "key": "titleText",
+                  "path": Array [
+                    "titleText",
+                  ],
+                  "type": "text",
+                  "value": "",
+                }
+              }
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              path={
+                Array [
+                  "titleText",
+                ]
+              }
+              style={
+                Object {
+                  "background": "rgba(255, 255, 255, 0.7)",
+                  "border": "solid 1px #efefef",
+                  "borderRadius": "30px",
+                  "boxSizing": "border-box",
+                  "display": "block",
+                  "margin": "0 auto",
+                  "outline": "none",
+                  "padding": "5px",
+                  "textIndent": "5px",
+                  "transition": "background 0.3s",
+                  "width": "100%",
+                }
+              }
+              tree={
+                Object {
+                  "getNode": [Function],
+                  "lens": [Function],
+                  "mutate": [Function],
+                }
+              }
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "marginBottom": "25px",
+            }
+          }
+        >
+          <div
+            style={Object {}}
+          >
+            <div
+              className="contexture-facet"
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "baseline",
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <label
+                  onClick={[Function]}
+                >
+                  <input
+                    checked={true}
+                    onChange={[Function]}
+                    type="radio"
+                  />
+                  Include
+                </label>
+                <label
+                  onClick={[Function]}
+                >
+                  <input
+                    checked={false}
+                    onChange={[Function]}
+                    type="radio"
+                  />
+                  Exclude
+                </label>
+              </div>
+              <input
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                placeholder="Find..."
+                style={
+                  Object {
+                    "background": "rgba(255, 255, 255, 0.7)",
+                    "border": "solid 1px #efefef",
+                    "borderRadius": "30px",
+                    "boxSizing": "border-box",
+                    "display": "block",
+                    "margin": "0 auto",
+                    "outline": "none",
+                    "padding": "5px",
+                    "textIndent": "5px",
+                    "transition": "background 0.3s",
+                    "width": "100%",
+                  }
+                }
+                value=""
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "baseline",
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <input
+                  checked={false}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <div
+                  style={
+                    Object {
+                      "flex": 2,
+                      "padding": "0 5px",
+                    }
+                  }
+                >
+                  Select All
+                </div>
+              </div>
+              <label
+                style={
+                  Object {
+                    "alignItems": "baseline",
+                    "cursor": "pointer",
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <input
+                  checked={true}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <div
+                  style={
+                    Object {
+                      "flex": 2,
+                      "padding": "0 5px",
+                    }
+                  }
+                >
+                  a
+                </div>
+                <div>
+                  15
+                </div>
+              </label>
+              <label
+                style={
+                  Object {
+                    "alignItems": "baseline",
+                    "cursor": "pointer",
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <input
+                  checked={false}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <div
+                  style={
+                    Object {
+                      "flex": 2,
+                      "padding": "0 5px",
+                    }
+                  }
+                >
+                  <i>
+                    Not Specified
+                  </i>
+                </div>
+                <div>
+                  4
+                </div>
+              </label>
+              <label
+                style={
+                  Object {
+                    "alignItems": "baseline",
+                    "cursor": "pointer",
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <input
+                  checked={false}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <div
+                  style={
+                    Object {
+                      "flex": 2,
+                      "padding": "0 5px",
+                    }
+                  }
+                >
+                  b
+                </div>
+                <div>
+                  3
+                </div>
+              </label>
+              <label
+                style={
+                  Object {
+                    "alignItems": "baseline",
+                    "cursor": "pointer",
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <input
+                  checked={false}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <div
+                  style={
+                    Object {
+                      "flex": 2,
+                      "padding": "0 5px",
+                    }
+                  }
+                >
+                  c
+                </div>
+                <div>
+                  1
+                </div>
+              </label>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                    "margin": "5px 0",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "marginBottom": "25px",
+            }
+          }
+        >
+          <div
+            style={Object {}}
+          >
+            <div
+              className="contexture-facet"
+            >
+              <div
+                style={
+                  Object {
+                    "alignItems": "baseline",
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <label
+                  onClick={[Function]}
+                >
+                  <input
+                    checked={true}
+                    onChange={[Function]}
+                    type="radio"
+                  />
+                  Include
+                </label>
+                <label
+                  onClick={[Function]}
+                >
+                  <input
+                    checked={false}
+                    onChange={[Function]}
+                    type="radio"
+                  />
+                  Exclude
+                </label>
+              </div>
+              <input
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                placeholder="Find..."
+                style={
+                  Object {
+                    "background": "rgba(255, 255, 255, 0.7)",
+                    "border": "solid 1px #efefef",
+                    "borderRadius": "30px",
+                    "boxSizing": "border-box",
+                    "display": "block",
+                    "margin": "0 auto",
+                    "outline": "none",
+                    "padding": "5px",
+                    "textIndent": "5px",
+                    "transition": "background 0.3s",
+                    "width": "100%",
+                  }
+                }
+                value=""
+              />
+              <div
+                style={
+                  Object {
+                    "alignItems": "baseline",
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <input
+                  checked={false}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <div
+                  style={
+                    Object {
+                      "flex": 2,
+                      "padding": "0 5px",
+                    }
+                  }
+                >
+                  Select All
+                </div>
+              </div>
+              <label
+                style={
+                  Object {
+                    "alignItems": "baseline",
+                    "cursor": "pointer",
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <input
+                  checked={true}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <div
+                  style={
+                    Object {
+                      "flex": 2,
+                      "padding": "0 5px",
+                    }
+                  }
+                >
+                  A
+                </div>
+                <div>
+                  15
+                </div>
+              </label>
+              <label
+                style={
+                  Object {
+                    "alignItems": "baseline",
+                    "cursor": "pointer",
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <input
+                  checked={false}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <div
+                  style={
+                    Object {
+                      "flex": 2,
+                      "padding": "0 5px",
+                    }
+                  }
+                >
+                  <i>
+                    Not Specified
+                  </i>
+                </div>
+                <div>
+                  4
+                </div>
+              </label>
+              <label
+                style={
+                  Object {
+                    "alignItems": "baseline",
+                    "cursor": "pointer",
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <input
+                  checked={false}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <div
+                  style={
+                    Object {
+                      "flex": 2,
+                      "padding": "0 5px",
+                    }
+                  }
+                >
+                  B
+                </div>
+                <div>
+                  3
+                </div>
+              </label>
+              <label
+                style={
+                  Object {
+                    "alignItems": "baseline",
+                    "cursor": "pointer",
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                  }
+                }
+              >
+                <input
+                  checked={false}
+                  onChange={[Function]}
+                  type="checkbox"
+                />
+                <div
+                  style={
+                    Object {
+                      "flex": 2,
+                      "padding": "0 5px",
+                    }
+                  }
+                >
+                  C
+                </div>
+                <div>
+                  1
+                </div>
+              </label>
+              <div
+                style={
+                  Object {
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                    "margin": "5px 0",
+                  }
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "marginBottom": "25px",
+            }
+          }
+        >
+          <div
+            style={Object {}}
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                  }
+                }
+              >
+                <input
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  style={
+                    Object {
+                      "background": "rgba(255, 255, 255, 0.7)",
+                      "border": "solid 1px #efefef",
+                      "borderRadius": "30px",
+                      "boxSizing": "border-box",
+                      "display": "block",
+                      "margin": "0 auto",
+                      "outline": "none",
+                      "padding": "5px",
+                      "textIndent": "5px",
+                      "transition": "background 0.3s",
+                      "width": "100%",
+                    }
+                  }
+                  type="number"
+                  value=""
+                />
+                <div>
+                  -
+                </div>
+                <input
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  style={
+                    Object {
+                      "background": "rgba(255, 255, 255, 0.7)",
+                      "border": "solid 1px #efefef",
+                      "borderRadius": "30px",
+                      "boxSizing": "border-box",
+                      "display": "block",
+                      "margin": "0 auto",
+                      "outline": "none",
+                      "padding": "5px",
+                      "textIndent": "5px",
+                      "transition": "background 0.3s",
+                      "width": "100%",
+                    }
+                  }
+                  type="number"
+                  value={100}
+                />
+              </div>
+              <div />
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "marginBottom": "25px",
+            }
+          }
+        >
+          <div
+            style={Object {}}
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "flex",
+                  }
+                }
+              >
+                <input
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  style={
+                    Object {
+                      "background": "rgba(255, 255, 255, 0.7)",
+                      "border": "solid 1px #efefef",
+                      "borderRadius": "30px",
+                      "boxSizing": "border-box",
+                      "display": "block",
+                      "margin": "0 auto",
+                      "outline": "none",
+                      "padding": "5px",
+                      "textIndent": "5px",
+                      "transition": "background 0.3s",
+                      "width": "100%",
+                    }
+                  }
+                  type="number"
+                  value=""
+                />
+                <div>
+                  -
+                </div>
+                <input
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  style={
+                    Object {
+                      "background": "rgba(255, 255, 255, 0.7)",
+                      "border": "solid 1px #efefef",
+                      "borderRadius": "30px",
+                      "boxSizing": "border-box",
+                      "display": "block",
+                      "margin": "0 auto",
+                      "outline": "none",
+                      "padding": "5px",
+                      "textIndent": "5px",
+                      "transition": "background 0.3s",
+                      "width": "100%",
+                    }
+                  }
+                  type="number"
+                  value={100}
+                />
+              </div>
+              <div />
+            </div>
+          </div>
+        </div>
+        <div
+          style={Object {}}
+        >
+          <div
+            style={Object {}}
+          >
+            <div
+              style={
+                Object {
+                  "display": "flex",
+                  "flexFlow": "column",
+                }
+              }
+            >
+              <select
+                onChange={[Function]}
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginBottom": "5px",
+                  }
+                }
+                value="within"
+              >
+                <option
+                  value="within"
+                >
+                  within
+                </option>
+                <option
+                  value="not within"
+                >
+                  not within
+                </option>
+              </select>
+              <div
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginBottom": "5px",
+                  }
+                }
+              >
+                <input
+                  min="1"
+                  onChange={[Function]}
+                  placeholder="Enter number of miles ..."
+                  type="number"
+                  value={1}
+                />
+                 
+                from
+              </div>
+              <div
+                style={
+                  Object {
+                    "flex": 1,
+                    "marginBottom": "5px",
+                  }
+                }
+              >
+                <div
+                  className="css-10nd86i"
+                  id={undefined}
+                  onKeyDown={[Function]}
+                >
+                  <div
+                    className="css-vj8t7z"
+                    onMouseDown={[Function]}
+                    onTouchEnd={[Function]}
+                  >
+                    <div
+                      className="css-huq41j"
+                    >
+                      <div
+                        className="css-1492t68"
+                      >
+                        Address ...
+                      </div>
+                      <div
+                        className="css-1g6gooi"
+                      >
+                        <div
+                          className=""
+                          style={
+                            Object {
+                              "display": "inline-block",
+                            }
+                          }
+                        >
+                          <input
+                            aria-autocomplete="list"
+                            aria-label={undefined}
+                            aria-labelledby={undefined}
+                            autoCapitalize="none"
+                            autoComplete="off"
+                            autoCorrect="off"
+                            className={undefined}
+                            disabled={false}
+                            id="react-select-2-input"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            spellCheck="false"
+                            style={
+                              Object {
+                                "background": 0,
+                                "border": 0,
+                                "boxSizing": "content-box",
+                                "color": "inherit",
+                                "fontSize": "inherit",
+                                "opacity": 1,
+                                "outline": 0,
+                                "padding": 0,
+                                "width": "1px",
+                              }
+                            }
+                            tabIndex="0"
+                            theme={
+                              Object {
+                                "borderRadius": 4,
+                                "colors": Object {
+                                  "danger": "#DE350B",
+                                  "dangerLight": "#FFBDAD",
+                                  "neutral0": "hsl(0, 0%, 100%)",
+                                  "neutral10": "hsl(0, 0%, 90%)",
+                                  "neutral20": "hsl(0, 0%, 80%)",
+                                  "neutral30": "hsl(0, 0%, 70%)",
+                                  "neutral40": "hsl(0, 0%, 60%)",
+                                  "neutral5": "hsl(0, 0%, 95%)",
+                                  "neutral50": "hsl(0, 0%, 50%)",
+                                  "neutral60": "hsl(0, 0%, 40%)",
+                                  "neutral70": "hsl(0, 0%, 30%)",
+                                  "neutral80": "hsl(0, 0%, 20%)",
+                                  "neutral90": "hsl(0, 0%, 10%)",
+                                  "primary": "#2684FF",
+                                  "primary25": "#DEEBFF",
+                                  "primary50": "#B2D4FF",
+                                  "primary75": "#4C9AFF",
+                                },
+                                "spacing": Object {
+                                  "baseUnit": 4,
+                                  "controlHeight": 38,
+                                  "menuGutter": 8,
+                                },
+                              }
+                            }
+                            type="text"
+                            value=""
+                          />
+                          <div
+                            style={
+                              Object {
+                                "height": 0,
+                                "left": 0,
+                                "overflow": "scroll",
+                                "position": "absolute",
+                                "top": 0,
+                                "visibility": "hidden",
+                                "whiteSpace": "pre",
+                              }
+                            }
+                          >
+                            
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      className="css-1wy0on6"
+                    >
+                      <span
+                        className="css-d8oujb"
+                      />
+                      <div
+                        aria-hidden="true"
+                        className="css-1ep9fjw"
+                        onMouseDown={[Function]}
+                        onTouchEnd={[Function]}
+                      >
+                        <svg
+                          aria-hidden="true"
+                          className="css-19bqh2r"
+                          focusable="false"
+                          height={20}
+                          viewBox="0 0 20 20"
+                          width={20}
+                        >
+                          <path
+                            d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        style={
+          Object {
+            "flex": 4,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "marginBottom": "25px",
+            }
+          }
+        >
+          <div
+            style={Object {}}
+          >
+            <div
+              style={
+                Object {
+                  "alignItems": "flex-end",
+                  "display": "flex",
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "height": 25,
+                      "margin": "0 0px",
+                    }
+                  }
+                  title={1}
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "padding": "5px",
+                    }
+                  }
+                >
+                  1970
+                </div>
+              </div>
+              <div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "height": 75,
+                      "margin": "0 0px",
+                    }
+                  }
+                  title={3}
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "padding": "5px",
+                    }
+                  }
+                >
+                  1979
+                </div>
+              </div>
+              <div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "height": 50,
+                      "margin": "0 0px",
+                    }
+                  }
+                  title={2}
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "padding": "5px",
+                    }
+                  }
+                >
+                  1989
+                </div>
+              </div>
+              <div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "height": 100,
+                      "margin": "0 0px",
+                    }
+                  }
+                  title={4}
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "padding": "5px",
+                    }
+                  }
+                >
+                  1999
+                </div>
+              </div>
+              <div>
+                <div
+                  style={
+                    Object {
+                      "background": "#ccc",
+                      "height": 25,
+                      "margin": "0 0px",
+                    }
+                  }
+                  title={1}
+                >
+                   
+                </div>
+                <div
+                  style={
+                    Object {
+                      "padding": "5px",
+                    }
+                  }
+                >
+                  2009
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "marginBottom": "25px",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "display": "inline-block",
+              }
+            }
+          >
+            <span>
+              1 - 1 out of 1
+            </span>
+          </div>
+        </div>
+        <div
+          style={Object {}}
+        >
+          <div
+            style={
+              Object {
+                "alignItems": "baseline",
+                "display": "flex",
+                "justifyContent": "center",
+              }
+            }
+          >
+            <div
+              style={Object {}}
+            >
+              <table>
+                <thead>
+                  <tr>
+                    <th
+                      style={
+                        Object {
+                          "cursor": "pointer",
+                        }
+                      }
+                    >
+                      <span
+                        onClick={[Function]}
+                      >
+                        Id
+                         
+                      </span>
+                    </th>
+                    <th
+                      style={
+                        Object {
+                          "cursor": "pointer",
+                        }
+                      }
+                    >
+                      <span
+                        onClick={[Function]}
+                      >
+                        Title
+                         
+                      </span>
+                    </th>
+                    <th
+                      style={
+                        Object {
+                          "cursor": "pointer",
+                        }
+                      }
+                    >
+                      <span
+                        onClick={[Function]}
+                      >
+                        A
+                         
+                      </span>
+                    </th>
+                    <th
+                      style={
+                        Object {
+                          "cursor": "pointer",
+                        }
+                      }
+                    >
+                      <span
+                        onClick={[Function]}
+                      >
+                        B
+                         
+                      </span>
+                    </th>
+                    <th
+                      style={
+                        Object {
+                          "cursor": "pointer",
+                        }
+                      }
+                    >
+                      <span
+                        onClick={[Function]}
+                      >
+                        C
+                         
+                      </span>
+                    </th>
+                    <th
+                      style={
+                        Object {
+                          "cursor": "pointer",
+                        }
+                      }
+                    >
+                      <span
+                        onClick={[Function]}
+                      >
+                        Nested Value
+                         
+                      </span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody
+                  style={Object {}}
+                >
+                  <tr>
+                    <td>
+                      123
+                    </td>
+                    <td>
+                      Some Result
+                    </td>
+                    <td>
+                      1
+                    </td>
+                    <td>
+                      2
+                    </td>
+                    <td>
+                      3
+                    </td>
+                    <td>
+                      4
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      124
+                    </td>
+                    <td>
+                      Some Other Result
+                    </td>
+                    <td>
+                      1
+                    </td>
+                    <td>
+                      4
+                    </td>
+                    <td>
+                      3
+                    </td>
+                    <td>
+                      5
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      135
+                    </td>
+                    <td>
+                      A Different Result
+                    </td>
+                    <td>
+                      1
+                    </td>
+                    <td>
+                      2
+                    </td>
+                    <td>
+                      3
+                    </td>
+                    <td>
+                      6
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`Storyshots Example Types Geo filter & HERE maps 1`] = `
@@ -353,7 +1631,7 @@ exports[`Storyshots Example Types Geo filter & HERE maps 1`] = `
                         autoCorrect="off"
                         className={undefined}
                         disabled={false}
-                        id="react-select-2-input"
+                        id="react-select-3-input"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -789,7 +2067,88 @@ exports[`Storyshots FilterAdder With FilteredPickerModal 1`] = `
 exports[`Storyshots FilterList Example 1`] = `
 <div
   style={Object {}}
-/>
+>
+  <div
+    style={
+      Object {
+        "marginBottom": "25px",
+      }
+    }
+  >
+    <div>
+      <div
+        style={Object {}}
+      >
+        <div
+          style={
+            Object {
+              "margin": "10px 0",
+            }
+          }
+        >
+          <b>
+            Field A
+          </b>
+        </div>
+      </div>
+      <div>
+        A TYPE
+      </div>
+    </div>
+  </div>
+  <div
+    style={
+      Object {
+        "marginBottom": "25px",
+      }
+    }
+  >
+    <div>
+      <div
+        style={Object {}}
+      >
+        <div
+          style={
+            Object {
+              "margin": "10px 0",
+            }
+          }
+        >
+          <b>
+            B Field
+          </b>
+        </div>
+      </div>
+      <div>
+        B TYPE
+      </div>
+    </div>
+  </div>
+  <div
+    style={Object {}}
+  >
+    <div>
+      <div
+        style={Object {}}
+      >
+        <div
+          style={
+            Object {
+              "margin": "10px 0",
+            }
+          }
+        >
+          <b>
+            c
+          </b>
+        </div>
+      </div>
+      <div>
+        B TYPE
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`Storyshots IMDB Advanced Search 1`] = `
@@ -1045,7 +2404,470 @@ exports[`Storyshots IMDB Quick Start 1`] = `
       "padding": "20px",
     }
   }
-/>
+>
+  <div
+    style={
+      Object {
+        "marginBottom": "25px",
+      }
+    }
+  >
+    <div
+      style={Object {}}
+    >
+      <input
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder="Search"
+        style={
+          Object {
+            "background": "rgba(255, 255, 255, 0.7)",
+            "border": "solid 1px #efefef",
+            "borderRadius": "30px",
+            "boxSizing": "border-box",
+            "display": "block",
+            "margin": "0 auto",
+            "outline": "none",
+            "padding": "5px",
+            "textIndent": "5px",
+            "transition": "background 0.3s",
+            "width": "100%",
+          }
+        }
+        value=""
+      />
+    </div>
+  </div>
+  <div
+    style={Object {}}
+  >
+    <div
+      style={
+        Object {
+          "display": "grid",
+          "gridGap": "5px",
+          "gridTemplateColumns": "1fr 4fr",
+          "msGridTemplateColumns": "1fr 4fr",
+        }
+      }
+    >
+      <div>
+        <div
+          style={
+            Object {
+              "marginBottom": "25px",
+            }
+          }
+        >
+          <div>
+            <b>
+              MetaScore
+            </b>
+            <div
+              style={Object {}}
+            >
+              <div>
+                <div
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "display": "flex",
+                    }
+                  }
+                >
+                  <input
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    style={
+                      Object {
+                        "background": "rgba(255, 255, 255, 0.7)",
+                        "border": "solid 1px #efefef",
+                        "borderRadius": "30px",
+                        "boxSizing": "border-box",
+                        "display": "block",
+                        "margin": "0 auto",
+                        "outline": "none",
+                        "padding": "5px",
+                        "textIndent": "5px",
+                        "transition": "background 0.3s",
+                        "width": "100%",
+                      }
+                    }
+                    type="number"
+                    value=""
+                  />
+                  <div>
+                    -
+                  </div>
+                  <input
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    style={
+                      Object {
+                        "background": "rgba(255, 255, 255, 0.7)",
+                        "border": "solid 1px #efefef",
+                        "borderRadius": "30px",
+                        "boxSizing": "border-box",
+                        "display": "block",
+                        "margin": "0 auto",
+                        "outline": "none",
+                        "padding": "5px",
+                        "textIndent": "5px",
+                        "transition": "background 0.3s",
+                        "width": "100%",
+                      }
+                    }
+                    type="number"
+                    value={100}
+                  />
+                </div>
+                <div />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          style={
+            Object {
+              "marginBottom": "25px",
+            }
+          }
+        >
+          <div>
+            <b>
+              Genre
+            </b>
+            <div
+              style={Object {}}
+            >
+              <div
+                className="contexture-facet"
+              >
+                <div
+                  style={
+                    Object {
+                      "alignItems": "baseline",
+                      "display": "flex",
+                      "justifyContent": "space-between",
+                    }
+                  }
+                >
+                  <label
+                    onClick={[Function]}
+                  >
+                    <input
+                      checked={true}
+                      onChange={[Function]}
+                      type="radio"
+                    />
+                    Include
+                  </label>
+                  <label
+                    onClick={[Function]}
+                  >
+                    <input
+                      checked={false}
+                      onChange={[Function]}
+                      type="radio"
+                    />
+                    Exclude
+                  </label>
+                </div>
+                <input
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder="Find..."
+                  style={
+                    Object {
+                      "background": "rgba(255, 255, 255, 0.7)",
+                      "border": "solid 1px #efefef",
+                      "borderRadius": "30px",
+                      "boxSizing": "border-box",
+                      "display": "block",
+                      "margin": "0 auto",
+                      "outline": "none",
+                      "padding": "5px",
+                      "textIndent": "5px",
+                      "transition": "background 0.3s",
+                      "width": "100%",
+                    }
+                  }
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "alignItems": "baseline",
+                      "display": "flex",
+                      "justifyContent": "space-between",
+                    }
+                  }
+                >
+                  <input
+                    checked={true}
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <div
+                    style={
+                      Object {
+                        "flex": 2,
+                        "padding": "0 5px",
+                      }
+                    }
+                  >
+                    Select All
+                  </div>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "display": "flex",
+                      "justifyContent": "space-between",
+                      "margin": "5px 0",
+                    }
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          style={Object {}}
+        >
+          <div>
+            <b>
+              Actors
+            </b>
+            <div
+              style={Object {}}
+            >
+              <div
+                className="contexture-facet"
+              >
+                <div
+                  style={
+                    Object {
+                      "alignItems": "baseline",
+                      "display": "flex",
+                      "justifyContent": "space-between",
+                    }
+                  }
+                >
+                  <label
+                    onClick={[Function]}
+                  >
+                    <input
+                      checked={true}
+                      onChange={[Function]}
+                      type="radio"
+                    />
+                    Include
+                  </label>
+                  <label
+                    onClick={[Function]}
+                  >
+                    <input
+                      checked={false}
+                      onChange={[Function]}
+                      type="radio"
+                    />
+                    Exclude
+                  </label>
+                </div>
+                <input
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder="Find..."
+                  style={
+                    Object {
+                      "background": "rgba(255, 255, 255, 0.7)",
+                      "border": "solid 1px #efefef",
+                      "borderRadius": "30px",
+                      "boxSizing": "border-box",
+                      "display": "block",
+                      "margin": "0 auto",
+                      "outline": "none",
+                      "padding": "5px",
+                      "textIndent": "5px",
+                      "transition": "background 0.3s",
+                      "width": "100%",
+                    }
+                  }
+                  value=""
+                />
+                <div
+                  style={
+                    Object {
+                      "alignItems": "baseline",
+                      "display": "flex",
+                      "justifyContent": "space-between",
+                    }
+                  }
+                >
+                  <input
+                    checked={true}
+                    onChange={[Function]}
+                    type="checkbox"
+                  />
+                  <div
+                    style={
+                      Object {
+                        "flex": 2,
+                        "padding": "0 5px",
+                      }
+                    }
+                  >
+                    Select All
+                  </div>
+                </div>
+                <div
+                  style={
+                    Object {
+                      "display": "flex",
+                      "justifyContent": "space-between",
+                      "margin": "5px 0",
+                    }
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div
+          style={Object {}}
+        >
+          <div
+            style={
+              Object {
+                "alignItems": "flex-end",
+                "display": "flex",
+                "justifyContent": "center",
+              }
+            }
+          />
+        </div>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "justifyContent": "space-around",
+            }
+          }
+        >
+          <h3>
+            <div
+              style={
+                Object {
+                  "display": "inline-block",
+                }
+              }
+            >
+              <span>
+                No Results
+              </span>
+            </div>
+          </h3>
+        </div>
+        <div
+          style={Object {}}
+        >
+          <div
+            style={
+              Object {
+                "display": "flex",
+                "flexWrap": "wrap",
+                "justifyContent": "center",
+              }
+            }
+          />
+        </div>
+        <div
+          style={
+            Object {
+              "display": "flex",
+              "justifyContent": "space-around",
+            }
+          }
+        >
+          <div
+            style={Object {}}
+          >
+            <div>
+              <span
+                disabled={true}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                style={
+                  Object {
+                    "background": "white",
+                    "border": "solid 1px #ccc",
+                    "color": "#444",
+                    "cursor": "pointer",
+                    "padding": "5px",
+                  }
+                }
+              >
+                <a
+                  onClick={[Function]}
+                >
+                  ←
+                </a>
+              </span>
+              <span
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                style={
+                  Object {
+                    "background": "white",
+                    "border": "solid 1px #ccc",
+                    "color": "#444",
+                    "cursor": "pointer",
+                    "fontWeight": "bold",
+                    "padding": "5px",
+                  }
+                }
+              >
+                <a
+                  onClick={undefined}
+                >
+                  1
+                </a>
+              </span>
+              <span
+                disabled={true}
+                onMouseOut={[Function]}
+                onMouseOver={[Function]}
+                style={
+                  Object {
+                    "background": "white",
+                    "border": "solid 1px #ccc",
+                    "color": "#444",
+                    "cursor": "pointer",
+                    "padding": "5px",
+                  }
+                }
+              >
+                <a
+                  onClick={[Function]}
+                >
+                  →
+                </a>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`Storyshots IMDB Search Button 1`] = `

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/FilterList.js
+++ b/src/FilterList.js
@@ -40,7 +40,7 @@ export let FilterList = InjectTreeNode(
               {!child.paused && (
                 <Dynamic
                   component={types[child.type]}
-                  path={[...child.path]}
+                  path={child.path.slice()}
                   {...mapNodeToProps(child, fields, types)}
                 />
               )}

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -196,7 +196,7 @@ let Header = withStateLens({ popover: false, adding: false, filtering: false })(
                   !filterNode.paused && (
                     <Dynamic
                       component={typeComponents[filterNode.type]}
-                      path={[...filterNode.path]}
+                      path={filterNode.path.slice()}
                       {...mapNodeToProps(filterNode, fields, typeComponents)}
                     />
                   )}

--- a/src/layout/SpacedList.js
+++ b/src/layout/SpacedList.js
@@ -1,14 +1,14 @@
-import _ from 'lodash/fp'
+import * as F from 'futil-js'
 import React from 'react'
 
 let SpacedList = ({ children, style = { marginBottom: '25px' } }) =>
-  _.map(
-    ((child, i) => (
+  F.mapIndexed(
+    (child, i) => (
       <div style={i !== children.length - 1 ? style : {}} key={i}>
         {child}
       </div>
     ),
-    children)
+    children
   )
 SpacedList.displayName = 'SpacedList'
 


### PR DESCRIPTION
Our last build was using map wrong in one of the occurrences (I messed up the parenthesis). Besides that, I found that the compiled code out of `[...child.path]` (where child.path is an array) would break on IE11. This is due to `child.path` being an observable array.