### PR TITLE
Set display name for the Text example type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-﻿# 1.41.5
+# 1.41.6
+* Text example type: set display name
+* StripedLoader: do not forward loading prop to child component
+
+# 1.41.5
 * CSS changes in regards to the tags remove size "button".
 
 # 1.41.4

--- a/__tests__/__snapshots__/Snaphot.js.snap
+++ b/__tests__/__snapshots__/Snaphot.js.snap
@@ -339,7 +339,6 @@ exports[`Storyshots Example Types Full Demo 1`] = `
             style={Object {}}
           >
             <input
-              loading={undefined}
               node={
                 Object {
                   "field": "title",
@@ -7049,7 +7048,6 @@ exports[`Storyshots QueryBuilder/Examples Multiple Filters 1`] = `
                                                     style={Object {}}
                                                   >
                                                     <input
-                                                      loading={null}
                                                       node={
                                                         Object {
                                                           "context": null,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.41.5",
+  "version": "1.41.6",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/Text.js
+++ b/src/exampleTypes/Text.js
@@ -7,5 +7,6 @@ let Text = injectTreeNode(
     lens: tree.lens(node.path, prop),
   }))(LensInput)
 )
+Text.displayName = 'Text'
 
 export default Text

--- a/src/utils/injectTreeNode.js
+++ b/src/utils/injectTreeNode.js
@@ -46,6 +46,6 @@ export default (
     return {
       tree,
       node,
-      ...(loadingAware ? {} : { loading: node.updating }),
+      ...(loadingAware ? { loading: node.updating } : {}),
     }
   })(StripedLoader(render, style))


### PR DESCRIPTION
Fixes https://github.com/smartprocure/contexture-react/issues/109