### PR TITLE
Auto scroll ResultTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.43.7
+* Set overflow: auto on table's horizontal axis
+
 # 1.43.6
 * Geo filter address formatting house # fix.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.43.6",
+  "version": "1.43.7",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.43.7",
+  "version": "1.43.8",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/themes/greyVest.js
+++ b/src/themes/greyVest.js
@@ -692,7 +692,11 @@ export let GVStyle = () => (
     `}
   </style>
 )
-export let Table = x => <table className="gv-table" {...x} />
+export let Table = x => (
+  <div style={{ overflow: 'auto' }}>
+    <table className="gv-table" {...x} />
+  </div>
+)
 
 export let Button = ({
   isActive,


### PR DESCRIPTION
A sensible behavior is to always scroll the table on its horizontal axis
and the correct way of doing this is to set `overflow: [scroll,auto]` on
its parent.