### PR TITLE
Preserve state between renders on TagsInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.39.1
+* TagsInput: Preserve state between renders
+
 # 1.39.0
 * New example type: mongoId; equivalent to a "text" example type
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.39.1",
+  "version": "1.39.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.39.1",
+  "version": "1.39.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/layout/TagsInput.js
+++ b/src/layout/TagsInput.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import _ from 'lodash/fp'
 import F from 'futil-js'
+import { withState } from 'recompose'
 import { observable } from 'mobx'
 import { observer, inject } from 'mobx-react'
 import { Flex } from './Flex'
@@ -27,102 +28,108 @@ let Tag = observer(({ value, removeTag, tagStyle, onClick }) => (
 ))
 Tag.displayName = 'Tag'
 
-let tagsInputState = observable({
-  currentInput: '',
-  selectedTag: null,
-  popoverOpen: false,
-})
-
-let TagsInput = observer(
-  ({
-    tags,
-    addTag,
-    removeTag,
-    submit = _.noop,
-    tagStyle,
-    TagComponent = Tag,
-    placeholder = 'Search...',
-    splitCommas,
-    PopoverContents,
-  }) => {
-    let state = tagsInputState
-    if (splitCommas)
-      addTag = _.flow(
-        _.split(','),
-        _.map(addTag)
+// We're only using withState to preserve the state between renders, since
+// inject doesn't do that for us.
+let TagsInput = withState(
+  'state',
+  'setState',
+  observable({
+    currentInput: '',
+    selectedTag: null,
+    popoverOpen: false,
+  })
+)(
+  observer(
+    ({
+      tags,
+      state,
+      addTag,
+      removeTag,
+      submit = _.noop,
+      tagStyle,
+      TagComponent = Tag,
+      placeholder = 'Search...',
+      splitCommas,
+      PopoverContents,
+    }) => {
+      if (splitCommas)
+        addTag = _.flow(
+          _.split(','),
+          _.map(addTag)
+        )
+      return (
+        <div>
+          <label style={{ display: 'block' }} className="tags-input">
+            <Flex
+              style={{
+                cursor: 'text',
+                alignItems: 'center',
+                flexWrap: 'wrap',
+              }}
+            >
+              {_.map(
+                t => (
+                  <TagComponent
+                    key={t}
+                    value={t}
+                    {...{ removeTag, tagStyle }}
+                    onClick={() => {
+                      state.popoverOpen = true
+                      state.selectedTag = t
+                    }}
+                  />
+                ),
+                tags
+              )}
+              <input
+                style={{ border: 'none', outline: 'none', width: 'auto' }}
+                onChange={e => {
+                  state.currentInput = e.target.value
+                }}
+                onBlur={() => {
+                  if (
+                    state.currentInput &&
+                    !_.includes(state.currentInput, tags)
+                  ) {
+                    addTag(state.currentInput)
+                    state.currentInput = ''
+                  }
+                }}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && !state.currentInput) submit()
+                  if (
+                    (e.key === 'Enter' ||
+                      e.key === 'Tab' ||
+                      (splitCommas && e.key === ',')) &&
+                    state.currentInput &&
+                    !_.includes(state.currentInput, tags)
+                  ) {
+                    addTag(state.currentInput)
+                    state.currentInput = ''
+                    e.preventDefault()
+                  }
+                  if (
+                    e.key === 'Backspace' &&
+                    !state.currentInput &&
+                    tags.length
+                  ) {
+                    removeTag(_.last(tags))
+                  }
+                }}
+                value={state.currentInput}
+                placeholder={placeholder}
+              />
+            </Flex>
+          </label>
+          {PopoverContents && (
+            <Popover isOpen={F.lensProp('popoverOpen', state)}>
+              <PopoverContents tag={state.selectedTag} />
+            </Popover>
+          )}
+        </div>
       )
-    return (
-      <div>
-        <label style={{ display: 'block' }} className="tags-input">
-          <Flex
-            style={{
-              cursor: 'text',
-              alignItems: 'center',
-              flexWrap: 'wrap',
-            }}
-          >
-            {_.map(
-              t => (
-                <TagComponent
-                  key={t}
-                  value={t}
-                  {...{ removeTag, tagStyle }}
-                  onClick={() => {
-                    state.popoverOpen = true
-                    state.selectedTag = t
-                  }}
-                />
-              ),
-              tags
-            )}
-            <input
-              style={{ border: 'none', outline: 'none', width: 'auto' }}
-              onChange={e => {
-                state.currentInput = e.target.value
-              }}
-              onBlur={() => {
-                if (
-                  state.currentInput &&
-                  !_.includes(state.currentInput, tags)
-                ) {
-                  addTag(state.currentInput)
-                  state.currentInput = ''
-                }
-              }}
-              onKeyDown={e => {
-                if (e.key === 'Enter' && !state.currentInput) submit()
-                if (
-                  (e.key === 'Enter' ||
-                    e.key === 'Tab' ||
-                    (splitCommas && e.key === ',')) &&
-                  state.currentInput &&
-                  !_.includes(state.currentInput, tags)
-                ) {
-                  addTag(state.currentInput)
-                  state.currentInput = ''
-                  e.preventDefault()
-                }
-                if (
-                  e.key === 'Backspace' &&
-                  !state.currentInput &&
-                  tags.length
-                ) {
-                  removeTag(_.last(tags))
-                }
-              }}
-              value={state.currentInput}
-              placeholder={placeholder}
-            />
-          </Flex>
-        </label>
-        {PopoverContents && (
-          <Popover isOpen={F.lensProp('popoverOpen', state)}>
-            <PopoverContents tag={state.selectedTag} />
-          </Popover>
-        )}
-      </div>
-    )
-  }
+    }
+  )
 )
 TagsInput.displayName = 'TagsInput'
 

--- a/src/layout/TagsInput.js
+++ b/src/layout/TagsInput.js
@@ -33,7 +33,7 @@ Tag.displayName = 'Tag'
 let TagsInput = withState(
   'state',
   'setState',
-  observable({
+  () => observable({
     currentInput: '',
     selectedTag: null,
     popoverOpen: false,

--- a/src/layout/TagsInput.js
+++ b/src/layout/TagsInput.js
@@ -30,10 +30,8 @@ Tag.displayName = 'Tag'
 
 // We're only using withState to preserve the state between renders, since
 // inject doesn't do that for us.
-let TagsInput = withState(
-  'state',
-  'setState',
-  () => observable({
+let TagsInput = withState('state', 'setState', () =>
+  observable({
     currentInput: '',
     selectedTag: null,
     popoverOpen: false,

--- a/src/layout/TagsInput.js
+++ b/src/layout/TagsInput.js
@@ -27,104 +27,102 @@ let Tag = observer(({ value, removeTag, tagStyle, onClick }) => (
 ))
 Tag.displayName = 'Tag'
 
-let TagsInput = inject(() => ({
-  state: observable({
-    currentInput: '',
-    selectedTag: null,
-    popoverOpen: false,
-  }),
-}))(
-  observer(
-    ({
-      tags,
-      state,
-      addTag,
-      removeTag,
-      submit = _.noop,
-      tagStyle,
-      TagComponent = Tag,
-      placeholder = 'Search...',
-      splitCommas,
-      PopoverContents,
-    }) => {
-      if (splitCommas)
-        addTag = _.flow(
-          _.split(','),
-          _.map(addTag)
-        )
-      return (
-        <div>
-          <label style={{ display: 'block' }} className="tags-input">
-            <Flex
-              style={{
-                cursor: 'text',
-                alignItems: 'center',
-                flexWrap: 'wrap',
-              }}
-            >
-              {_.map(
-                t => (
-                  <TagComponent
-                    key={t}
-                    value={t}
-                    {...{ removeTag, tagStyle }}
-                    onClick={() => {
-                      state.popoverOpen = true
-                      state.selectedTag = t
-                    }}
-                  />
-                ),
-                tags
-              )}
-              <input
-                style={{ border: 'none', outline: 'none', width: 'auto' }}
-                onChange={e => {
-                  state.currentInput = e.target.value
-                }}
-                onBlur={() => {
-                  if (
-                    state.currentInput &&
-                    !_.includes(state.currentInput, tags)
-                  ) {
-                    addTag(state.currentInput)
-                    state.currentInput = ''
-                  }
-                }}
-                onKeyDown={e => {
-                  if (e.key === 'Enter' && !state.currentInput) submit()
-                  if (
-                    (e.key === 'Enter' ||
-                      e.key === 'Tab' ||
-                      (splitCommas && e.key === ',')) &&
-                    state.currentInput &&
-                    !_.includes(state.currentInput, tags)
-                  ) {
-                    addTag(state.currentInput)
-                    state.currentInput = ''
-                    e.preventDefault()
-                  }
-                  if (
-                    e.key === 'Backspace' &&
-                    !state.currentInput &&
-                    tags.length
-                  ) {
-                    removeTag(_.last(tags))
-                  }
-                }}
-                value={state.currentInput}
-                placeholder={placeholder}
-              />
-            </Flex>
-          </label>
-          {PopoverContents && (
-            <Popover isOpen={F.lensProp('popoverOpen', state)}>
-              <PopoverContents tag={state.selectedTag} />
-            </Popover>
-          )}
-        </div>
+let tagsInputState = observable({
+  currentInput: '',
+  selectedTag: null,
+  popoverOpen: false,
+})
+
+let TagsInput = observer(
+  ({
+    tags,
+    addTag,
+    removeTag,
+    submit = _.noop,
+    tagStyle,
+    TagComponent = Tag,
+    placeholder = 'Search...',
+    splitCommas,
+    PopoverContents,
+  }) => {
+    let state = tagsInputState
+    if (splitCommas)
+      addTag = _.flow(
+        _.split(','),
+        _.map(addTag)
       )
-    }
-  )
+    return (
+      <div>
+        <label style={{ display: 'block' }} className="tags-input">
+          <Flex
+            style={{
+              cursor: 'text',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+            }}
+          >
+            {_.map(
+              t => (
+                <TagComponent
+                  key={t}
+                  value={t}
+                  {...{ removeTag, tagStyle }}
+                  onClick={() => {
+                    state.popoverOpen = true
+                    state.selectedTag = t
+                  }}
+                />
+              ),
+              tags
+            )}
+            <input
+              style={{ border: 'none', outline: 'none', width: 'auto' }}
+              onChange={e => {
+                state.currentInput = e.target.value
+              }}
+              onBlur={() => {
+                if (
+                  state.currentInput &&
+                  !_.includes(state.currentInput, tags)
+                ) {
+                  addTag(state.currentInput)
+                  state.currentInput = ''
+                }
+              }}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && !state.currentInput) submit()
+                if (
+                  (e.key === 'Enter' ||
+                    e.key === 'Tab' ||
+                    (splitCommas && e.key === ',')) &&
+                  state.currentInput &&
+                  !_.includes(state.currentInput, tags)
+                ) {
+                  addTag(state.currentInput)
+                  state.currentInput = ''
+                  e.preventDefault()
+                }
+                if (
+                  e.key === 'Backspace' &&
+                  !state.currentInput &&
+                  tags.length
+                ) {
+                  removeTag(_.last(tags))
+                }
+              }}
+              value={state.currentInput}
+              placeholder={placeholder}
+            />
+          </Flex>
+        </label>
+        {PopoverContents && (
+          <Popover isOpen={F.lensProp('popoverOpen', state)}>
+            <PopoverContents tag={state.selectedTag} />
+          </Popover>
+        )}
+      </div>
+    )
+  }
 )
 TagsInput.displayName = 'TagsInput'
 


### PR DESCRIPTION
Fixes https://github.com/smartprocure/contexture-react/issues/139

`TagsInput` was wrapped on an `inject` to use state, but `inject`'s purpose is to provide props, so the state got injected anew on every re-render. A more reusable solution is to have somethin g like `withState` for MobX, but this quickfix seems appropriate for now, since we'll probably move to React 16.8 with hooks later on.