### PR TITLE
Add new example type for mongoId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.38.7
+# 1.39.0
 * New example type: mongoId; equivalent to a "text" example type
 
 # 1.38.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.38.7
+* New example type: mongoId; equivalent to a "text" example type
+
 # 1.38.6
 * GreyVest: Fix Refresh icon button pulse speed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.38.6",
+  "version": "1.38.7",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.38.7",
+  "version": "1.39.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/index.js
+++ b/src/exampleTypes/index.js
@@ -81,6 +81,7 @@ export default ({
     tagsText: Components.TagsText,
     geo: Components.Geo,
     text: Components.Text,
+    mongoId: Components.Text,
     exists: Components.Exists,
     bool: Components.Bool,
   }


### PR DESCRIPTION
The implementation is the same as the `text` default type.