### PR TITLE
feature/122 - improve Facet checkbox label styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.32.0
+* improves checkbox and label stylign in Facet example type
+
 # 1.31.0
 * TagsQuery: Add tag popover with support for changing join, per tag distance (0 vs 3 distance as "fuzzy" v "exact"), exact toggle, per tag disabling, and an apply distance to all tags link
 * TagsText: Add Support

--- a/__tests__/__snapshots__/Snaphot.js.snap
+++ b/__tests__/__snapshots__/Snaphot.js.snap
@@ -453,7 +453,7 @@ exports[`Storyshots Example Types Full Demo 1`] = `
               <label
                 style={
                   Object {
-                    "alignItems": "baseline",
+                    "alignItems": "center",
                     "cursor": "pointer",
                     "display": "flex",
                     "justifyContent": "space-between",
@@ -674,7 +674,7 @@ exports[`Storyshots Example Types Full Demo 1`] = `
               <label
                 style={
                   Object {
-                    "alignItems": "baseline",
+                    "alignItems": "center",
                     "cursor": "pointer",
                     "display": "flex",
                     "justifyContent": "space-between",
@@ -4008,7 +4008,7 @@ exports[`Storyshots IMDB Quick Start 1`] = `
                 <label
                   style={
                     Object {
-                      "alignItems": "baseline",
+                      "alignItems": "center",
                       "cursor": "pointer",
                       "display": "flex",
                       "justifyContent": "space-between",
@@ -4112,7 +4112,7 @@ exports[`Storyshots IMDB Quick Start 1`] = `
                 <label
                   style={
                     Object {
-                      "alignItems": "baseline",
+                      "alignItems": "center",
                       "cursor": "pointer",
                       "display": "flex",
                       "justifyContent": "space-between",
@@ -5302,7 +5302,7 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
                                                       <label
                                                         style={
                                                           Object {
-                                                            "alignItems": "baseline",
+                                                            "alignItems": "center",
                                                             "cursor": "pointer",
                                                             "display": "flex",
                                                             "justifyContent": "space-between",
@@ -6786,7 +6786,6 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
                                                           "lastUpdateTime": null,
                                                           "markedForUpdate": null,
                                                           "missedUpdate": null,
-                                                          "operator": "containsWord",
                                                           "path": Array [
                                                             "root",
                                                             "group24",
@@ -7720,7 +7719,7 @@ exports[`Storyshots QueryBuilder/Examples One Filter with facet options 1`] = `
                               <label
                                 style={
                                   Object {
-                                    "alignItems": "baseline",
+                                    "alignItems": "center",
                                     "cursor": "pointer",
                                     "display": "flex",
                                     "justifyContent": "space-between",

--- a/__tests__/__snapshots__/Snaphot.js.snap
+++ b/__tests__/__snapshots__/Snaphot.js.snap
@@ -6786,6 +6786,7 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
                                                           "lastUpdateTime": null,
                                                           "markedForUpdate": null,
                                                           "missedUpdate": null,
+                                                          "operator": "containsWord",
                                                           "path": Array [
                                                             "root",
                                                             "group24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.31.0",
+  "version": "1.32.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -31,7 +31,7 @@ let SelectAll = observer(({ node, tree, Checkbox }) => {
     <label
       style={{
         justifyContent: 'space-between',
-        alignItems: 'baseline',
+        alignItems: 'center',
         display: 'flex',
         cursor: 'pointer',
       }}


### PR DESCRIPTION
Fixes #122 

### Description
* sets `align-items: center` on the checkbox + label container in the Facet component