### PR TITLE
Fix error when adding a new field in QueryBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.49.3
+* Fix error when adding a new field in QueryBuilder
+
 # 1.49.2
 * Shrink font sizes to match design
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.49.1",
+  "version": "1.49.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.49.2",
+  "version": "1.49.3",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/queryBuilder/FilterContents.js
+++ b/src/queryBuilder/FilterContents.js
@@ -32,7 +32,7 @@ let FilterContents = inject(_.defaults)(
       // `get` allows us to create a dependency on field before we know it exists (because the client will only add it if it's a type that uses it as it wouldn't make sense for something like `results`)
       let nodeField = get(node, 'field')
       let typeOptions = _.get([nodeField, 'typeOptions'], fields) || []
-      if (!_.includes(node.type, typeOptions))
+      if (node.type && !_.includes(node.type, typeOptions))
         typeOptions = [...typeOptions, node.type]
       let nodeLabel = _.get([nodeField, 'label'], fields) || nodeField
       return (


### PR DESCRIPTION
Error was caused by `FilterContents` pushing a `node.type` value of `null` (from a newly added filter) into an array that is then passed to `F.autoLabelOptions`, which can't handle the `null` and throws.

The futil method should still be fixed, but this change alone is enough to stop the issue.