### PR TITLE
Fix React unique key warning in ResultTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.37.3
+* Fix unique key React warning in ResultTable's HighlightedColumn tr
+
 # 1.37.2
 * Fix Date Picker styling in grey vest to match grey vest theme
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.37.2",
+  "version": "1.37.3",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -84,8 +84,8 @@ let HighlightedColumn = withStateLens({ viewModal: false })(
                 <tbody>
                   {_.map(
                     ({ label, value }) => (
-                      <tr>
-                        <td key={label}>{labelForField(schema, label)}</td>
+                      <tr key={label}>
+                        <td>{labelForField(schema, label)}</td>
                         <td dangerouslySetInnerHTML={{ __html: value }} />
                       </tr>
                     ),


### PR DESCRIPTION
The `key` prop was assigned to the wrong component.