### PR TITLE
Stop propagating clicks when removing a tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-﻿# 1.41.2
+﻿# 1.41.3
+* Hotfix: do not trigger a tag popover when removing a tag in a search input
+
+# 1.41.2
 * Fix an issue sorting nested FieldPicker contents
 
 # 1.41.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.41.2",
+  "version": "1.41.3",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/themes/greyVest.js
+++ b/src/themes/greyVest.js
@@ -862,7 +862,10 @@ let TagComponent = observer(({ value, removeTag, tagStyle, onClick }) => (
     {value}
     <span
       className="tags-input-tag-remove fa fa-times"
-      onClick={() => removeTag(value)}
+      onClick={e => {
+        e.stopPropagation()
+        removeTag(value)
+      }}
     />
   </div>
 ))


### PR DESCRIPTION
When removing a tag, the click was being propagated up the tree to the handler that triggers a tag popover, which fails because the tag was just removed.

I don't know why this problem started happening but the root cause might be that https://github.com/smartprocure/contexture-react/pull/161 actually triggers a rerender whereas before it wasn't being triggered.