### PR TITLE
Fix loading styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.43.10
+* Fix loading styles for all components
+
 # 1.43.9
 * TagsInput: edit tag when backspace is pressed and no input is present.
 

--- a/__tests__/__snapshots__/Snaphot.js.snap
+++ b/__tests__/__snapshots__/Snaphot.js.snap
@@ -1477,9 +1477,7 @@ exports[`Storyshots Example Types Full Demo 1`] = `
                     </th>
                   </tr>
                 </thead>
-                <tbody
-                  style={Object {}}
-                >
+                <tbody>
                   <tr>
                     <td>
                       123
@@ -1928,9 +1926,7 @@ exports[`Storyshots Example Types ResultTable Customizations 1`] = `
           </th>
         </tr>
       </thead>
-      <tbody
-        style={Object {}}
-      >
+      <tbody>
         <tr>
           <td
             style={
@@ -2062,9 +2058,7 @@ exports[`Storyshots Example Types ResultTable Display Field Optional 1`] = `
           </th>
         </tr>
       </thead>
-      <tbody
-        style={Object {}}
-      >
+      <tbody>
         <tr>
           <td
             style={

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.43.9",
+  "version": "1.43.10",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -6,7 +6,6 @@ import InjectTreeNode from '../utils/injectTreeNode'
 import { Popover, Dynamic } from '../layout'
 import { withStateLens } from '../utils/mobx-react-utils'
 import { fieldsToOptions } from '../FilterAdder'
-import { loading } from '../styles/generic'
 import DefaultIcon from '../DefaultIcon'
 import {
   applyDefaults,
@@ -272,7 +271,7 @@ Header.displayName = 'Header'
 // Separate this our so that the table root doesn't create a dependency on results to headers won't need to rerender on data change
 let TableBody = observer(
   ({ node, visibleFields, Modal, Table, Row, schema }) => (
-    <tbody style={node.markedForUpdate || node.updating ? loading : {}}>
+    <tbody>
       {!!getResults(node).length &&
         _.map(
           x => (
@@ -373,8 +372,7 @@ let ResultTable = InjectTreeNode(
         />
       </Table>
     )
-  }),
-  { loadingAware: true }
+  })
 )
 ResultTable.displayName = 'ResultTable'
 

--- a/src/utils/StripedLoader.js
+++ b/src/utils/StripedLoader.js
@@ -3,8 +3,8 @@ import { observer } from 'mobx-react'
 import { loading } from '../styles/generic'
 
 let StripedLoader = (Component, style = {}) =>
-  observer(props => (
-    <div style={{ ...style, ...(props.node && props.node.updating && loading) }}>
+  observer(({ isLoading, ...props }) => (
+    <div style={{ ...style, ...(isLoading && loading) }}>
       <Component {...props} />
     </div>
   ))

--- a/src/utils/StripedLoader.js
+++ b/src/utils/StripedLoader.js
@@ -4,7 +4,7 @@ import { loading } from '../styles/generic'
 
 let StripedLoader = (Component, style = {}) =>
   observer(props => (
-    <div style={{ ...style, ...(props.loading && loading) }}>
+    <div style={{ ...style, ...(props.node && props.node.updating && loading) }}>
       <Component {...props} />
     </div>
   ))

--- a/src/utils/injectTreeNode.js
+++ b/src/utils/injectTreeNode.js
@@ -9,7 +9,6 @@ export default (
     type,
     reactors,
     nodeProps = _.keys(reactors),
-    loadingAware = false,
     allowEmptyNode = false,
     style,
   } = {}
@@ -45,9 +44,5 @@ export default (
     } else if (!node && !allowEmptyNode)
       throw Error(`Node not provided, and couldn't find node at ${path}`)
 
-    return {
-      tree,
-      node,
-      ...(loadingAware ? { loading: node && node.updating } : {}),
-    }
+    return { tree, node }
   })(StripedLoader(render, style))

--- a/src/utils/injectTreeNode.js
+++ b/src/utils/injectTreeNode.js
@@ -44,5 +44,5 @@ export default (
     } else if (!node && !allowEmptyNode)
       throw Error(`Node not provided, and couldn't find node at ${path}`)
 
-    return { tree, node }
+    return { tree, node, isLoading: node && node.updating }
   })(StripedLoader(render, style))


### PR DESCRIPTION
Fix regression introduced in
https://github.com/smartprocure/contexture-react/pull/162 where loading
styles for anything using `injectTreeNode` were not being applied.

Also, remove the `loadingAware` option of `injectTreeNode`, which was
only being used by `ResultTable` in order to apply its own styling on
loading to the table body.