### PR TITLE
Feature/204 - round findBestRange results in Number component if significantDigits is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.45.1
+# round findBestRange result if significantDigits is set in Number component
+
 # 1.45.0
 * Preserve geo filter dropdown state across renders.
 * Do not return `location` from `utils/geo.js:loadHereOptions`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.45.1
 # round findBestRange result if significantDigits is set in Number component
+# Number component supports setting significantDigits: 0
 
 # 1.45.0
 * Preserve geo filter dropdown state across renders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.45.1
-# round findBestRange result if significantDigits is set in Number component
-# Number component supports setting significantDigits: 0
+* Round findBestRange result if significantDigits is set in Number component
+* Number component supports setting significantDigits: 0
 
 # 1.45.0
 * Preserve geo filter dropdown state across renders.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.44.0",
+  "version": "1.45.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5409,7 +5409,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.45.0",
+  "version": "1.45.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/Number.js
+++ b/src/exampleTypes/Number.js
@@ -48,7 +48,10 @@ let NumberComponent = injectTreeNode(
               onClick={async () => {
                 // Calculate best range
                 await tree.mutate(node.path, { findBestRange: true })
-                let { min, max } = _.pick(['min', 'max'], _.get('context.bestRange', node))
+                let { min, max } = _.pick(
+                  ['min', 'max'],
+                  _.get('context.bestRange', node)
+                )
                 if (_.isNumber(significantDigits)) {
                   min = round(min, significantDigits)
                   max = round(max, significantDigits)

--- a/src/exampleTypes/Number.js
+++ b/src/exampleTypes/Number.js
@@ -48,10 +48,7 @@ let NumberComponent = injectTreeNode(
               onClick={async () => {
                 // Calculate best range
                 await tree.mutate(node.path, { findBestRange: true })
-                let { min, max } = _.pick(
-                  ['min', 'max'],
-                  _.get('context.bestRange', node)
-                )
+                let { min, max } = _.get('context.bestRange', node)
                 if (_.isNumber(significantDigits)) {
                   min = round(min, significantDigits)
                   max = round(max, significantDigits)

--- a/src/exampleTypes/Number.js
+++ b/src/exampleTypes/Number.js
@@ -23,7 +23,7 @@ let NumberComponent = injectTreeNode(
             value={formatter(node.min) || ''}
             onChange={e =>
               tree.mutate(node.path, {
-                min: significantDigits
+                min: _.isNumber(significantDigits)
                   ? round(e.target.value, significantDigits)
                   : e.target.value,
               })
@@ -34,7 +34,7 @@ let NumberComponent = injectTreeNode(
             value={formatter(node.max) || ''}
             onChange={e =>
               tree.mutate(node.path, {
-                max: significantDigits
+                max: _.isNumber(significantDigits)
                   ? round(e.target.value, significantDigits)
                   : e.target.value,
               })
@@ -48,11 +48,16 @@ let NumberComponent = injectTreeNode(
               onClick={async () => {
                 // Calculate best range
                 await tree.mutate(node.path, { findBestRange: true })
+                let { min, max } = _.pick(['min', 'max'], _.get('context.bestRange', node))
+                if (_.isNumber(significantDigits)) {
+                  min = round(min, significantDigits)
+                  max = round(max, significantDigits)
+                }
                 // Disable best range so the calculation isn't run anymore
                 tree.mutate(node.path, {
                   findBestRange: false,
-                  min: _.get('context.bestRange.min', node),
-                  max: _.get('context.bestRange.max', node),
+                  min,
+                  max,
                 })
               }}
             >


### PR DESCRIPTION
Fixes #204 

### Description
* see title
* I wasn't able to actually test the rounding because I couldn't find a field in the IMDB data for which the find best range button did anything -- I assume that's the data and not the find best range stuff, which is working fine on bid search
* Bonus Fix: now allows setting `significantDigits: 0` for integer rounding