### PR TITLE
Fix the `sticky` with z-index of 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.28.1
+* Add z-index to `sticky` search-bar
+
 # 1.28.0
 * Factor out Select layout compnent
 * GreyVest: Add danger and success button colors

--- a/__tests__/__snapshots__/Snaphot.js.snap
+++ b/__tests__/__snapshots__/Snaphot.js.snap
@@ -2571,6 +2571,7 @@ exports[`Storyshots IMDB Check List 1`] = `
         grid-gap: 30px;
         position: sticky;
         top: 5px;
+        z-index: 1;
         /*background: #f6f6f6;*/
       }
       .gv-search-bar .gv-box {
@@ -2982,6 +2983,7 @@ exports[`Storyshots IMDB Grey Vest Theme 1`] = `
         grid-gap: 30px;
         position: sticky;
         top: 5px;
+        z-index: 1;
         /*background: #f6f6f6;*/
       }
       .gv-search-bar .gv-box {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/themes/greyVest.js
+++ b/src/themes/greyVest.js
@@ -386,6 +386,7 @@ export let GVStyle = () => (
         grid-gap: 30px;
         position: sticky;
         top: 5px;
+        z-index: 1;
         /*background: #f6f6f6;*/
       }
       .gv-search-bar .gv-box {


### PR DESCRIPTION
Adds z-index of 1 to the sticky search bar due to it becoming the lower layer on scrolling etc.

Fixes https://github.com/smartprocure/bid-search/issues/542