### PR TITLE
Handle better null with the DateInput component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.48.3
+* Handle null better in the DateInput component
+
 # 1.48.2
 * Handle null children in SearchFilters and TreePauseButton
 * Fix ResultsTable inline filtering without Provider

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.48.2",
+  "version": "1.48.3",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/themes/greyVest/DateInput.js
+++ b/src/themes/greyVest/DateInput.js
@@ -9,7 +9,7 @@ let DateInput = observer(
       calendarType={'US'}
       calendarIcon={calendarIcon}
       clearIcon={clearIcon}
-      value={_.isDate(value) ? value : new Date(value)}
+      value={_.isDate(value) || _.isEmpty(value) ? value : new Date(value)}
       {...props}
     />
   )


### PR DESCRIPTION
Fixes the issue where if the value is `null` in the DateInput component it would display a date in the past etc.