### PR TITLE
No slicey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.30.2
+* Use `_.toArray` instead of `.slice()` to protect against undefined values.
+
 # 1.30.1
 * Fix the DateRangePicker OnChange issue
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/FilterList.js
+++ b/src/FilterList.js
@@ -81,7 +81,7 @@ export let FilterList = InjectTreeNode(
                   <div className="filter-list-item-contents">
                     <Dynamic
                       component={types[child.type]}
-                      path={child.path.slice()}
+                      path={_.toArray(child.path)}
                       {...mapNodeToProps(child, fields, types)}
                     />
                   </div>

--- a/src/exampleTypes/CheckableResultTable.js
+++ b/src/exampleTypes/CheckableResultTable.js
@@ -7,7 +7,7 @@ import { length } from '../utils/futil'
 import InjectTreeNode from '../utils/injectTreeNode'
 
 let Label = observer(({ node, Checkbox, selected, getValue }) => {
-  let results = getResults(node).slice()
+  let results = _.toArray(getResults(node))
   let allChecked = length(results) === length(F.view(selected))
   let checkAll = F.sets(
     allChecked

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -196,7 +196,7 @@ let Header = withStateLens({ popover: false, adding: false, filtering: false })(
                   !filterNode.paused && (
                     <Dynamic
                       component={typeComponents[filterNode.type]}
-                      path={filterNode.path.slice()}
+                      path={_.toArray(filterNode.path)}
                       {...mapNodeToProps(filterNode, fields, typeComponents)}
                     />
                   )}

--- a/src/queryBuilder/Group.js
+++ b/src/queryBuilder/Group.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import _ from 'lodash/fp'
 import * as F from 'futil-js'
 import { Component, lenservable } from '../utils/mobx-react-utils'
 import styles from '../styles'
@@ -85,7 +86,7 @@ let Group = Component(
                   )}
                 </div>
               ),
-              tree.children.slice()
+              _.toArray(tree.children)
             )}
             {/*<FilterMoveTarget index={tree.children.length} tree={tree} /> */}
             {root.adding && (

--- a/src/utils/tree.js
+++ b/src/utils/tree.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 import * as F from 'futil-js'
 
-export let traverse = x => x && x.children && x.children.slice() // mobx needs slice
+export let traverse = x => x && x.children && _.toArray(x.children) // mobx needs slice
 export let keyPath = key => (_.isString(key) ? { key } : key)
 export default F.tree(traverse, keyPath)


### PR DESCRIPTION
* Use `_.toArray` instead of `.slice()` to protect against undefined values.

For: https://github.com/smartprocure/bid-search/issues/567