### PR TITLE
Hide scrollbars when there's nothing to scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.43.2
+* Hide scrollbars when the content fits
+
 # 1.43.1
 * Date example type: correctly initialize select component.
 

--- a/__tests__/__snapshots__/Snaphot.js.snap
+++ b/__tests__/__snapshots__/Snaphot.js.snap
@@ -2791,7 +2791,7 @@ exports[`Storyshots Grey Vest Refs 1`] = `
         width: auto;
         max-width: 640px;
         border: 30px solid white;
-        overflow-x: scroll;
+        overflow-x: auto;
       }
     
   </style>
@@ -3483,7 +3483,7 @@ exports[`Storyshots IMDB Check List 1`] = `
         width: auto;
         max-width: 640px;
         border: 30px solid white;
-        overflow-x: scroll;
+        overflow-x: auto;
       }
     
   </style>
@@ -4050,7 +4050,7 @@ exports[`Storyshots IMDB Grey Vest Theme 1`] = `
         width: auto;
         max-width: 640px;
         border: 30px solid white;
-        overflow-x: scroll;
+        overflow-x: auto;
       }
     
   </style>
@@ -4610,7 +4610,7 @@ exports[`Storyshots Layout NestedPicker 1`] = `
     style={
       Object {
         "display": "inline-flex",
-        "overflow": "scroll",
+        "overflow": "auto",
         "width": "100%",
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.43.1",
+  "version": "1.43.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/layout/Modal.js
+++ b/src/layout/Modal.js
@@ -15,7 +15,7 @@ let Modal = ({ isOpen, children, style = {} }) => (
           right: 0,
           backgroundColor: 'rgba(0,0,0,0.3)',
           padding: 50,
-          overflowY: 'scroll',
+          overflowY: 'auto',
           zIndex: 1000,
           display: 'flex',
           justifyContent: 'space-around',

--- a/src/layout/NestedPicker.js
+++ b/src/layout/NestedPicker.js
@@ -79,7 +79,7 @@ let PanelTreePicker = inject((store, { onChange, options }) => {
   observer(({ selectAtLevel, state, nestedOptions, Item }) => (
     <div
       className="panel-tree-picker"
-      style={{ display: 'inline-flex', width: '100%', overflow: 'scroll' }}
+      style={{ display: 'inline-flex', width: '100%', overflow: 'auto' }}
     >
       <Section
         options={nestedOptions}

--- a/src/themes/greyVest.js
+++ b/src/themes/greyVest.js
@@ -687,7 +687,7 @@ export let GVStyle = () => (
         width: auto;
         max-width: 640px;
         border: 30px solid white;
-        overflow-x: scroll;
+        overflow-x: auto;
       }
     `}
   </style>


### PR DESCRIPTION
Setting `overflow: scroll` shows a scroll bar in my browser (Chrome 72.0.3626.119) regardless of whether the content needs to be scrolled or not. `overflow: auto` only shows the scrollbar when the content overflows and hides it otherwise.