### PR TITLE
Nested field picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.26.2
+# 1.27.0
+* Added nested support to the field picker. To nest options, add a `path` prop on fields before passing along to an Adder (which is also used by ResultsTable)
+
+# 1.26.2
 * Small performance improvement on CheckableResultsTable.
 
 # 1.26.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.27.0
 * Added nested support to the field picker. To nest options, add a `path` prop on fields before passing along to an Adder (which is also used by ResultsTable)
+* Fixed Modal max-width to be fit-content instead of arbitrarily 500px
+* Allow overriding the Picker in ModalFilterAdder
 
 # 1.26.2
 * Small performance improvement on CheckableResultsTable.

--- a/__tests__/__snapshots__/Snaphot.js.snap
+++ b/__tests__/__snapshots__/Snaphot.js.snap
@@ -2091,7 +2091,7 @@ exports[`Storyshots FilterAdder Example 1`] = `
 </div>
 `;
 
-exports[`Storyshots FilterAdder With FilteredPickerModal 1`] = `
+exports[`Storyshots FilterAdder With NestedPickerModal 1`] = `
 <div
   style={Object {}}
 >
@@ -2686,6 +2686,13 @@ exports[`Storyshots IMDB Check List 1`] = `
         border: solid 1px #f1f1f1;
         padding: 5px;
       }
+      
+      .panel-tree-picker &gt; div {
+        border-right: solid 1px #eef0f1;
+      }
+      .panel-tree-picker &gt; div:last-child {
+        border-right: none;
+      }
     
   </style>
   <div>
@@ -3078,6 +3085,13 @@ exports[`Storyshots IMDB Grey Vest Theme 1`] = `
         box-shadow: 0 2px 10px 0 rgba(39, 44, 65, 0.1);
         border: solid 1px #f1f1f1;
         padding: 5px;
+      }
+      
+      .panel-tree-picker &gt; div {
+        border-right: solid 1px #eef0f1;
+      }
+      .panel-tree-picker &gt; div:last-child {
+        border-right: none;
       }
     
   </style>
@@ -3590,30 +3604,6 @@ exports[`Storyshots Layout Awaiter 1`] = `
 </div>
 `;
 
-exports[`Storyshots Layout FilteredPicker 1`] = `
-<div>
-  <input
-    onChange={[Function]}
-    value=""
-  />
-  <div
-    onClick={[Function]}
-  >
-    abcd
-  </div>
-  <div
-    onClick={[Function]}
-  >
-    bcde
-  </div>
-  <div
-    onClick={[Function]}
-  >
-    cdef
-  </div>
-</div>
-`;
-
 exports[`Storyshots Layout Highlight 1`] = `
 <div>
   <div>
@@ -3643,6 +3633,53 @@ exports[`Storyshots Layout ModalPicker 1`] = `
   >
     Pick
   </button>
+</div>
+`;
+
+exports[`Storyshots Layout NestedPicker 1`] = `
+<div>
+  <input
+    onChange={[Function]}
+    placeholder="Enter filter keyword..."
+    value=""
+  />
+  <div
+    className="panel-tree-picker"
+    style={
+      Object {
+        "display": "inline-flex",
+        "overflow": "scroll",
+        "width": "100%",
+      }
+    }
+  >
+    <div>
+      <div
+        active={false}
+        disabled={undefined}
+        hasChildren={true}
+        onClick={[Function]}
+      >
+        Abcd
+      </div>
+      <div
+        active={false}
+        disabled={undefined}
+        hasChildren={true}
+        onClick={[Function]}
+      >
+        Bcde
+      </div>
+      <div
+        active={false}
+        disabled={undefined}
+        hasChildren={true}
+        onClick={[Function]}
+      >
+        Cdef
+      </div>
+    </div>
+  </div>
 </div>
 `;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.26.2",
+  "version": "1.27.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/ModalFilterAdder.js
+++ b/src/ModalFilterAdder.js
@@ -1,5 +1,5 @@
 import FilterAdder from './FilterAdder'
-import { Modal, ModalPicker, FilteredPicker } from './layout/'
+import { Modal, ModalPicker, NestedPicker } from './layout/'
 import { defaultProps } from 'recompose'
 
 export default ({
@@ -8,7 +8,7 @@ export default ({
   Button,
   Highlight,
   label = 'Add Custom Filter',
-  Picker = FilteredPicker
+  Picker = NestedPicker
 } = {}) =>
   defaultProps({
     Picker: defaultProps({

--- a/src/ModalFilterAdder.js
+++ b/src/ModalFilterAdder.js
@@ -8,7 +8,7 @@ export default ({
   Button,
   Highlight,
   label = 'Add Custom Filter',
-  Picker = NestedPicker
+  Picker = NestedPicker,
 } = {}) =>
   defaultProps({
     Picker: defaultProps({

--- a/src/ModalFilterAdder.js
+++ b/src/ModalFilterAdder.js
@@ -8,12 +8,13 @@ export default ({
   Button,
   Highlight,
   label = 'Add Custom Filter',
+  Picker = FilteredPicker
 } = {}) =>
   defaultProps({
     Picker: defaultProps({
       Modal,
       Button,
       label,
-      Picker: defaultProps({ Input, Highlight, Item })(FilteredPicker),
+      Picker: defaultProps({ Input, Highlight, Item })(Picker),
     })(ModalPicker),
   })(FilterAdder)

--- a/src/layout/Modal.js
+++ b/src/layout/Modal.js
@@ -24,7 +24,7 @@ let Modal = observer(
           style={{
             backgroundColor: '#fff',
             borderRadius: 5,
-            maxWidth: 500,
+            maxWidth: 'fit-content',
             // minHeight: 300,
             margin: '0 auto',
             padding: 30,

--- a/src/layout/NestedPicker.js
+++ b/src/layout/NestedPicker.js
@@ -56,21 +56,21 @@ let PanelTreePicker = inject((store, { onChange, options }) => {
   let x = {
     state: observable({ selected: [] }),
     nestedOptions: toNested(options),
-    select: level => (key, field) => {
+    selectAtLevel: _.curry((level, key, field) => {
       if (isField(field)) onChange(field.value)
       else x.state.selected.splice(level, x.state.selected.length - level, key)
-    },
+    }),
   }
   return x
 })(
-  observer(({ select, state, nestedOptions, Item }) => (
+  observer(({ selectAtLevel, state, nestedOptions, Item }) => (
     <div
       className="panel-tree-picker"
       style={{ display: 'inline-flex', width: '100%', overflow: 'scroll' }}
     >
       <Section
         options={nestedOptions}
-        onClick={select(0)}
+        onClick={selectAtLevel(0)}
         selected={state.selected[0]}
         Item={Item}
       />
@@ -79,7 +79,7 @@ let PanelTreePicker = inject((store, { onChange, options }) => {
           <Section
             key={index}
             options={_.get(state.selected.slice(0, index + 1), nestedOptions)}
-            onClick={select(index + 1)}
+            onClick={selectAtLevel(index + 1)}
             selected={state.selected[index + 1]}
             Item={Item}
           />

--- a/src/layout/NestedPicker.js
+++ b/src/layout/NestedPicker.js
@@ -60,7 +60,7 @@ let PanelTreePicker = inject((store, {onChange, options}) => {
   }
   return x
 })(
-  observer(({ options, select, state, nestedOptions, Item }) => (
+  observer(({ select, state, nestedOptions, Item }) => (
     <div
       className='panel-tree-picker'
       style={{display: 'inline-flex', width: '100%', overflow: 'scroll'}}

--- a/src/layout/NestedPicker.js
+++ b/src/layout/NestedPicker.js
@@ -1,0 +1,113 @@
+import React from 'react'
+import F from 'futil-js'
+import _ from 'lodash/fp'
+import {inject, observer} from 'mobx-react'
+import {observable} from 'mobx'
+import { withStateLens } from '../utils/mobx-react-utils'
+import TextHighlight from './TextHighlight'
+
+
+// Unflatten by with support for arrays (allow dots in paths) and not needing a _.keyBy first
+let unflattenObjectBy = _.curry(
+  (iteratee, x) => _.zipObjectDeep(F.mapIndexed(iteratee, x), _.values(x))
+)
+
+let isField = x => x.typeDefault
+
+let FilteredSection = observer(({ options, onClick, highlight, Highlight, Item }) =>
+  <div>
+    {F.mapIndexed(
+      (option, field) => (
+        <Item key={field} onClick={() => onClick(option.value)}>
+           <Highlight text={option.label} pattern={highlight} />
+        </Item>
+      ),
+      options
+    )}
+  </div>
+)
+let Section = observer(({options, onClick, selected, Item}) => (
+  <div>
+    {F.mapIndexed(
+      (item, key) => (
+        <Item
+          key={key}
+          onClick={() => onClick(item.value || key, item)}
+          active={selected === key}
+          disabled={selected && selected !== key}
+          hasChildren={!isField(item)}>
+          {isField(item) ? item.shortLabel || item.label : _.startCase(key)}
+        </Item>
+      ),
+      options
+    )}
+  </div>
+))
+
+
+let toNested = _.flow(
+  _.map(x => _.defaults({ path: x.value }, x)),
+  unflattenObjectBy('path')
+)
+let PanelTreePicker = inject((store, {onChange, options}) => {
+  let x = {
+    state: observable({ selected: [] }),
+    nestedOptions: toNested(options),
+    select: level => (key, field) => {
+      if (isField(field)) onChange(field.value)
+      else x.state.selected.splice(level, x.state.selected.length - level, key)
+    },
+  }
+  return x
+})(
+  observer(({ options, select, state, nestedOptions, Item }) => (
+    <div
+      className='panel-tree-picker'
+      style={{display: 'inline-flex', width: '100%', overflow: 'scroll'}}
+    >
+      <Section
+        options={nestedOptions}
+        onClick={select(0)}
+        selected={state.selected[0]}
+        Item={Item}
+      />
+      {F.mapIndexed(
+        (_key, index) => (
+          <Section
+            key={index}
+            options={_.get(state.selected.slice(0, index + 1), nestedOptions)}
+            onClick={select(index + 1)}
+            selected={state.selected[index + 1]}
+            Item={Item}
+          />
+        ),
+        state.selected
+      )}
+    </div>
+  ))
+)
+
+let matchLabel = str => _.filter(x => F.matchAllWords(str)(x.label))
+let wrapPicker = _.flow(observer, withStateLens({ filter: '' }))
+export default wrapPicker(({ 
+  options,
+  onChange,
+  filter,
+  Input = 'input',
+  Highlight = TextHighlight,
+  Item = 'div'
+}) => (
+  <div>
+    <Input {...F.domLens.value(filter)} placeholder='Enter filter keyword...' />
+    {F.view(filter)
+      ? <FilteredSection
+          options={matchLabel(F.view(filter))(options)}
+          onClick={onChange}
+          highlight={F.view(filter)}
+          Highlight={Highlight}
+          Item={Item}
+        />
+      : <PanelTreePicker options={options} onChange={onChange} Item={Item} />
+    }
+  </div>
+))

--- a/src/layout/NestedPicker.js
+++ b/src/layout/NestedPicker.js
@@ -27,6 +27,7 @@ let FilteredSection = observer(
     </div>
   )
 )
+FilteredSection.displayName = 'FilteredSection'
 let Section = observer(({ options, onClick, selected, Item }) => (
   <div>
     {F.mapIndexed(
@@ -45,6 +46,7 @@ let Section = observer(({ options, onClick, selected, Item }) => (
     )}
   </div>
 ))
+Section.displayName = 'Section'
 
 let toNested = _.flow(
   _.map(x => _.defaults({ path: x.value }, x)),
@@ -87,12 +89,9 @@ let PanelTreePicker = inject((store, { onChange, options }) => {
     </div>
   ))
 )
+PanelTreePicker.displayName = 'PanelTreePicker'
 
 let matchLabel = str => _.filter(x => F.matchAllWords(str)(x.label))
-let wrapPicker = _.flow(
-  observer,
-  withStateLens({ filter: '' })
-)
 let NestedPicker = ({
   options,
   onChange,
@@ -116,5 +115,8 @@ let NestedPicker = ({
     )}
   </div>
 )
-
+let wrapPicker = _.flow(
+  observer,
+  withStateLens({ filter: '' })
+)
 export default wrapPicker(NestedPicker)

--- a/src/layout/NestedPicker.js
+++ b/src/layout/NestedPicker.js
@@ -93,32 +93,28 @@ let wrapPicker = _.flow(
   observer,
   withStateLens({ filter: '' })
 )
-let NestedPicker =
-  ({
-    options,
-    onChange,
-    filter,
-    Input = 'input',
-    Highlight = TextHighlight,
-    Item = 'div',
-  }) => (
-    <div>
-      <Input
-        {...F.domLens.value(filter)}
-        placeholder="Enter filter keyword..."
+let NestedPicker = ({
+  options,
+  onChange,
+  filter,
+  Input = 'input',
+  Highlight = TextHighlight,
+  Item = 'div',
+}) => (
+  <div>
+    <Input {...F.domLens.value(filter)} placeholder="Enter filter keyword..." />
+    {F.view(filter) ? (
+      <FilteredSection
+        options={matchLabel(F.view(filter))(options)}
+        onClick={onChange}
+        highlight={F.view(filter)}
+        Highlight={Highlight}
+        Item={Item}
       />
-      {F.view(filter) ? (
-        <FilteredSection
-          options={matchLabel(F.view(filter))(options)}
-          onClick={onChange}
-          highlight={F.view(filter)}
-          Highlight={Highlight}
-          Item={Item}
-        />
-      ) : (
-        <PanelTreePicker options={options} onChange={onChange} Item={Item} />
-      )}
-    </div>
-  )
+    ) : (
+      <PanelTreePicker options={options} onChange={onChange} Item={Item} />
+    )}
+  </div>
+)
 
 export default wrapPicker(NestedPicker)

--- a/src/layout/NestedPicker.js
+++ b/src/layout/NestedPicker.js
@@ -1,32 +1,33 @@
 import React from 'react'
 import F from 'futil-js'
 import _ from 'lodash/fp'
-import {inject, observer} from 'mobx-react'
-import {observable} from 'mobx'
+import { inject, observer } from 'mobx-react'
+import { observable } from 'mobx'
 import { withStateLens } from '../utils/mobx-react-utils'
 import TextHighlight from './TextHighlight'
 
-
 // Unflatten by with support for arrays (allow dots in paths) and not needing a _.keyBy first
-let unflattenObjectBy = _.curry(
-  (iteratee, x) => _.zipObjectDeep(F.mapIndexed(iteratee, x), _.values(x))
+let unflattenObjectBy = _.curry((iteratee, x) =>
+  _.zipObjectDeep(F.mapIndexed(iteratee, x), _.values(x))
 )
 
 let isField = x => x.typeDefault
 
-let FilteredSection = observer(({ options, onClick, highlight, Highlight, Item }) =>
-  <div>
-    {F.mapIndexed(
-      (option, field) => (
-        <Item key={field} onClick={() => onClick(option.value)}>
-           <Highlight text={option.label} pattern={highlight} />
-        </Item>
-      ),
-      options
-    )}
-  </div>
+let FilteredSection = observer(
+  ({ options, onClick, highlight, Highlight, Item }) => (
+    <div>
+      {F.mapIndexed(
+        (option, field) => (
+          <Item key={field} onClick={() => onClick(option.value)}>
+            <Highlight text={option.label} pattern={highlight} />
+          </Item>
+        ),
+        options
+      )}
+    </div>
+  )
 )
-let Section = observer(({options, onClick, selected, Item}) => (
+let Section = observer(({ options, onClick, selected, Item }) => (
   <div>
     {F.mapIndexed(
       (item, key) => (
@@ -35,7 +36,8 @@ let Section = observer(({options, onClick, selected, Item}) => (
           onClick={() => onClick(item.value || key, item)}
           active={selected === key}
           disabled={selected && selected !== key}
-          hasChildren={!isField(item)}>
+          hasChildren={!isField(item)}
+        >
           {isField(item) ? item.shortLabel || item.label : _.startCase(key)}
         </Item>
       ),
@@ -44,12 +46,11 @@ let Section = observer(({options, onClick, selected, Item}) => (
   </div>
 ))
 
-
 let toNested = _.flow(
   _.map(x => _.defaults({ path: x.value }, x)),
   unflattenObjectBy('path')
 )
-let PanelTreePicker = inject((store, {onChange, options}) => {
+let PanelTreePicker = inject((store, { onChange, options }) => {
   let x = {
     state: observable({ selected: [] }),
     nestedOptions: toNested(options),
@@ -62,8 +63,8 @@ let PanelTreePicker = inject((store, {onChange, options}) => {
 })(
   observer(({ select, state, nestedOptions, Item }) => (
     <div
-      className='panel-tree-picker'
-      style={{display: 'inline-flex', width: '100%', overflow: 'scroll'}}
+      className="panel-tree-picker"
+      style={{ display: 'inline-flex', width: '100%', overflow: 'scroll' }}
     >
       <Section
         options={nestedOptions}
@@ -88,26 +89,35 @@ let PanelTreePicker = inject((store, {onChange, options}) => {
 )
 
 let matchLabel = str => _.filter(x => F.matchAllWords(str)(x.label))
-let wrapPicker = _.flow(observer, withStateLens({ filter: '' }))
-export default wrapPicker(({ 
-  options,
-  onChange,
-  filter,
-  Input = 'input',
-  Highlight = TextHighlight,
-  Item = 'div'
-}) => (
-  <div>
-    <Input {...F.domLens.value(filter)} placeholder='Enter filter keyword...' />
-    {F.view(filter)
-      ? <FilteredSection
+let wrapPicker = _.flow(
+  observer,
+  withStateLens({ filter: '' })
+)
+export default wrapPicker(
+  ({
+    options,
+    onChange,
+    filter,
+    Input = 'input',
+    Highlight = TextHighlight,
+    Item = 'div',
+  }) => (
+    <div>
+      <Input
+        {...F.domLens.value(filter)}
+        placeholder="Enter filter keyword..."
+      />
+      {F.view(filter) ? (
+        <FilteredSection
           options={matchLabel(F.view(filter))(options)}
           onClick={onChange}
           highlight={F.view(filter)}
           Highlight={Highlight}
           Item={Item}
         />
-      : <PanelTreePicker options={options} onChange={onChange} Item={Item} />
-    }
-  </div>
-))
+      ) : (
+        <PanelTreePicker options={options} onChange={onChange} Item={Item} />
+      )}
+    </div>
+  )
+)

--- a/src/layout/NestedPicker.js
+++ b/src/layout/NestedPicker.js
@@ -93,7 +93,7 @@ let wrapPicker = _.flow(
   observer,
   withStateLens({ filter: '' })
 )
-export default wrapPicker(
+let NestedPicker =
   ({
     options,
     onChange,
@@ -120,4 +120,5 @@ export default wrapPicker(
       )}
     </div>
   )
-)
+
+export default wrapPicker(NestedPicker)

--- a/src/layout/Pickers.js
+++ b/src/layout/Pickers.js
@@ -1,4 +1,3 @@
-import _ from 'lodash/fp'
 import F from 'futil-js'
 import React from 'react'
 import { observer } from 'mobx-react'

--- a/src/layout/Pickers.js
+++ b/src/layout/Pickers.js
@@ -3,33 +3,6 @@ import F from 'futil-js'
 import React from 'react'
 import { observer } from 'mobx-react'
 import { withStateLens } from '../utils/mobx-react-utils'
-import TextHighlight from './TextHighlight'
-
-export let FilteredPicker = withStateLens({ filter: '' })(
-  observer(
-    ({
-      options,
-      onChange,
-      filter,
-      Input = 'input',
-      Item = 'div',
-      Highlight = TextHighlight,
-    }) => (
-      <div>
-        <Input {...F.domLens.value(filter)} />
-        {_.map(
-          ({ value, label }) => (
-            <Item key={value} onClick={() => onChange(value)}>
-              <Highlight text={label} pattern={F.view(filter)} />
-            </Item>
-          ),
-          _.filter(x => F.matchAllWords(F.view(filter))(x.label), options)
-        )}
-      </div>
-    )
-  )
-)
-FilteredPicker.displayName = 'FilteredPicker'
 
 export let ModalPicker = withStateLens({ isOpen: false })(
   observer(

--- a/src/layout/index.js
+++ b/src/layout/index.js
@@ -5,7 +5,8 @@ import Modal from './Modal'
 import Popover from './Popover'
 import SpacedList from './SpacedList'
 import TextHighlight from './TextHighlight'
-import { FilteredPicker, ModalPicker } from './Pickers'
+import { ModalPicker } from './Pickers'
+import NestedPicker from './NestedPicker'
 import Dynamic from './Dynamic'
 import BarChart from './BarChart'
 import { Tag, TagsInput } from './TagsInput'
@@ -20,7 +21,7 @@ export {
   Popover,
   SpacedList,
   TextHighlight,
-  FilteredPicker,
+  NestedPicker,
   ModalPicker,
   Dynamic,
   BarChart,

--- a/src/queryBuilder/FilterContents.js
+++ b/src/queryBuilder/FilterContents.js
@@ -2,14 +2,14 @@ import * as F from 'futil-js'
 import _ from 'lodash/fp'
 import React from 'react'
 import { inject, observer } from 'mobx-react'
-import { ModalPicker, Modal, FilteredPicker, Dynamic } from '../layout/'
+import { ModalPicker, Modal, NestedPicker, Dynamic } from '../layout/'
 import { fieldsToOptions } from '../FilterAdder'
 import { defaultProps } from 'recompose'
 import { get } from '../utils/mobx-utils'
 
 let FieldPicker = defaultProps({
   Modal,
-  Picker: FilteredPicker,
+  Picker: NestedPicker,
 })(ModalPicker)
 
 let FilterContents = inject(_.defaults)(

--- a/src/themes/blueberry.js
+++ b/src/themes/blueberry.js
@@ -7,7 +7,7 @@ import { defaultProps } from 'recompose'
 import {
   Flex,
   TextHighlight,
-  FilteredPicker,
+  NestedFiltered,
   ModalFilterAdder,
   TagsInput,
 } from '../'
@@ -290,7 +290,7 @@ export let ExampleTypes = ExampleTypeConstructor({
   RadioList: ButtonRadio,
   Table,
   FieldPicker: defaultProps({ Input, Highlight, Item: ListGroupItem })(
-    FilteredPicker
+    NestedFiltered
   ),
   ListGroupItem,
   TagsInput: defaultProps({ TagComponent })(TagsInput),

--- a/src/themes/greyVest.js
+++ b/src/themes/greyVest.js
@@ -539,25 +539,21 @@ let iconMap = {
 }
 let Icon = ({ icon }) => <Dynamic component={iconMap[icon]} />
 
+let AddLabel = (
+  <Flex style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+    Add Custom Filter
+    <i className="material-icons" style={{ opacity: 0.4 }}>
+      filter_list
+    </i>
+  </Flex>
+)
+
 export let Adder = ModalFilterAdder({
   Button,
   Input,
   Highlight,
   Item: ListGroupItem,
-  label: (
-    <span
-      style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-      }}
-    >
-      Add Custom Filter
-      <i className="material-icons" style={{ opacity: 0.4 }}>
-        filter_list
-      </i>
-    </span>
-  ),
+  label: AddLabel,
 })
 
 export let PagerItem = observer(({ active, disabled, ...x }) => (

--- a/src/themes/greyVest.js
+++ b/src/themes/greyVest.js
@@ -440,6 +440,13 @@ export let GVStyle = () => (
         border: solid 1px #f1f1f1;
         padding: 5px;
       }
+      
+      .panel-tree-picker > div {
+        border-right: solid 1px #eef0f1;
+      }
+      .panel-tree-picker > div:last-child {
+        border-right: none;
+      }
     `}
   </style>
 )
@@ -548,11 +555,34 @@ let AddLabel = (
   </Flex>
 )
 
+let FilterListItem = observer(({ active, disabled, hasChildren, children, ...props }) => (
+  <div
+    style={{
+      padding: '10px 40px',
+      cursor: 'pointer',
+      fontSize: 18,
+      background: active ? '#ebebeb' : '#fff',
+      color: disabled ? '#9b9b9b' : '#000',
+    }}
+    {...props}
+  >
+    {hasChildren
+    ? <Flex style={{alignItems: 'center'}}>
+        {children}
+        <i className="material-icons" style={{fontSize: 20}}>
+          chevron_right
+        </i>
+      </Flex>
+    : children}
+  </div>
+))
+
+
 export let Adder = ModalFilterAdder({
   Button,
   Input,
   Highlight,
-  Item: ListGroupItem,
+  Item: FilterListItem,
   label: AddLabel,
 })
 
@@ -582,7 +612,7 @@ export let ExampleTypes = ExampleTypeConstructor({
   Checkbox,
   RadioList: ButtonRadio,
   Table,
-  FieldPicker: defaultProps({ Input, Highlight, Item: ListGroupItem })(
+  FieldPicker: defaultProps({ Input, Highlight, Item: FilterListItem })(
     NestedPicker
   ),
   ListGroupItem,

--- a/src/themes/greyVest.js
+++ b/src/themes/greyVest.js
@@ -555,28 +555,31 @@ let AddLabel = (
   </Flex>
 )
 
-let FilterListItem = observer(({ active, disabled, hasChildren, children, ...props }) => (
-  <div
-    style={{
-      padding: '10px 40px',
-      cursor: 'pointer',
-      fontSize: 18,
-      background: active ? '#ebebeb' : '#fff',
-      color: disabled ? '#9b9b9b' : '#000',
-    }}
-    {...props}
-  >
-    {hasChildren
-    ? <Flex style={{alignItems: 'center'}}>
-        {children}
-        <i className="material-icons" style={{fontSize: 20}}>
-          chevron_right
-        </i>
-      </Flex>
-    : children}
-  </div>
-))
-
+let FilterListItem = observer(
+  ({ active, disabled, hasChildren, children, ...props }) => (
+    <div
+      style={{
+        padding: '10px 40px',
+        cursor: 'pointer',
+        fontSize: 18,
+        background: active ? '#ebebeb' : '#fff',
+        color: disabled ? '#9b9b9b' : '#000',
+      }}
+      {...props}
+    >
+      {hasChildren ? (
+        <Flex style={{ alignItems: 'center' }}>
+          {children}
+          <i className="material-icons" style={{ fontSize: 20 }}>
+            chevron_right
+          </i>
+        </Flex>
+      ) : (
+        children
+      )}
+    </div>
+  )
+)
 
 export let Adder = ModalFilterAdder({
   Button,

--- a/src/themes/greyVest.js
+++ b/src/themes/greyVest.js
@@ -7,7 +7,7 @@ import { withStateLens } from '../utils/mobx-react-utils'
 import {
   Flex,
   TextHighlight,
-  FilteredPicker,
+  NestedPicker,
   ModalFilterAdder,
   TagsInput,
   FilterList as BaseFilterList,
@@ -583,7 +583,7 @@ export let ExampleTypes = ExampleTypeConstructor({
   RadioList: ButtonRadio,
   Table,
   FieldPicker: defaultProps({ Input, Highlight, Item: ListGroupItem })(
-    FilteredPicker
+    NestedPicker
   ),
   ListGroupItem,
   TagsInput: defaultProps({ TagComponent })(TagsInput),

--- a/stories/DemoControls.js
+++ b/stories/DemoControls.js
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react'
 import { withStateLens } from '../src/utils/mobx-react-utils'
 import { defaultProps } from 'recompose'
 import ExampleTypeConstructor from '../src/exampleTypes/'
-import { TextHighlight, FilteredPicker, ModalFilterAdder } from '../src'
+import { TextHighlight, NestedPicker, ModalFilterAdder } from '../src'
 
 export let Button = x => (
   <button
@@ -116,7 +116,7 @@ export let ExampleTypes = ExampleTypeConstructor({
     Input,
     Highlight,
     Item: ListGroupItem,
-  })(FilteredPicker),
+  })(NestedPicker),
 })
 let { ResultPager } = ExampleTypes
 export let Pager = defaultProps({ Item: PagerItem })(ResultPager)

--- a/stories/filterAdder.js
+++ b/stories/filterAdder.js
@@ -6,7 +6,7 @@ import FilterAdder from '../src/FilterAdder'
 import { applyDefaults } from '../src/utils/schema'
 import { defaultProps } from 'recompose'
 import Modal from '../src/layout/Modal'
-import { ModalPicker, FilteredPicker } from '../src/layout/Pickers'
+import { ModalPicker, NestedPicker } from '../src'
 
 let Select = ({ options, onChange }) => (
   <select onChange={e => onChange(e.target.value)}>
@@ -25,7 +25,7 @@ let Adder = defaultProps({
   Picker: defaultProps({
     Modal,
     label: '+ Include Additional Filter',
-    Picker: FilteredPicker,
+    Picker: NestedPicker,
   })(ModalPicker),
 })(FilterAdder)
 
@@ -54,7 +54,7 @@ export default () => {
         <div>Check action log to see adding being dispatched</div>
       </div>
     ))
-    .addWithJSX('With FilteredPickerModal', () => (
+    .addWithJSX('With NestedPickerModal', () => (
       <Adder
         tree={mockTree}
         path={['path']}

--- a/stories/imdb/stories/blueberry.js
+++ b/stories/imdb/stories/blueberry.js
@@ -117,6 +117,9 @@ let schemas = fromPromise(
             title: { order: 1 },
             genres: { display: divs },
             actors: { display: divs },
+            imdbId: { path: ['Imdb', 'imdbId'] },
+            imdbRating: { path: ['Imdb', 'imdbRating'] },
+            imdbVotes: { path: ['Imdb', 'imdbVotes'] },
           },
         },
       })

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -147,6 +147,9 @@ let schemas = fromPromise(
             title: { order: 1 },
             genres: { display: divs },
             actors: { display: divs },
+            imdbId: { path: ['Imdb', 'imdbId'] },
+            imdbRating: { path: ['Imdb', 'imdbRating'] },
+            imdbVotes: { path: ['Imdb', 'imdbVotes'] },
           },
         },
       })

--- a/stories/layout.js
+++ b/stories/layout.js
@@ -9,7 +9,7 @@ import Popover from '../src/layout/Popover'
 import Modal from '../src/layout/Modal'
 import Awaiter from '../src/layout/Awaiter'
 import TextHighlight from '../src/layout/TextHighlight'
-import { FilteredPicker, ModalPicker } from '../src/layout/Pickers'
+import { NestedPicker, ModalPicker } from '../src'
 
 let ModalDemo = withStateLens({ isOpen: false })(
   observer(({ isOpen }) => (
@@ -64,8 +64,8 @@ export default () => {
         </div>
       )
     })
-    .addWithJSX('FilteredPicker', () => (
-      <FilteredPicker
+    .addWithJSX('NestedPicker', () => (
+      <NestedPicker
         options={['abcd', 'bcde', 'cdef'].map(x => ({ label: x, value: x }))}
         onChange={action(`picked`)}
       />
@@ -75,7 +75,7 @@ export default () => {
         options={['abcd', 'bcde', 'cdef'].map(x => ({ label: x, value: x }))}
         onChange={action('picked')}
         label="Pick"
-        Picker={FilteredPicker}
+        Picker={NestedPicker}
         Modal={Modal}
       />
     ))


### PR DESCRIPTION
* Added nested support to the field picker. To nest options, add a `path` prop on fields before passing along to an Adder (which is also used by ResultsTable)
* Fixed Modal max-width to be fit-content instead of arbitrarily 500px
* Allow overriding the Picker in ModalFilterAdder

<img width="496" alt="screen shot 2018-11-12 at 7 04 53 pm" src="https://user-images.githubusercontent.com/1043503/48382187-dd388680-e6ad-11e8-8bbd-c79c4409b2cd.png">
