### PR TITLE
Preserve geo location dropdown state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.43.9
+* Preserve geo filter dropdown state across renders
+
 # 1.43.8
 * Set overflow: auto on table's horizontal axis
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-# 1.44.1
-* Preserve geo filter dropdown state across renders
+# 1.45.0
+* Preserve geo filter dropdown state across renders.
+* Do not return `location` from `utils/geo.js:loadHereOptions`
 
 # 1.44.0
 * Number component allows rounding decimal expansions to n digits with `signficantDigits` prop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.44.1",
+  "version": "1.45.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.43.8",
+  "version": "1.43.9",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/Geo.js
+++ b/src/exampleTypes/Geo.js
@@ -63,6 +63,7 @@ let GeoComponent = injectTreeNode(
             <AutoComplete
               cacheOptions
               escapeClearsValue
+              defaultValue={node.selectedOption}
               placeholder={placeholder}
               noOptionsMessage={() => ''}
               styles={customStyles}
@@ -71,10 +72,11 @@ let GeoComponent = injectTreeNode(
                 const inputValue = newValue.replace(/[^a-zA-Z0-9\s]+/g, '')
                 return inputValue
               }}
-              onChange={async ({ value }) => {
-                let data = await GeoCodeLocation(value)
+              onChange={async selectedOption => {
+                let data = await GeoCodeLocation(selectedOption.value)
                 if (data && data.latitude && data.longitude && data.location) {
                   tree.mutate(node.path, {
+                    selectedOption,
                     latitude: data.latitude,
                     longitude: data.longitude,
                     location: data.location,


### PR DESCRIPTION
The `location` field returned from `loadHereOptions` was only being used by the Geo example type to store it in the node. However, it was slightly different from the label of the selected option, which was also a location. This PR changes that so we don't return `location` anymore and instead use the option's label as the `location` value for the node.