### PR TITLE
Other matches field labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-﻿# 1.34.1
+﻿# 1.34.2
+* ResultTable: Lookup field labels in ResultTable other matches
+* ResultTable: Dont highlight field names
+* ResultTable: Fix other matches cursor
+* GreyVest: Add inline title highlighting and additional writers highlighting
+
+# 1.34.1
 * Fixed inconsistent column header for the highlighted records on the ResultTable.
 
 # 1.34.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.34.0",
+  "version": "1.34.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -52,7 +52,7 @@ let HighlightedColumn = withStateLens({ viewModal: false })(
       Table = 'table',
       Modal = null,
       viewModal,
-      schema
+      schema,
     }) =>
       !_.isEmpty(additionalFields) ? (
         <Cell key="additionalFields">
@@ -232,35 +232,37 @@ let Header = withStateLens({ popover: false, adding: false, filtering: false })(
 Header.displayName = 'Header'
 
 // Separate this our so that the table root doesn't create a dependency on results to headers won't need to rerender on data change
-let TableBody = observer(({ node, visibleFields, Modal, Table, Row, schema }) => (
-  <tbody style={node.markedForUpdate || node.updating ? loading : {}}>
-    {!!getResults(node).length &&
-      _.map(
-        x => (
-          <Row key={x._id}>
-            {_.map(
-              ({ field, display = x => x, Cell = 'td' }) => (
-                <Cell key={field}>
-                  {display(_.get(field, getRecord(x)), getRecord(x))}
-                </Cell>
-              ),
-              visibleFields
-            )}
-            <HighlightedColumn
-              {...{
-                node,
-                additionalFields: _.result('additionalFields.slice', x),
-                Modal,
-                Table,
-                schema
-              }}
-            />
-          </Row>
-        ),
-        getResults(node)
-      )}
-  </tbody>
-))
+let TableBody = observer(
+  ({ node, visibleFields, Modal, Table, Row, schema }) => (
+    <tbody style={node.markedForUpdate || node.updating ? loading : {}}>
+      {!!getResults(node).length &&
+        _.map(
+          x => (
+            <Row key={x._id}>
+              {_.map(
+                ({ field, display = x => x, Cell = 'td' }) => (
+                  <Cell key={field}>
+                    {display(_.get(field, getRecord(x)), getRecord(x))}
+                  </Cell>
+                ),
+                visibleFields
+              )}
+              <HighlightedColumn
+                {...{
+                  node,
+                  additionalFields: _.result('additionalFields.slice', x),
+                  Modal,
+                  Table,
+                  schema,
+                }}
+              />
+            </Row>
+          ),
+          getResults(node)
+        )}
+    </tbody>
+  )
+)
 TableBody.displayName = 'TableBody'
 
 let ResultTable = InjectTreeNode(

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -39,6 +39,9 @@ let HighlightedColumnHeader = observer(
 )
 HighlightedColumnHeader.displayName = 'HighlightedColumnHeader'
 
+let labelForField = (schema, field) =>
+  _.getOr(field, 'label', _.find({ field }, schema))
+
 let HighlightedColumn = withStateLens({ viewModal: false })(
   observer(
     ({
@@ -49,6 +52,7 @@ let HighlightedColumn = withStateLens({ viewModal: false })(
       Table = 'table',
       Modal = null,
       viewModal,
+      schema
     }) =>
       !_.isEmpty(additionalFields) ? (
         <Cell key="additionalFields">
@@ -60,7 +64,7 @@ let HighlightedColumn = withStateLens({ viewModal: false })(
                   {_.map(
                     ({ label, value }) => (
                       <tr>
-                        <td key={label}>{label}</td>
+                        <td key={label}>{labelForField(schema, label)}</td>
                         <td dangerouslySetInnerHTML={{ __html: value }} />
                       </tr>
                     ),
@@ -70,10 +74,10 @@ let HighlightedColumn = withStateLens({ viewModal: false })(
               </Table>
             </Modal>
           )}
-          <div onClick={F.on(viewModal)}>
+          <div style={{ cursor: 'pointer' }} onClick={F.on(viewModal)}>
             This search also matched on the fields:{' '}
             {_.flow(
-              _.map(({ label }) => <b>{label}</b>),
+              _.map(({ label }) => labelForField(schema, label)),
               F.intersperse(F.differentLast(() => ', ', () => ' and '))
             )(additionalFields)}
             .<br />
@@ -228,7 +232,7 @@ let Header = withStateLens({ popover: false, adding: false, filtering: false })(
 Header.displayName = 'Header'
 
 // Separate this our so that the table root doesn't create a dependency on results to headers won't need to rerender on data change
-let TableBody = observer(({ node, visibleFields, Modal, Table, Row }) => (
+let TableBody = observer(({ node, visibleFields, Modal, Table, Row, schema }) => (
   <tbody style={node.markedForUpdate || node.updating ? loading : {}}>
     {!!getResults(node).length &&
       _.map(
@@ -248,6 +252,7 @@ let TableBody = observer(({ node, visibleFields, Modal, Table, Row }) => (
                 additionalFields: _.result('additionalFields.slice', x),
                 Modal,
                 Table,
+                schema
               }}
             />
           </Row>
@@ -322,6 +327,7 @@ let ResultTable = InjectTreeNode(
           visibleFields={visibleFields}
           Modal={Modal}
           Table={Table}
+          schema={schema}
         />
       </Table>
     )

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -186,7 +186,7 @@ let schemas = fromPromise(
               display: x => <img src={x} width="180" height="270" />,
               order: 2,
             },
-            title: { order: 1 },
+            title: { order: 1, display: x => <span dangerouslySetInnerHTML={{ __html: x }} /> },
             genres: { display: divs },
             actors: { display: divs },
             imdbId: { path: ['Imdb', 'imdbId'] },

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -186,7 +186,10 @@ let schemas = fromPromise(
               display: x => <img src={x} width="180" height="270" />,
               order: 2,
             },
-            title: { order: 1, display: x => <span dangerouslySetInnerHTML={{ __html: x }} /> },
+            title: {
+              order: 1,
+              display: x => <span dangerouslySetInnerHTML={{ __html: x }} />,
+            },
             genres: { display: divs },
             actors: { display: divs },
             imdbId: { path: ['Imdb', 'imdbId'] },

--- a/stories/imdb/utils/contexture.js
+++ b/stories/imdb/utils/contexture.js
@@ -26,8 +26,8 @@ export let schemas = {
       type: 'movie',
       highlight: {
         inline: ['title'],
-        additional: 'writers'
-      }
+        additional: 'writers',
+      },
     },
     modeMap: {
       word: '',

--- a/stories/imdb/utils/contexture.js
+++ b/stories/imdb/utils/contexture.js
@@ -24,6 +24,10 @@ export let schemas = {
     elasticsearch: {
       index: 'movies',
       type: 'movie',
+      highlight: {
+        inline: ['title'],
+        additional: 'writers'
+      }
     },
     modeMap: {
       word: '',


### PR DESCRIPTION
* ResultTable: Lookup field labels in ResultTable other matches
* ResultTable: Dont highlight field names
* ResultTable: Fix other matches cursor
* GreyVest: Add inline title highlighting and additional writers highlighting

<img width="1200" alt="screen shot 2019-01-13 at 9 00 33 pm" src="https://user-images.githubusercontent.com/1043503/51093921-515add80-1776-11e9-9bd8-bf03d25b066d.png">
<img width="410" alt="screen shot 2019-01-13 at 9 00 38 pm" src="https://user-images.githubusercontent.com/1043503/51093922-515add80-1776-11e9-9a16-50c16cea2701.png">
