### PR TITLE
Nested filter list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 * QueryBuilder: Fix support for TagsQuery (was checking for join instead of children)
 * QueryBuilder: Make Rule hover same as background
 * QueryBuilder: Change default background
+* QueryBuilder: Pass along button component prop
 * GreyVest: Theme FilterList groups properly
+* GreyVest: Prefill QueryBuilder with gv button
+* GreyVest: Remove extra default margins on inputs
 * IMDB GreyVest Story: Add a toggle to switch between FilterList and QueryBuilder in real time
 
 # 1.28.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.29.0
+* FilterList: Add support for groups, allowing it to render anything QueryBuilder can!
+* QueryBuilder: Fix support for TagsQuery (was checking for join instead of children)
+* QueryBuilder: Make Rule hover same as background
+* QueryBuilder: Change default background
+* GreyVest: Theme FilterList groups properly
+* IMDB GreyVest Story: Add a toggle to switch between FilterList and QueryBuilder in real time
+
 # 1.28.1
 * Add z-index to `sticky` search-bar
 

--- a/__tests__/__snapshots__/Snaphot.js.snap
+++ b/__tests__/__snapshots__/Snaphot.js.snap
@@ -2109,7 +2109,10 @@ exports[`Storyshots FilterList Example 1`] = `
 <div
   style={Object {}}
 >
-  <div>
+  <div
+    className={undefined}
+    style={undefined}
+  >
     <div
       className="filter-list-item"
     >
@@ -2678,9 +2681,17 @@ exports[`Storyshots IMDB Check List 1`] = `
       }
       
       .filter-list-item-contents {
-        margin-top: 15px
+        margin-top: 15px;
       }
       
+      .filter-list-group {
+        border-left: solid 2px;
+        padding-left: 35px; /* 30 for filter-list-item + 5 space */
+        margin-left: -30px;
+        margin-top: -25px; /* -30 for filter-list-item + 5 space */
+        padding-top: 30px;
+      }
+
       .gv-grid {
         display: grid;
         grid-template-columns: 400px 1fr;
@@ -3090,9 +3101,17 @@ exports[`Storyshots IMDB Grey Vest Theme 1`] = `
       }
       
       .filter-list-item-contents {
-        margin-top: 15px
+        margin-top: 15px;
       }
       
+      .filter-list-group {
+        border-left: solid 2px;
+        padding-left: 35px; /* 30 for filter-list-item + 5 space */
+        margin-left: -30px;
+        margin-top: -25px; /* -30 for filter-list-item + 5 space */
+        padding-top: 30px;
+      }
+
       .gv-grid {
         display: grid;
         grid-template-columns: 400px 1fr;
@@ -3721,7 +3740,7 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
 <div
   style={
     Object {
-      "background": "#f0f8ff",
+      "background": "rgb(247, 247, 247)",
     }
   }
 >
@@ -3773,7 +3792,7 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
                     onClick={[Function]}
                     style={
                       Object {
-                        "background": "#f0f8ff",
+                        "background": "rgb(247, 247, 247)",
                         "borderBottom": "solid 2px black",
                         "borderBottomColor": "#5bc0de",
                         "height": 17.5,
@@ -4031,7 +4050,7 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
                                 onClick={[Function]}
                                 style={
                                   Object {
-                                    "background": "#f0f8ff",
+                                    "background": "rgb(247, 247, 247)",
                                     "borderBottom": "solid 2px black",
                                     "borderBottomColor": "#5cb85c",
                                     "height": 17.5,
@@ -4395,7 +4414,7 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
                         <div
                           style={
                             Object {
-                              "background": "#f0f8ff",
+                              "background": "rgb(247, 247, 247)",
                               "display": "flex",
                             }
                           }
@@ -4487,7 +4506,7 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
                                             onClick={[Function]}
                                             style={
                                               Object {
-                                                "background": "#f0f8ff",
+                                                "background": "rgb(247, 247, 247)",
                                                 "borderBottom": "solid 2px black",
                                                 "borderBottomColor": "#5bc0de",
                                                 "height": 17.5,
@@ -4723,7 +4742,7 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
                                     <div
                                       style={
                                         Object {
-                                          "background": "#f0f8ff",
+                                          "background": "rgb(247, 247, 247)",
                                           "display": "flex",
                                         }
                                       }
@@ -5445,7 +5464,7 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
                         <div
                           style={
                             Object {
-                              "background": "#f0f8ff",
+                              "background": "rgb(247, 247, 247)",
                               "display": "flex",
                             }
                           }
@@ -5649,7 +5668,7 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
             <div
               style={
                 Object {
-                  "background": "#f0f8ff",
+                  "background": "rgb(247, 247, 247)",
                   "display": "flex",
                 }
               }
@@ -5741,7 +5760,7 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
                                 onClick={[Function]}
                                 style={
                                   Object {
-                                    "background": "#f0f8ff",
+                                    "background": "rgb(247, 247, 247)",
                                     "borderBottom": "solid 2px black",
                                     "borderBottomColor": "#5cb85c",
                                     "height": 17.5,
@@ -5816,7 +5835,7 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
                                             onClick={[Function]}
                                             style={
                                               Object {
-                                                "background": "#f0f8ff",
+                                                "background": "rgb(247, 247, 247)",
                                                 "borderBottom": "solid 2px black",
                                                 "borderBottomColor": "#5bc0de",
                                                 "height": 17.5,
@@ -5983,7 +6002,7 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
                                     <div
                                       style={
                                         Object {
-                                          "background": "#f0f8ff",
+                                          "background": "rgb(247, 247, 247)",
                                           "display": "flex",
                                         }
                                       }
@@ -6225,7 +6244,7 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
                         <div
                           style={
                             Object {
-                              "background": "#f0f8ff",
+                              "background": "rgb(247, 247, 247)",
                               "display": "flex",
                             }
                           }
@@ -6451,7 +6470,7 @@ exports[`Storyshots QueryBuilder/Examples One Filter 1`] = `
 <div
   style={
     Object {
-      "background": "#f0f8ff",
+      "background": "rgb(247, 247, 247)",
     }
   }
 >
@@ -6493,7 +6512,7 @@ exports[`Storyshots QueryBuilder/Examples One Filter 1`] = `
             <div
               style={
                 Object {
-                  "background": "#f0f8ff",
+                  "background": "rgb(247, 247, 247)",
                   "display": "flex",
                 }
               }
@@ -6675,7 +6694,7 @@ exports[`Storyshots QueryBuilder/Examples One Filter on a misplaced root 1`] = `
 <div
   style={
     Object {
-      "background": "#f0f8ff",
+      "background": "rgb(247, 247, 247)",
     }
   }
 >
@@ -6717,7 +6736,7 @@ exports[`Storyshots QueryBuilder/Examples One Filter on a misplaced root 1`] = `
             <div
               style={
                 Object {
-                  "background": "#f0f8ff",
+                  "background": "rgb(247, 247, 247)",
                   "display": "flex",
                 }
               }
@@ -6899,7 +6918,7 @@ exports[`Storyshots QueryBuilder/Examples One Filter with facet options 1`] = `
 <div
   style={
     Object {
-      "background": "#f0f8ff",
+      "background": "rgb(247, 247, 247)",
     }
   }
 >
@@ -6941,7 +6960,7 @@ exports[`Storyshots QueryBuilder/Examples One Filter with facet options 1`] = `
             <div
               style={
                 Object {
-                  "background": "#f0f8ff",
+                  "background": "rgb(247, 247, 247)",
                   "display": "flex",
                 }
               }
@@ -7250,7 +7269,7 @@ exports[`Storyshots QueryBuilder/Examples One Filter with fields 1`] = `
 <div
   style={
     Object {
-      "background": "#f0f8ff",
+      "background": "rgb(247, 247, 247)",
     }
   }
 >
@@ -7292,7 +7311,7 @@ exports[`Storyshots QueryBuilder/Examples One Filter with fields 1`] = `
             <div
               style={
                 Object {
-                  "background": "#f0f8ff",
+                  "background": "rgb(247, 247, 247)",
                   "display": "flex",
                 }
               }
@@ -7506,7 +7525,7 @@ exports[`Storyshots QueryBuilder/Internals/AddPreview and 1`] = `
   onClick={[Function]}
   style={
     Object {
-      "background": "#f0f8ff",
+      "background": "rgb(247, 247, 247)",
     }
   }
 >
@@ -7546,7 +7565,7 @@ exports[`Storyshots QueryBuilder/Internals/AddPreview not 1`] = `
   onClick={[Function]}
   style={
     Object {
-      "background": "#f0f8ff",
+      "background": "rgb(247, 247, 247)",
     }
   }
 >
@@ -7586,7 +7605,7 @@ exports[`Storyshots QueryBuilder/Internals/AddPreview or 1`] = `
   onClick={[Function]}
   style={
     Object {
-      "background": "#f0f8ff",
+      "background": "rgb(247, 247, 247)",
     }
   }
 >
@@ -7690,7 +7709,7 @@ exports[`Storyshots QueryBuilder/Internals/Group Multiple Filters 1`] = `
                     onClick={[Function]}
                     style={
                       Object {
-                        "background": "#f0f8ff",
+                        "background": "rgb(247, 247, 247)",
                         "borderBottom": "solid 2px black",
                         "borderBottomColor": "#5bc0de",
                         "height": 17.5,
@@ -7921,7 +7940,7 @@ exports[`Storyshots QueryBuilder/Internals/Group Multiple Filters 1`] = `
                                 onClick={[Function]}
                                 style={
                                   Object {
-                                    "background": "#f0f8ff",
+                                    "background": "rgb(247, 247, 247)",
                                     "borderBottom": "solid 2px black",
                                     "borderBottomColor": "#5cb85c",
                                     "height": 17.5,
@@ -8231,7 +8250,7 @@ exports[`Storyshots QueryBuilder/Internals/Group Multiple Filters 1`] = `
                         <div
                           style={
                             Object {
-                              "background": "#f0f8ff",
+                              "background": "rgb(247, 247, 247)",
                               "display": "flex",
                             }
                           }
@@ -8323,7 +8342,7 @@ exports[`Storyshots QueryBuilder/Internals/Group Multiple Filters 1`] = `
                                             onClick={[Function]}
                                             style={
                                               Object {
-                                                "background": "#f0f8ff",
+                                                "background": "rgb(247, 247, 247)",
                                                 "borderBottom": "solid 2px black",
                                                 "borderBottomColor": "#5bc0de",
                                                 "height": 17.5,
@@ -8463,7 +8482,7 @@ exports[`Storyshots QueryBuilder/Internals/Group Multiple Filters 1`] = `
                                     <div
                                       style={
                                         Object {
-                                          "background": "#f0f8ff",
+                                          "background": "rgb(247, 247, 247)",
                                           "display": "flex",
                                         }
                                       }
@@ -9067,7 +9086,7 @@ exports[`Storyshots QueryBuilder/Internals/Group Multiple Filters 1`] = `
                         <div
                           style={
                             Object {
-                              "background": "#f0f8ff",
+                              "background": "rgb(247, 247, 247)",
                               "display": "flex",
                             }
                           }
@@ -9244,7 +9263,7 @@ exports[`Storyshots QueryBuilder/Internals/Group Multiple Filters 1`] = `
             <div
               style={
                 Object {
-                  "background": "#f0f8ff",
+                  "background": "rgb(247, 247, 247)",
                   "display": "flex",
                 }
               }
@@ -9336,7 +9355,7 @@ exports[`Storyshots QueryBuilder/Internals/Group Multiple Filters 1`] = `
                                 onClick={[Function]}
                                 style={
                                   Object {
-                                    "background": "#f0f8ff",
+                                    "background": "rgb(247, 247, 247)",
                                     "borderBottom": "solid 2px black",
                                     "borderBottomColor": "#5cb85c",
                                     "height": 17.5,
@@ -9411,7 +9430,7 @@ exports[`Storyshots QueryBuilder/Internals/Group Multiple Filters 1`] = `
                                             onClick={[Function]}
                                             style={
                                               Object {
-                                                "background": "#f0f8ff",
+                                                "background": "rgb(247, 247, 247)",
                                                 "borderBottom": "solid 2px black",
                                                 "borderBottomColor": "#5bc0de",
                                                 "height": 17.5,
@@ -9551,7 +9570,7 @@ exports[`Storyshots QueryBuilder/Internals/Group Multiple Filters 1`] = `
                                     <div
                                       style={
                                         Object {
-                                          "background": "#f0f8ff",
+                                          "background": "rgb(247, 247, 247)",
                                           "display": "flex",
                                         }
                                       }
@@ -9728,7 +9747,7 @@ exports[`Storyshots QueryBuilder/Internals/Group Multiple Filters 1`] = `
                         <div
                           style={
                             Object {
-                              "background": "#f0f8ff",
+                              "background": "rgb(247, 247, 247)",
                               "display": "flex",
                             }
                           }
@@ -9937,7 +9956,7 @@ exports[`Storyshots QueryBuilder/Internals/Group One Filter 1`] = `
             <div
               style={
                 Object {
-                  "background": "#f0f8ff",
+                  "background": "rgb(247, 247, 247)",
                   "display": "flex",
                 }
               }
@@ -10117,7 +10136,7 @@ exports[`Storyshots QueryBuilder/Internals/Indentable and 1`] = `
       onClick={undefined}
       style={
         Object {
-          "background": "#f0f8ff",
+          "background": "rgb(247, 247, 247)",
         }
       }
     >
@@ -10199,7 +10218,7 @@ exports[`Storyshots QueryBuilder/Internals/Indentable not 1`] = `
       onClick={undefined}
       style={
         Object {
-          "background": "#f0f8ff",
+          "background": "rgb(247, 247, 247)",
         }
       }
     >
@@ -10281,7 +10300,7 @@ exports[`Storyshots QueryBuilder/Internals/Indentable or 1`] = `
       onClick={undefined}
       style={
         Object {
-          "background": "#f0f8ff",
+          "background": "rgb(247, 247, 247)",
         }
       }
     >
@@ -10351,7 +10370,7 @@ exports[`Storyshots QueryBuilder/Internals/Operator and 1`] = `
             "height": "2px",
             "left": "50px",
             "position": "relative",
-            "width": "39px",
+            "width": "15px",
           }
         }
       />
@@ -10369,26 +10388,12 @@ exports[`Storyshots QueryBuilder/Internals/Operator first and 1`] = `
         onClick={[Function]}
         style={
           Object {
-            "background": "#f0f8ff",
+            "background": "rgb(247, 247, 247)",
             "borderBottom": "solid 2px black",
             "borderBottomColor": "#5bc0de",
             "height": 17.5,
             "marginLeft": "24px",
             "width": "40px",
-          }
-        }
-      />
-      <div
-        style={
-          Object {
-            "background": "#5bc0de",
-            "bottom": "17.5px",
-            "color": "white",
-            "height": "2px",
-            "left": 63,
-            "position": "relative",
-            "top": -2,
-            "width": 25,
           }
         }
       />
@@ -10431,7 +10436,7 @@ exports[`Storyshots QueryBuilder/Internals/Operator first not 1`] = `
             "height": "2px",
             "left": "50px",
             "position": "relative",
-            "width": "39px",
+            "width": "15px",
           }
         }
       />
@@ -10449,26 +10454,12 @@ exports[`Storyshots QueryBuilder/Internals/Operator first or 1`] = `
         onClick={[Function]}
         style={
           Object {
-            "background": "#f0f8ff",
+            "background": "rgb(247, 247, 247)",
             "borderBottom": "solid 2px black",
             "borderBottomColor": "#5cb85c",
             "height": 17.5,
             "marginLeft": "24px",
             "width": "40px",
-          }
-        }
-      />
-      <div
-        style={
-          Object {
-            "background": "#5cb85c",
-            "bottom": "17.5px",
-            "color": "white",
-            "height": "2px",
-            "left": 63,
-            "position": "relative",
-            "top": -2,
-            "width": 25,
           }
         }
       />
@@ -10511,7 +10502,7 @@ exports[`Storyshots QueryBuilder/Internals/Operator not 1`] = `
             "height": "2px",
             "left": "50px",
             "position": "relative",
-            "width": "39px",
+            "width": "15px",
           }
         }
       />
@@ -10554,7 +10545,7 @@ exports[`Storyshots QueryBuilder/Internals/Operator or 1`] = `
             "height": "2px",
             "left": "50px",
             "position": "relative",
-            "width": "39px",
+            "width": "15px",
           }
         }
       />

--- a/__tests__/__snapshots__/Snaphot.js.snap
+++ b/__tests__/__snapshots__/Snaphot.js.snap
@@ -2427,7 +2427,6 @@ exports[`Storyshots IMDB Check List 1`] = `
       .gv-input[type="text"], textarea.gv-input, .gv-input[type="number"], .gv-input[type="date"] {
         padding: 5px;
         text-indent: 5px;
-        margin: 5px auto;
       }
       .gv-input, .gv-body select, .gv-body input {
         outline: none;
@@ -2456,7 +2455,6 @@ exports[`Storyshots IMDB Check List 1`] = `
         border-radius: 4px;
         min-height: 40px;
         box-sizing: border-box;
-        margin: 5px auto;
         background: #fff;
         /* Arbitrary theme design */
         padding: 15px;
@@ -2847,7 +2845,6 @@ exports[`Storyshots IMDB Grey Vest Theme 1`] = `
       .gv-input[type="text"], textarea.gv-input, .gv-input[type="number"], .gv-input[type="date"] {
         padding: 5px;
         text-indent: 5px;
-        margin: 5px auto;
       }
       .gv-input, .gv-body select, .gv-body input {
         outline: none;
@@ -2876,7 +2873,6 @@ exports[`Storyshots IMDB Grey Vest Theme 1`] = `
         border-radius: 4px;
         min-height: 40px;
         box-sizing: border-box;
-        margin: 5px auto;
         background: #fff;
         /* Arbitrary theme design */
         padding: 15px;
@@ -6449,17 +6445,6 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
   </div>
   <button
     onClick={[Function]}
-    style={
-      Object {
-        "background": "white",
-        "border": "1px solid #ccc",
-        "borderRadius": 5000,
-        "display": "inline-block",
-        "padding": ".5rem 1rem",
-        "textAlign": "center",
-      }
-    }
-    type="button"
   >
     Add Filter
   </button>
@@ -6673,17 +6658,6 @@ exports[`Storyshots QueryBuilder/Examples One Filter 1`] = `
   </div>
   <button
     onClick={[Function]}
-    style={
-      Object {
-        "background": "white",
-        "border": "1px solid #ccc",
-        "borderRadius": 5000,
-        "display": "inline-block",
-        "padding": ".5rem 1rem",
-        "textAlign": "center",
-      }
-    }
-    type="button"
   >
     Add Filter
   </button>
@@ -6897,17 +6871,6 @@ exports[`Storyshots QueryBuilder/Examples One Filter on a misplaced root 1`] = `
   </div>
   <button
     onClick={[Function]}
-    style={
-      Object {
-        "background": "white",
-        "border": "1px solid #ccc",
-        "borderRadius": 5000,
-        "display": "inline-block",
-        "padding": ".5rem 1rem",
-        "textAlign": "center",
-      }
-    }
-    type="button"
   >
     Add Filter
   </button>
@@ -7248,17 +7211,6 @@ exports[`Storyshots QueryBuilder/Examples One Filter with facet options 1`] = `
   </div>
   <button
     onClick={[Function]}
-    style={
-      Object {
-        "background": "white",
-        "border": "1px solid #ccc",
-        "borderRadius": 5000,
-        "display": "inline-block",
-        "padding": ".5rem 1rem",
-        "textAlign": "center",
-      }
-    }
-    type="button"
   >
     Add Filter
   </button>
@@ -7503,17 +7455,6 @@ exports[`Storyshots QueryBuilder/Examples One Filter with fields 1`] = `
   </div>
   <button
     onClick={[Function]}
-    style={
-      Object {
-        "background": "white",
-        "border": "1px solid #ccc",
-        "borderRadius": 5000,
-        "display": "inline-block",
-        "padding": ".5rem 1rem",
-        "textAlign": "center",
-      }
-    }
-    type="button"
   >
     Add Filter
   </button>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/FilterList.js
+++ b/src/FilterList.js
@@ -4,7 +4,7 @@ import { observer, inject } from 'mobx-react'
 import { Dynamic } from './layout'
 import InjectTreeNode from './utils/injectTreeNode'
 import DefaultIcon from './DefaultIcon'
-import {bdJoin} from './styles/generic'
+import { bdJoin } from './styles/generic'
 
 export let Label = inject(_.pick('tree'))(
   observer(({ tree, node, Icon, ...x }) => (
@@ -52,39 +52,42 @@ export let FilterList = InjectTreeNode(
       mapNodeToLabel = _.noop,
       Icon = DefaultIcon,
       className,
-      style
+      style,
     }) => (
       <div style={style} className={className}>
         {_.map(
-          child => child.children
-          ? <FilterList
-              key={child.path}
-              node={child}
-              typeComponents={types}
-              fields={fields}
-              mapNodeToProps={mapNodeToProps}
-              mapNodeToLabel={mapNodeToLabel}
-              Icon={Icon}
-              className={'filter-list-group'}
-              style={bdJoin(child)}
-            />
-          : <div key={child.path} className="filter-list-item">
-              <FieldLabel
+          child =>
+            child.children ? (
+              <FilterList
+                key={child.path}
                 node={child}
+                typeComponents={types}
                 fields={fields}
+                mapNodeToProps={mapNodeToProps}
+                mapNodeToLabel={mapNodeToLabel}
                 Icon={Icon}
-                label={mapNodeToLabel(child, fields, types)}
+                className={'filter-list-group'}
+                style={bdJoin(child)}
               />
-              {!child.paused && (
-                <div className="filter-list-item-contents">
-                  <Dynamic
-                    component={types[child.type]}
-                    path={child.path.slice()}
-                    {...mapNodeToProps(child, fields, types)}
-                  />
-                </div>
-              )}
-            </div>,
+            ) : (
+              <div key={child.path} className="filter-list-item">
+                <FieldLabel
+                  node={child}
+                  fields={fields}
+                  Icon={Icon}
+                  label={mapNodeToLabel(child, fields, types)}
+                />
+                {!child.paused && (
+                  <div className="filter-list-item-contents">
+                    <Dynamic
+                      component={types[child.type]}
+                      path={child.path.slice()}
+                      {...mapNodeToProps(child, fields, types)}
+                    />
+                  </div>
+                )}
+              </div>
+            ),
           node.children
         )}
       </div>

--- a/src/FilterList.js
+++ b/src/FilterList.js
@@ -4,6 +4,7 @@ import { observer, inject } from 'mobx-react'
 import { Dynamic } from './layout'
 import InjectTreeNode from './utils/injectTreeNode'
 import DefaultIcon from './DefaultIcon'
+import {bdJoin} from './styles/generic'
 
 export let Label = inject(_.pick('tree'))(
   observer(({ tree, node, Icon, ...x }) => (
@@ -50,11 +51,24 @@ export let FilterList = InjectTreeNode(
       mapNodeToProps = _.noop,
       mapNodeToLabel = _.noop,
       Icon = DefaultIcon,
+      className,
+      style
     }) => (
-      <div>
+      <div style={style} className={className}>
         {_.map(
-          child => (
-            <div key={child.path} className="filter-list-item">
+          child => child.children
+          ? <FilterList
+              key={child.path}
+              node={child}
+              typeComponents={types}
+              fields={fields}
+              mapNodeToProps={mapNodeToProps}
+              mapNodeToLabel={mapNodeToLabel}
+              Icon={Icon}
+              className={'filter-list-group'}
+              style={bdJoin(child)}
+            />
+          : <div key={child.path} className="filter-list-item">
               <FieldLabel
                 node={child}
                 fields={fields}
@@ -70,8 +84,7 @@ export let FilterList = InjectTreeNode(
                   />
                 </div>
               )}
-            </div>
-          ),
+            </div>,
           node.children
         )}
       </div>

--- a/src/queryBuilder/FilterContents.js
+++ b/src/queryBuilder/FilterContents.js
@@ -13,68 +13,70 @@ let FieldPicker = defaultProps({
 })(ModalPicker)
 
 let FilterContents = inject(_.defaults)(
-  observer(({ node, root, fields, types = {}, ContextureButton = 'button' }) => {
-    // `get` allows us to create a dependency on field before we know it exists (because the client will only add it if it's a type that uses it as it wouldn't make sense for something like `results`)
-    let nodeField = get(node, 'field')
-    return (
-      <div
-        style={{
-          display: 'flex',
-          width: '100%',
-        }}
-      >
-        <FieldPicker
-          Button={ContextureButton}
-          label={
-            nodeField ? _.get([nodeField, 'label'], fields) : 'Pick a Field'
-          }
-          options={fieldsToOptions(fields)}
-          // TODO: consider type options in case this isn't safe, e.g. a field/type change action
-          onChange={field => root.mutate(node.path, { field })}
-        />
-        {nodeField && (
-          <div style={{ margin: '0 5px' }}>
-            <select
-              onChange={({ target: { value } }) => {
-                root.typeChange(node, value)
-              }}
-              value={F.when(_.isNil, undefined)(node.type)} // fix null value issue...
-            >
-              {_.map(
-                x => (
-                  <option key={x.value} value={x.value} disabled={x.disabled}>
-                    {x.label}
-                  </option>
-                ),
-                [
-                  {
-                    value: null,
-                    label: 'Select Type',
-                    disabled: node.type,
-                  },
-                  ...F.autoLabelOptions(
-                    _.get([nodeField, 'typeOptions'], fields)
+  observer(
+    ({ node, root, fields, types = {}, ContextureButton = 'button' }) => {
+      // `get` allows us to create a dependency on field before we know it exists (because the client will only add it if it's a type that uses it as it wouldn't make sense for something like `results`)
+      let nodeField = get(node, 'field')
+      return (
+        <div
+          style={{
+            display: 'flex',
+            width: '100%',
+          }}
+        >
+          <FieldPicker
+            Button={ContextureButton}
+            label={
+              nodeField ? _.get([nodeField, 'label'], fields) : 'Pick a Field'
+            }
+            options={fieldsToOptions(fields)}
+            // TODO: consider type options in case this isn't safe, e.g. a field/type change action
+            onChange={field => root.mutate(node.path, { field })}
+          />
+          {nodeField && (
+            <div style={{ margin: '0 5px' }}>
+              <select
+                onChange={({ target: { value } }) => {
+                  root.typeChange(node, value)
+                }}
+                value={F.when(_.isNil, undefined)(node.type)} // fix null value issue...
+              >
+                {_.map(
+                  x => (
+                    <option key={x.value} value={x.value} disabled={x.disabled}>
+                      {x.label}
+                    </option>
                   ),
-                ]
-              )}
-            </select>
-          </div>
-        )}
-        {node.type && (
-          <div
-            style={{
-              display: 'inline-block',
-              verticalAlign: 'top',
-              width: '100%',
-              marginRight: '5px',
-            }}
-          >
-            <Dynamic component={types[node.type]} node={node} tree={root} />
-          </div>
-        )}
-      </div>
-    )
-  })
+                  [
+                    {
+                      value: null,
+                      label: 'Select Type',
+                      disabled: node.type,
+                    },
+                    ...F.autoLabelOptions(
+                      _.get([nodeField, 'typeOptions'], fields)
+                    ),
+                  ]
+                )}
+              </select>
+            </div>
+          )}
+          {node.type && (
+            <div
+              style={{
+                display: 'inline-block',
+                verticalAlign: 'top',
+                width: '100%',
+                marginRight: '5px',
+              }}
+            >
+              <Dynamic component={types[node.type]} node={node} tree={root} />
+            </div>
+          )}
+        </div>
+      )
+    }
+  )
 )
 FilterContents.displayName = 'FilterContents'
 

--- a/src/queryBuilder/FilterContents.js
+++ b/src/queryBuilder/FilterContents.js
@@ -13,7 +13,7 @@ let FieldPicker = defaultProps({
 })(ModalPicker)
 
 let FilterContents = inject(_.defaults)(
-  observer(({ node, root, fields, types = {} }) => {
+  observer(({ node, root, fields, types = {}, ContextureButton = 'button' }) => {
     // `get` allows us to create a dependency on field before we know it exists (because the client will only add it if it's a type that uses it as it wouldn't make sense for something like `results`)
     let nodeField = get(node, 'field')
     return (
@@ -24,6 +24,7 @@ let FilterContents = inject(_.defaults)(
         }}
       >
         <FieldPicker
+          Button={ContextureButton}
           label={
             nodeField ? _.get([nodeField, 'label'], fields) : 'Pick a Field'
           }

--- a/src/queryBuilder/Group.js
+++ b/src/queryBuilder/Group.js
@@ -36,7 +36,7 @@ let GroupItem = FilterDragSource(args => {
           {...{ tree, child, root, parentTree, index, parent: state }}
         />
       )}
-      {child.join ? (
+      {child.children ? (
         <Group tree={child} root={root} parentTree={tree} />
       ) : (
         <Rule {...{ ...args, node: child }} />

--- a/src/queryBuilder/Operator.js
+++ b/src/queryBuilder/Operator.js
@@ -15,7 +15,7 @@ let BlankOperator = ({ state, tree, child }) => (
         borderBottomColor: styles.joinColor(tree.join),
       }}
     />
-    {child.join &&
+    {child.children &&
       child.join !== 'not' && (
         <div
           style={{
@@ -33,7 +33,7 @@ let OperatorLine = Component(({ tree, child, style }) => (
   <div
     style={{
       ...styles.operatorLine,
-      ...(child.join && child.join !== 'not' && styles.operatorLineExtended),
+      ...(child.children && child.join !== 'not' && styles.operatorLineExtended),
       ...styles.bgJoin(tree),
       ...style,
     }}

--- a/src/queryBuilder/Operator.js
+++ b/src/queryBuilder/Operator.js
@@ -33,7 +33,9 @@ let OperatorLine = Component(({ tree, child, style }) => (
   <div
     style={{
       ...styles.operatorLine,
-      ...(child.children && child.join !== 'not' && styles.operatorLineExtended),
+      ...(child.children &&
+        child.join !== 'not' &&
+        styles.operatorLineExtended),
       ...styles.bgJoin(tree),
       ...style,
     }}

--- a/src/queryBuilder/QueryBuilder.js
+++ b/src/queryBuilder/QueryBuilder.js
@@ -111,19 +111,17 @@ export default DDContext(
         ...ContextureClientBridge(types, tree),
       }),
     }),
-    ({ state, path, fields, types = {} }) => (
-      <Provider fields={fields} types={types}>
+    ({ state, path, fields, types = {}, Button = 'button' }) => (
+      <Provider fields={fields} types={types} ContextureButton={Button}>
         <div style={{ background }}>
           <Group tree={state.getNode(path)} root={state} isRoot={true} />
-          <button
-            type="button"
-            style={styles.btn}
+          <Button
             onClick={() => {
               state.adding = !state.adding
             }}
           >
             {state.adding ? 'Cancel' : 'Add Filter'}
-          </button>
+          </Button>
         </div>
       </Provider>
     ),

--- a/src/queryBuilder/Rule.js
+++ b/src/queryBuilder/Rule.js
@@ -21,7 +21,7 @@ let Rule = ({ state, node, tree, root, connectDragSource, isDragging }) =>
               ...styles.bgStriped,
             }),
             ...(isDragging && { opacity: 0.25 }),
-            ...(state.ruleHover && { background: 'rgba(0, 0, 0, 0.05)' }),
+            ...(state.ruleHover && { background: styles.background }),
           }}
           {...F.domLens.hover(state.lens.ruleHover)}
         >

--- a/src/styles/queryBuilder.js
+++ b/src/styles/queryBuilder.js
@@ -7,7 +7,7 @@ import {
 } from './generic'
 
 // Style Configuration
-export let background = '#f0f8ff'
+export let background = 'rgb(247, 247, 247)'//'#f0f8ff'
 // let background = '#fff'
 // let operatorHeight = 50
 let operatorHeight = 35

--- a/src/styles/queryBuilder.js
+++ b/src/styles/queryBuilder.js
@@ -7,7 +7,7 @@ import {
 } from './generic'
 
 // Style Configuration
-export let background = 'rgb(247, 247, 247)'//'#f0f8ff'
+export let background = 'rgb(247, 247, 247)' //'#f0f8ff'
 // let background = '#fff'
 // let operatorHeight = 50
 let operatorHeight = 35

--- a/src/themes/greyVest.js
+++ b/src/themes/greyVest.js
@@ -493,9 +493,17 @@ export let GVStyle = () => (
       }
       
       .filter-list-item-contents {
-        margin-top: 15px
+        margin-top: 15px;
       }
       
+      .filter-list-group {
+        border-left: solid 2px;
+        padding-left: 35px; /* 30 for filter-list-item + 5 space */
+        margin-left: -30px;
+        margin-top: -25px; /* -30 for filter-list-item + 5 space */
+        padding-top: 30px;
+      }
+
       .gv-grid {
         display: grid;
         grid-template-columns: 400px 1fr;

--- a/src/themes/greyVest.js
+++ b/src/themes/greyVest.js
@@ -15,6 +15,7 @@ import {
 } from '../'
 import DefaultSelect from '../layout/Select'
 import ExampleTypeConstructor from '../exampleTypes/'
+import QueryBuilderComponent from '../queryBuilder'
 
 export let Input = ({ className = '', style, type = 'text', ...x }) => (
   <input
@@ -239,7 +240,6 @@ export let GVStyle = () => (
       .gv-input[type="text"], textarea.gv-input, .gv-input[type="number"], .gv-input[type="date"] {
         padding: 5px;
         text-indent: 5px;
-        margin: 5px auto;
       }
       .gv-input, .gv-body select, .gv-body input {
         outline: none;
@@ -268,7 +268,6 @@ export let GVStyle = () => (
         border-radius: 4px;
         min-height: 40px;
         box-sizing: border-box;
-        margin: 5px auto;
         background: #fff;
         /* Arbitrary theme design */
         padding: 15px;
@@ -744,3 +743,6 @@ let ErrorText = ({ children }) => (
 )
 export let ErrorList = ({ children }) =>
   _.map(e => <ErrorText key={e}>{e}</ErrorText>, _.castArray(children))
+
+
+export let QueryBuilder = defaultProps({ Button })(QueryBuilderComponent)

--- a/src/themes/greyVest.js
+++ b/src/themes/greyVest.js
@@ -744,5 +744,4 @@ let ErrorText = ({ children }) => (
 export let ErrorList = ({ children }) =>
   _.map(e => <ErrorText key={e}>{e}</ErrorText>, _.castArray(children))
 
-
 export let QueryBuilder = defaultProps({ Button })(QueryBuilderComponent)

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -45,17 +45,25 @@ let tree = Contexture({
     {
       key: 'criteria',
       type: 'group',
+      join: 'and',
       children: [
         {
-          key: 'titleContains',
-          type: 'tagsQuery',
-          field: 'title',
-        },
-        {
-          key: 'titleDoesNotContain',
-          type: 'tagsQuery',
-          field: 'title',
-          join: 'none',
+          key: 'titleGroup',
+          type: 'group',
+          join: 'or',
+          children: [
+            {
+              key: 'titleContains',
+              type: 'tagsQuery',
+              field: 'title',
+            },
+            {
+              key: 'titleDoesNotContain',
+              type: 'tagsQuery',
+              field: 'title',
+              join: 'none',
+            },
+          ]
         },
         {
           key: 'searchNumber',

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -1,10 +1,11 @@
 import _ from 'lodash/fp'
+import F from 'futil-js'
 import React from 'react'
 import { observable } from 'mobx'
 import { fromPromise } from 'mobx-utils'
 import { Provider } from 'mobx-react'
 import Contexture, { updateSchemas } from '../utils/contexture'
-import { Label, Flex, Awaiter } from '../../../src'
+import { Label, Flex, Awaiter, QueryBuilder } from '../../../src'
 import {
   FilterList,
   Fonts,
@@ -112,6 +113,7 @@ tree.disableAutoUpdate = true
 
 let state = observable({
   autoUpdate: false,
+  showBuilder: false,
   tab: 'results',
 })
 
@@ -172,9 +174,14 @@ export default () => (
     <Awaiter promise={schemas}>
       {schemas => (
         <Provider tree={tree}>
-          <div className="gv-grid">
-            <div>
-              <h1>Filters</h1>
+          <div className="gv-grid" style={state.showBuilder ? {gridTemplateColumns: '1fr'} : {}}>
+            {state.showBuilder || <div>
+              <Flex style={{ alignItems: 'center' }}>
+                <h1>Filters</h1>
+                <IconButton title="Open Builder" onClick={F.flip('showBuilder', state)}>
+                  <i className="material-icons">build</i>
+                </IconButton>
+              </Flex>                
               <div className="gv-box filter-list">
                 <div className="filter-list-item">
                   <Label>Released</Label>
@@ -207,6 +214,7 @@ export default () => (
                 />
               </div>
             </div>
+            }
             <div>
               <h1>Search Movies</h1>
               <div className="gv-search-bar">
@@ -246,6 +254,20 @@ export default () => (
                   </div>
                 </div>
               </div>
+              {state.showBuilder &&
+                <div>
+                  <Flex style={{ alignItems: 'center' }}>
+                    <h1>Builder</h1>
+                    <IconButton title="Open Builder" onClick={F.flip('showBuilder', state)}>
+                      <i className="material-icons">build</i>
+                    </IconButton>
+                  </Flex>
+                  <QueryBuilder
+                    types={TypeMap}
+                    fields={schemas.movies.fields}
+                    path={['root', 'criteria']}
+                  />
+                </div>}
               <h1>Search Results</h1>
               <Tabs
                 options={[

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -5,7 +5,7 @@ import { observable } from 'mobx'
 import { fromPromise } from 'mobx-utils'
 import { Provider } from 'mobx-react'
 import Contexture, { updateSchemas } from '../utils/contexture'
-import { Label, Flex, Awaiter, QueryBuilder } from '../../../src'
+import { Label, Flex, Awaiter } from '../../../src'
 import {
   FilterList,
   Fonts,
@@ -16,6 +16,7 @@ import {
   ExampleTypes,
   IconButton,
   Tabs,
+  QueryBuilder
 } from '../../../src/themes/greyVest'
 import { Column } from './../../../src/layout/ExpandableTable'
 let {

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -16,7 +16,7 @@ import {
   ExampleTypes,
   IconButton,
   Tabs,
-  QueryBuilder
+  QueryBuilder,
 } from '../../../src/themes/greyVest'
 import { Column } from './../../../src/layout/ExpandableTable'
 let {

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -64,7 +64,7 @@ let tree = Contexture({
               field: 'title',
               join: 'none',
             },
-          ]
+          ],
         },
         {
           key: 'searchNumber',
@@ -174,47 +174,54 @@ export default () => (
     <Awaiter promise={schemas}>
       {schemas => (
         <Provider tree={tree}>
-          <div className="gv-grid" style={state.showBuilder ? {gridTemplateColumns: '1fr'} : {}}>
-            {state.showBuilder || <div>
-              <Flex style={{ alignItems: 'center' }}>
-                <h1>Filters</h1>
-                <IconButton title="Open Builder" onClick={F.flip('showBuilder', state)}>
-                  <i className="material-icons">build</i>
-                </IconButton>
-              </Flex>                
-              <div className="gv-box filter-list">
-                <div className="filter-list-item">
-                  <Label>Released</Label>
-                  <div className="filter-list-item-contents">
-                    <DateRangePicker
-                      path={['root', 'status']}
-                      ranges={[
-                        { label: 'All Time', from: '', to: '' },
-                        { label: 'This Year', from: 'now/y', to: '' },
-                        { label: 'Last Year', from: 'now-1y/y', to: 'now/y' },
-                      ]}
-                    />
+          <div
+            className="gv-grid"
+            style={state.showBuilder ? { gridTemplateColumns: '1fr' } : {}}
+          >
+            {state.showBuilder || (
+              <div>
+                <Flex style={{ alignItems: 'center' }}>
+                  <h1>Filters</h1>
+                  <IconButton
+                    title="Open Builder"
+                    onClick={F.flip('showBuilder', state)}
+                  >
+                    <i className="material-icons">build</i>
+                  </IconButton>
+                </Flex>
+                <div className="gv-box filter-list">
+                  <div className="filter-list-item">
+                    <Label>Released</Label>
+                    <div className="filter-list-item-contents">
+                      <DateRangePicker
+                        path={['root', 'status']}
+                        ranges={[
+                          { label: 'All Time', from: '', to: '' },
+                          { label: 'This Year', from: 'now/y', to: '' },
+                          { label: 'Last Year', from: 'now-1y/y', to: 'now/y' },
+                        ]}
+                      />
+                    </div>
                   </div>
+                  <FilterList
+                    path={['root', 'criteria']}
+                    fields={schemas.movies.fields}
+                    typeComponents={TypeMap}
+                    mapNodeToLabel={({ key }) =>
+                      ({
+                        titleContains: 'Title Contains',
+                        titleDoesNotContain: 'Title Does Not Contain',
+                      }[key])
+                    }
+                  />
+                  <Adder
+                    path={['root', 'criteria']}
+                    fields={schemas.movies.fields}
+                    uniqueFields
+                  />
                 </div>
-                <FilterList
-                  path={['root', 'criteria']}
-                  fields={schemas.movies.fields}
-                  typeComponents={TypeMap}
-                  mapNodeToLabel={({ key }) =>
-                    ({
-                      titleContains: 'Title Contains',
-                      titleDoesNotContain: 'Title Does Not Contain',
-                    }[key])
-                  }
-                />
-                <Adder
-                  path={['root', 'criteria']}
-                  fields={schemas.movies.fields}
-                  uniqueFields
-                />
               </div>
-            </div>
-            }
+            )}
             <div>
               <h1>Search Movies</h1>
               <div className="gv-search-bar">
@@ -254,11 +261,14 @@ export default () => (
                   </div>
                 </div>
               </div>
-              {state.showBuilder &&
+              {state.showBuilder && (
                 <div>
                   <Flex style={{ alignItems: 'center' }}>
                     <h1>Builder</h1>
-                    <IconButton title="Open Builder" onClick={F.flip('showBuilder', state)}>
+                    <IconButton
+                      title="Open Builder"
+                      onClick={F.flip('showBuilder', state)}
+                    >
                       <i className="material-icons">build</i>
                     </IconButton>
                   </Flex>
@@ -267,7 +277,8 @@ export default () => (
                     fields={schemas.movies.fields}
                     path={['root', 'criteria']}
                   />
-                </div>}
+                </div>
+              )}
               <h1>Search Results</h1>
               <Tabs
                 options={[


### PR DESCRIPTION
Add support for NestedFilter lists, which allows FilterList to render anything QueryBuilder can!

It does this (in grey vest) by adding a 2 px border on the left of groups to show what's and/or/not together using the same colors as the query builder.

Here's a contrived example with lots of nesting:
<img width="408" alt="screen shot 2018-12-06 at 10 56 04 pm" src="https://user-images.githubusercontent.com/1043503/49626968-40b28d00-f9aa-11e8-8360-50d41c527a76.png">

This also adds a toggle button on the IMDB Grey Vest storybook example which show switching between basic and advanced in real time with no explosions:
<img width="972" alt="screen shot 2018-12-06 at 11 32 38 pm" src="https://user-images.githubusercontent.com/1043503/49627889-478fce80-f9af-11e8-8ea7-194932caa97f.png">

It still looks a bit crappy because some things are still using the original rounded buttons and the tags input is much taller than other inputs. This will be fixed once we get new designs.

Diff is best viewed ignoring whitespace