### PR TITLE
Fix `a` tag on Other Matches column to have a blank href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.38.2
+* Fix `a` tag on Other Matches column to have a blank href
+
 # 1.38.1
 * Short other matches text and make it a proper link
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -98,7 +98,7 @@ let HighlightedColumn = withStateLens({ viewModal: false })(
             </Modal>
           )}
           <a
-            href
+            href=""
             onClick={e => {
               e.preventDefault()
               F.on(viewModal)()


### PR DESCRIPTION
Fix `a` tag on Other Matches column to have a blank href