### PR TITLE
TermStatsTable dropdown tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 1.48.6
+# 1.48.8
+* TermsStatsTable: Add margin to size dropdown to align with table
+* TermsStatsTable: Default to 20 items
+
+# 1.48.7
 * StripedLoader: Fix regression in 1.48.7
 
 # 1.48.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # 1.48.8
 * TermsStatsTable: Add margin to size dropdown to align with table
-* TermsStatsTable: Default to 20 items
 
 # 1.48.7
 * StripedLoader: Fix regression in 1.48.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * TagsInput: Better validation on the input
 
 # 1.48.7
-* StripedLoader: Fix regression in 1.48.7
+* StripedLoader: Fix regression in 1.48.6
 
 # 1.48.6
 * StripedLoader: Fix loading styles

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.48.7",
+  "version": "1.48.8",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.48.8",
+  "version": "1.48.9",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/TermsStatsTable.js
+++ b/src/exampleTypes/TermsStatsTable.js
@@ -19,14 +19,14 @@ let SimpleFilter = observer(({ Input = 'input', ...props }) => (
   </Flex>
 ))
 let SelectSize = observer(
-  ({ node, tree, options = [10, 20, 50, 100, 500, 1000] }) => (
+  ({ node, tree, options = [10, 25, 50, 100, 500, 1000] }) => (
     <Flex style={toolBarStyle}>
       <SimpleLabel text="Size:" />
       <Select
         onChange={e => {
           tree.mutate(node.path, { size: e.target.value })
         }}
-        value={_.getOr(20, 'size', node)}
+        value={_.getOr(25, 'size', node)}
         placeholder={null}
         style={{ width: '100px' }}
         options={_.map(x => ({ value: x, label: x }), options)}

--- a/src/exampleTypes/TermsStatsTable.js
+++ b/src/exampleTypes/TermsStatsTable.js
@@ -19,14 +19,14 @@ let SimpleFilter = observer(({ Input = 'input', ...props }) => (
   </Flex>
 ))
 let SelectSize = observer(
-  ({ node, tree, options = [10, 25, 50, 100, 500, 1000] }) => (
+  ({ node, tree, options = [10, 20, 50, 100, 500, 1000] }) => (
     <Flex style={toolBarStyle}>
       <SimpleLabel text="Size:" />
       <Select
         onChange={e => {
           tree.mutate(node.path, { size: e.target.value })
         }}
-        value={_.getOr(25, 'size', node)}
+        value={_.getOr(20, 'size', node)}
         placeholder={null}
         style={{ width: '100px' }}
         options={_.map(x => ({ value: x, label: x }), options)}
@@ -52,7 +52,7 @@ let TermsStatsTable = injectTreeNode(
       ...props
     }) => (
       <div>
-        <Flex style={toolBarStyle}>
+        <Flex style={{ ...toolBarStyle, margin: 40, marginBottom: 0 }}>
           <Filter
             Input={Input}
             {...F.domLens.value(tree.lens(node.path, 'filter'))}


### PR DESCRIPTION
Fixes https://github.com/smartprocure/bid-search/issues/2099

Changed the dropdown default size to 20. The real fix is more
complicated since we've got to share state between the table and the
dropdown but playbooks will get refactored anyway.