### PR TITLE
Do not pass props indiscriminately to Section child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.34.4
+# 1.34.5
+* NestedPicker: Whitelist props for a React DOM element when a custom Item is not being passed
+
+# 1.34.4
 * QueryBuilder: Fix weird spacing caused by flex instead of grid
 * GreyVest: Fix input indentation
 * ResultTable: Fix "double click" issue when inline filtering on a node that needs to be added

--- a/__tests__/__snapshots__/Snaphot.js.snap
+++ b/__tests__/__snapshots__/Snaphot.js.snap
@@ -4352,25 +4352,19 @@ exports[`Storyshots Layout NestedPicker 1`] = `
   >
     <div>
       <div
-        active={false}
         disabled={undefined}
-        hasChildren={true}
         onClick={[Function]}
       >
         Abcd
       </div>
       <div
-        active={false}
         disabled={undefined}
-        hasChildren={true}
         onClick={[Function]}
       >
         Bcde
       </div>
       <div
-        active={false}
         disabled={undefined}
-        hasChildren={true}
         onClick={[Function]}
       >
         Cdef

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.34.4",
+  "version": "1.34.5",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/layout/NestedPicker.js
+++ b/src/layout/NestedPicker.js
@@ -14,7 +14,7 @@ let unflattenObjectBy = _.curry((iteratee, x) =>
 let isField = x => x.typeDefault
 
 let FilteredSection = observer(
-  ({ options, onClick, highlight, Highlight, Item }) => (
+  ({ options, onClick, highlight, Highlight, Item = 'div' }) => (
     <div>
       {F.mapIndexed(
         (option, field) => (
@@ -28,20 +28,29 @@ let FilteredSection = observer(
   )
 )
 FilteredSection.displayName = 'FilteredSection'
-let Section = observer(({ options, onClick, selected, Item }) => (
+let Section = observer(({ options, onClick, selected, Item = 'div' }) => (
   <div>
     {F.mapIndexed(
-      (item, key) => (
-        <Item
-          key={key}
-          onClick={() => onClick(item.value || key, item)}
-          active={selected === key}
-          disabled={selected && selected !== key}
-          hasChildren={!isField(item)}
-        >
-          {isField(item) ? item.shortLabel || item.label : _.startCase(key)}
-        </Item>
-      ),
+      (item, key) =>
+        Item === 'div' ? (
+          <div
+            key={key}
+            onClick={() => onClick(item.value || key, item)}
+            disabled={selected && selected !== key}
+          >
+            {isField(item) ? item.shortLabel || item.label : _.startCase(key)}
+          </div>
+        ) : (
+          <Item
+            key={key}
+            onClick={() => onClick(item.value || key, item)}
+            disabled={selected && selected !== key}
+            active={selected === key}
+            hasChildren={!isField(item)}
+          >
+            {isField(item) ? item.shortLabel || item.label : _.startCase(key)}
+          </Item>
+        ),
       options
     )}
   </div>
@@ -98,7 +107,7 @@ let NestedPicker = ({
   filter,
   Input = 'input',
   Highlight = TextHighlight,
-  Item = 'div',
+  Item,
 }) => (
   <div>
     <Input {...F.domLens.value(filter)} placeholder="Enter filter keyword..." />

--- a/src/layout/NestedPicker.js
+++ b/src/layout/NestedPicker.js
@@ -13,8 +13,11 @@ let unflattenObjectBy = _.curry((iteratee, x) =>
 
 let isField = x => x.typeDefault
 
+const div = ({ children, onClick, disabled }) =>
+  <div onClick={onClick} disabled={disabled}>{children}</div>
+
 let FilteredSection = observer(
-  ({ options, onClick, highlight, Highlight, Item = 'div' }) => (
+  ({ options, onClick, highlight, Highlight, Item }) => (
     <div>
       {F.mapIndexed(
         (option, field) => (
@@ -28,28 +31,20 @@ let FilteredSection = observer(
   )
 )
 FilteredSection.displayName = 'FilteredSection'
-let Section = observer(({ options, onClick, selected, Item = 'div' }) => (
+
+let Section = observer(({ options, onClick, selected, Item }) => (
   <div>
     {F.mapIndexed(
-      (item, key) =>
-        Item === 'div' ? (
-          <div
-            key={key}
-            onClick={() => onClick(item.value || key, item)}
-            disabled={selected && selected !== key}
-          >
-            {isField(item) ? item.shortLabel || item.label : _.startCase(key)}
-          </div>
-        ) : (
-          <Item
-            key={key}
-            onClick={() => onClick(item.value || key, item)}
-            disabled={selected && selected !== key}
-            active={selected === key}
-            hasChildren={!isField(item)}
-          >
-            {isField(item) ? item.shortLabel || item.label : _.startCase(key)}
-          </Item>
+      (item, key) => (
+        <Item
+          key={key}
+          onClick={() => onClick(item.value || key, item)}
+          active={selected === key}
+          disabled={selected && selected !== key}
+          hasChildren={!isField(item)}
+        >
+          {isField(item) ? item.shortLabel || item.label : _.startCase(key)}
+        </Item>
         ),
       options
     )}
@@ -107,7 +102,7 @@ let NestedPicker = ({
   filter,
   Input = 'input',
   Highlight = TextHighlight,
-  Item,
+  Item = div,
 }) => (
   <div>
     <Input {...F.domLens.value(filter)} placeholder="Enter filter keyword..." />

--- a/src/layout/NestedPicker.js
+++ b/src/layout/NestedPicker.js
@@ -13,8 +13,11 @@ let unflattenObjectBy = _.curry((iteratee, x) =>
 
 let isField = x => x.typeDefault
 
-const div = ({ children, onClick, disabled }) =>
-  <div onClick={onClick} disabled={disabled}>{children}</div>
+const DefaultItem = ({ children, onClick, disabled }) => (
+  <div onClick={onClick} disabled={disabled}>
+    {children}
+  </div>
+)
 
 let FilteredSection = observer(
   ({ options, onClick, highlight, Highlight, Item }) => (
@@ -45,7 +48,7 @@ let Section = observer(({ options, onClick, selected, Item }) => (
         >
           {isField(item) ? item.shortLabel || item.label : _.startCase(key)}
         </Item>
-        ),
+      ),
       options
     )}
   </div>
@@ -102,7 +105,7 @@ let NestedPicker = ({
   filter,
   Input = 'input',
   Highlight = TextHighlight,
-  Item = div,
+  Item = DefaultItem,
 }) => (
   <div>
     <Input {...F.domLens.value(filter)} placeholder="Enter filter keyword..." />


### PR DESCRIPTION
The `Section` component had an implicit interface assumption on its
`Item` prop (that it accepts `hasChildren` and `active` props). However,
when `Item` defaults to `div`, React complains about the extraneous
props.