### PR TITLE
Replace link with empty href with link-styled button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.40.0
+* New style "gv-link-button", to use a button in place of an <a> tag with no 
+  href
+
 # 1.39.0
 * New example type: mongoId; equivalent to a "text" example type
 

--- a/__tests__/__snapshots__/Snaphot.js.snap
+++ b/__tests__/__snapshots__/Snaphot.js.snap
@@ -2326,6 +2326,21 @@ exports[`Storyshots Grey Vest Refs 1`] = `
       .gv-button-radio &gt; .gv-button:last-child {
         margin-right: 0;
       }
+      .gv-link-button {
+        /* Same as a contexture-themed link */
+        color: #0076DE;
+        background-color: transparent;
+        border: none;
+        cursor: pointer;
+        text-decoration: underline;
+        display: inline;
+        margin: 0;
+        padding: 0;
+      }
+      .gv-link-button:hover,
+      .gv-link-button:focus {
+        text-decoration: none;
+      }
 
       /* Table */
       .gv-table {
@@ -3003,6 +3018,21 @@ exports[`Storyshots IMDB Check List 1`] = `
       .gv-button-radio &gt; .gv-button:last-child {
         margin-right: 0;
       }
+      .gv-link-button {
+        /* Same as a contexture-themed link */
+        color: #0076DE;
+        background-color: transparent;
+        border: none;
+        cursor: pointer;
+        text-decoration: underline;
+        display: inline;
+        margin: 0;
+        padding: 0;
+      }
+      .gv-link-button:hover,
+      .gv-link-button:focus {
+        text-decoration: none;
+      }
 
       /* Table */
       .gv-table {
@@ -3554,6 +3584,21 @@ exports[`Storyshots IMDB Grey Vest Theme 1`] = `
       }
       .gv-button-radio &gt; .gv-button:last-child {
         margin-right: 0;
+      }
+      .gv-link-button {
+        /* Same as a contexture-themed link */
+        color: #0076DE;
+        background-color: transparent;
+        border: none;
+        cursor: pointer;
+        text-decoration: underline;
+        display: inline;
+        margin: 0;
+        padding: 0;
+      }
+      .gv-link-button:hover,
+      .gv-link-button:focus {
+        text-decoration: none;
       }
 
       /* Table */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.39.3",
+  "version": "1.40.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -97,15 +97,15 @@ let HighlightedColumn = withStateLens({ viewModal: false })(
               </Table>
             </Modal>
           )}
-          <a
-            href=""
+          <button
+            className="gv-link-button"
             onClick={e => {
               e.preventDefault()
               F.on(viewModal)()
             }}
           >
             Matched {_.size(additionalFields)} other field(s)
-          </a>
+          </button>
         </Cell>
       )
   )

--- a/src/themes/greyVest.js
+++ b/src/themes/greyVest.js
@@ -215,6 +215,21 @@ export let GVStyle = () => (
       .gv-button-radio > .gv-button:last-child {
         margin-right: 0;
       }
+      .gv-link-button {
+        /* Same as a contexture-themed link */
+        color: #0076DE;
+        background-color: transparent;
+        border: none;
+        cursor: pointer;
+        text-decoration: underline;
+        display: inline;
+        margin: 0;
+        padding: 0;
+      }
+      .gv-link-button:hover,
+      .gv-link-button:focus {
+        text-decoration: none;
+      }
 
       /* Table */
       .gv-table {


### PR DESCRIPTION
Now we can use `gv-link-button` to replace any `<a>` that has no href with a `<button className="gv-link-button">`