### PR TITLE
Fix height of gv-button-group.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.29.0
+* Fix height of gv-button-group to 60px.
+
 # 1.28.1
 * Add z-index to `sticky` search-bar
 

--- a/__tests__/__snapshots__/Snaphot.js.snap
+++ b/__tests__/__snapshots__/Snaphot.js.snap
@@ -2553,6 +2553,7 @@ exports[`Storyshots IMDB Check List 1`] = `
         border-radius: 3px;
         display: flex;
         overflow: hidden;
+        height: 60px;
       }
       .gv-button-group &gt; :first-child {
         border-top-right-radius: 0px;
@@ -2965,6 +2966,7 @@ exports[`Storyshots IMDB Grey Vest Theme 1`] = `
         border-radius: 3px;
         display: flex;
         overflow: hidden;
+        height: 60px;
       }
       .gv-button-group &gt; :first-child {
         border-top-right-radius: 0px;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/themes/greyVest.js
+++ b/src/themes/greyVest.js
@@ -368,6 +368,7 @@ export let GVStyle = () => (
         border-radius: 3px;
         display: flex;
         overflow: hidden;
+        height: 60px;
       }
       .gv-button-group > :first-child {
         border-top-right-radius: 0px;


### PR DESCRIPTION
Fixed height to 60px.

Relates to https://github.com/smartprocure/bid-search/issues/539