### PR TITLE
Rename `tree` props in QueryBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.49.6
+* Rename all instances of `tree` to `node` in QueryBuilder props
+
 # 1.49.5
 * Simplify QueryBuilder and contexture-mobx with the latest contexture-client
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.49.5",
+  "version": "1.49.6",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/queryBuilder/DragDrop/IndentTarget.js
+++ b/src/queryBuilder/DragDrop/IndentTarget.js
@@ -9,9 +9,9 @@ let FilterIndentSpec = {
     let source = monitor.getItem()
     let isSelf = props.child === source.node
     if (isSelf) {
-      props.root.remove(props.tree, props.child)
+      props.root.remove(props.node, props.child)
     } else {
-      let newGroup = props.root.indent(props.tree, props.child, true)
+      let newGroup = props.root.indent(props.node, props.child, true)
       props.root.move(source.tree, source.node, newGroup, 1)
     }
   },
@@ -19,7 +19,7 @@ let FilterIndentSpec = {
 export let FilterIndentTarget = FilterDropTarget(FilterIndentSpec)(
   ({
     child,
-    tree,
+    node,
     // root,
     connectDropTarget,
     // isOver,
@@ -37,7 +37,7 @@ export let FilterIndentTarget = FilterDropTarget(FilterIndentSpec)(
               position: 'fixed',
               ...(dragItem.node === child
                 ? styles.bgStriped
-                : styles.bgPreview(oppositeJoin(tree.join))),
+                : styles.bgPreview(oppositeJoin(node.join))),
               zIndex: 100,
             }}
           />

--- a/src/queryBuilder/DragDrop/MoveTargets.js
+++ b/src/queryBuilder/DragDrop/MoveTargets.js
@@ -6,17 +6,17 @@ import styles from '../../styles'
 let FilterMoveSpec = {
   drop(props, monitor) {
     let { tree, node } = monitor.getItem()
-    props.root.move(tree, node, props.tree, props.index)
+    props.root.move(tree, node, props.node, props.index)
   },
 }
 let FilterMoveDropTarget = style =>
   FilterDropTarget(FilterMoveSpec)(
-    ({ tree, connectDropTarget, isOver, canDrop }) =>
+    ({ node, connectDropTarget, isOver, canDrop }) =>
       connectDropTarget(
         canDrop ? (
           <div
             style={{
-              ...styles.bgPreview(tree),
+              ...styles.bgPreview(node),
               ...style({ isOver }),
             }}
           />

--- a/src/queryBuilder/Group.js
+++ b/src/queryBuilder/Group.js
@@ -15,7 +15,7 @@ let { background } = styles
 let GroupItem = FilterDragSource(args => {
   let {
     child,
-    tree,
+    tree: node,
     index,
     state,
     root,
@@ -28,17 +28,17 @@ let GroupItem = FilterDragSource(args => {
     <div
       style={{
         ...styles.dFlex,
-        ...(index === tree.children.length - 1 &&
+        ...(index === node.children.length - 1 &&
           !root.adding && { background }),
       }}
     >
-      {!(isRoot && tree.children.length === 1) && (
+      {!(isRoot && node.children.length === 1) && (
         <Operator
-          {...{ tree, child, root, parentTree, index, parent: state }}
+          {...{ node, child, root, parentTree, index, parent: state }}
         />
       )}
       {child.children ? (
-        <Group tree={child} root={root} parentTree={tree} />
+        <Group tree={child} root={root} parentTree={node} />
       ) : (
         <Rule {...{ ...args, node: child }} />
       )}

--- a/src/queryBuilder/Group.js
+++ b/src/queryBuilder/Group.js
@@ -20,7 +20,7 @@ let GroupItem = FilterDragSource(args => {
     state,
     root,
     isRoot,
-    parentNode,
+    parent,
     connectDragSource,
     //connectDragPreview, isDragging
   } = args
@@ -34,11 +34,11 @@ let GroupItem = FilterDragSource(args => {
     >
       {!(isRoot && node.children.length === 1) && (
         <Operator
-          {...{ node, child, root, parentNode, index, parent: state }}
+          {...{ node, child, root, parent, index, parentState: state }}
         />
       )}
       {child.children ? (
-        <Group node={child} root={root} parentNode={node} />
+        <Group node={child} root={root} parent={node} />
       ) : (
         <Rule {...{ ...args, parent: node, node: child }} />
       )}

--- a/src/queryBuilder/Group.js
+++ b/src/queryBuilder/Group.js
@@ -15,7 +15,7 @@ let { background } = styles
 let GroupItem = FilterDragSource(args => {
   let {
     child,
-    tree: node,
+    node,
     index,
     state,
     root,
@@ -38,9 +38,9 @@ let GroupItem = FilterDragSource(args => {
         />
       )}
       {child.children ? (
-        <Group tree={child} root={root} parentTree={node} />
+        <Group node={child} root={root} parentTree={node} />
       ) : (
-        <Rule {...{ ...args, node: child }} />
+        <Rule {...{ ...args, parent: node, node: child }} />
       )}
     </div>
   )
@@ -55,14 +55,14 @@ let Group = Component(
     }),
   }),
   args => {
-    let { tree, root, state, isRoot } = args
+    let { node, root, state, isRoot } = args
     return (
-      <Indentable tree={tree} indent={state.lens.wrapHover}>
+      <Indentable tree={node} indent={state.lens.wrapHover}>
         <div
           style={{
             ...styles.conditions,
             ...(!isRoot && styles.w100),
-            ...styles.bdJoin(tree),
+            ...styles.bdJoin(node),
             ...(state.removeHover && {
               ...styles.bgStriped,
               borderColor: background,
@@ -86,15 +86,15 @@ let Group = Component(
                   )}
                 </div>
               ),
-              _.toArray(tree.children)
+              _.toArray(node.children)
             )}
             {/*<FilterMoveTarget index={tree.children.length} tree={tree} /> */}
             {root.adding && (
               <AddPreview
                 onClick={() => {
-                  root.add(tree)
+                  root.add(node)
                 }}
-                join={tree.join}
+                join={node.join}
                 style={{
                   marginLeft: 0,
                   borderTopLeftRadius: 5,

--- a/src/queryBuilder/Group.js
+++ b/src/queryBuilder/Group.js
@@ -57,7 +57,7 @@ let Group = Component(
   args => {
     let { node, root, state, isRoot } = args
     return (
-      <Indentable tree={node} indent={state.lens.wrapHover}>
+      <Indentable node={node} indent={state.lens.wrapHover}>
         <div
           style={{
             ...styles.conditions,

--- a/src/queryBuilder/Group.js
+++ b/src/queryBuilder/Group.js
@@ -20,7 +20,7 @@ let GroupItem = FilterDragSource(args => {
     state,
     root,
     isRoot,
-    parentTree,
+    parentNode,
     connectDragSource,
     //connectDragPreview, isDragging
   } = args
@@ -34,11 +34,11 @@ let GroupItem = FilterDragSource(args => {
     >
       {!(isRoot && node.children.length === 1) && (
         <Operator
-          {...{ node, child, root, parentTree, index, parent: state }}
+          {...{ node, child, root, parentNode, index, parent: state }}
         />
       )}
       {child.children ? (
-        <Group node={child} root={root} parentTree={node} />
+        <Group node={child} root={root} parentNode={node} />
       ) : (
         <Rule {...{ ...args, parent: node, node: child }} />
       )}

--- a/src/queryBuilder/Operator.js
+++ b/src/queryBuilder/Operator.js
@@ -46,7 +46,10 @@ let JoinOperator = ({ state, parentState, node, child }) => (
   <div>
     <div
       onClick={F.flip(state.lens.isOpen)}
-      style={{ ...styles.operator, ...styles.bgJoin(parentState.joinHover || node) }}
+      style={{
+        ...styles.operator,
+        ...styles.bgJoin(parentState.joinHover || node),
+      }}
     >
       <span
         style={{

--- a/src/queryBuilder/Operator.js
+++ b/src/queryBuilder/Operator.js
@@ -42,21 +42,21 @@ let OperatorLine = Component(({ node, child, style }) => (
 ))
 OperatorLine.displayName = 'OperatorLine'
 
-let JoinOperator = ({ state, node, child, parent }) => (
+let JoinOperator = ({ state, parentState, node, child }) => (
   <div>
     <div
       onClick={F.flip(state.lens.isOpen)}
-      style={{ ...styles.operator, ...styles.bgJoin(parent.joinHover || node) }}
+      style={{ ...styles.operator, ...styles.bgJoin(parentState.joinHover || node) }}
     >
       <span
         style={{
-          ...(parent.joinHover && {
+          ...(parentState.joinHover && {
             fontStyle: 'italic',
             opacity: 0.5,
           }),
         }}
       >
-        {parent.joinHover || node.join}
+        {parentState.joinHover || node.join}
       </span>
     </div>
     <OperatorLine {...{ node, child }} />
@@ -70,12 +70,12 @@ let Operator = Component(
       isOpen: false,
     }),
   }),
-  ({ state, node, child, parent, root, parentNode, index }) => (
+  ({ state, parentState, node, child, parent, root, index }) => (
     <div>
       {!(index !== 0 || node.join === 'not') ? (
         <BlankOperator {...{ state, node, child }} />
       ) : (
-        <JoinOperator {...{ state, node, child, parent }} />
+        <JoinOperator {...{ state, node, child, parentState }} />
       )}
       <OperatorMoveTarget {...{ node, root, index }} />
       <Popover
@@ -83,10 +83,10 @@ let Operator = Component(
         style={{
           ...styles.operatorPopover,
           ...styles.bdJoin(node),
-          ...(parent.wrapHover && { marginLeft: 0 }),
+          ...(parentState.wrapHover && { marginLeft: 0 }),
         }}
       >
-        <OperatorMenu {...{ node, parent, root, parentNode }} />
+        <OperatorMenu {...{ node, parentState, root, parent }} />
       </Popover>
     </div>
   ),

--- a/src/queryBuilder/Operator.js
+++ b/src/queryBuilder/Operator.js
@@ -70,7 +70,7 @@ let Operator = Component(
       isOpen: false,
     }),
   }),
-  ({ state, node, child, parent, root, parentTree, index }) => (
+  ({ state, node, child, parent, root, parentNode, index }) => (
     <div>
       {!(index !== 0 || node.join === 'not') ? (
         <BlankOperator {...{ state, node, child }} />
@@ -86,7 +86,7 @@ let Operator = Component(
           ...(parent.wrapHover && { marginLeft: 0 }),
         }}
       >
-        <OperatorMenu {...{ node, parent, root, parentTree }} />
+        <OperatorMenu {...{ node, parent, root, parentNode }} />
       </Popover>
     </div>
   ),

--- a/src/queryBuilder/Operator.js
+++ b/src/queryBuilder/Operator.js
@@ -6,13 +6,13 @@ import Popover from '../layout/Popover'
 import OperatorMenu from './OperatorMenu'
 import { OperatorMoveTarget } from './DragDrop/MoveTargets'
 
-let BlankOperator = ({ state, tree, child }) => (
+let BlankOperator = ({ state, node, child }) => (
   <div>
     <div
       onClick={F.flip(state.lens.isOpen)}
       style={{
         ...styles.blankOperator,
-        borderBottomColor: styles.joinColor(tree.join),
+        borderBottomColor: styles.joinColor(node.join),
       }}
     />
     {child.children && child.join !== 'not' && (
@@ -20,7 +20,7 @@ let BlankOperator = ({ state, tree, child }) => (
         style={{
           ...styles.operatorLine,
           ...styles.blankOperatorLineExtended,
-          ...styles.bgJoin(tree),
+          ...styles.bgJoin(node),
         }}
       />
     )}
@@ -28,25 +28,25 @@ let BlankOperator = ({ state, tree, child }) => (
 )
 BlankOperator.displayName = 'BlankOperator'
 
-let OperatorLine = Component(({ tree, child, style }) => (
+let OperatorLine = Component(({ node, child, style }) => (
   <div
     style={{
       ...styles.operatorLine,
       ...(child.children &&
         child.join !== 'not' &&
         styles.operatorLineExtended),
-      ...styles.bgJoin(tree),
+      ...styles.bgJoin(node),
       ...style,
     }}
   />
 ))
 OperatorLine.displayName = 'OperatorLine'
 
-let JoinOperator = ({ state, tree, child, parent }) => (
+let JoinOperator = ({ state, node, child, parent }) => (
   <div>
     <div
       onClick={F.flip(state.lens.isOpen)}
-      style={{ ...styles.operator, ...styles.bgJoin(parent.joinHover || tree) }}
+      style={{ ...styles.operator, ...styles.bgJoin(parent.joinHover || node) }}
     >
       <span
         style={{
@@ -56,10 +56,10 @@ let JoinOperator = ({ state, tree, child, parent }) => (
           }),
         }}
       >
-        {parent.joinHover || tree.join}
+        {parent.joinHover || node.join}
       </span>
     </div>
-    <OperatorLine {...{ tree, child }} />
+    <OperatorLine {...{ node, child }} />
   </div>
 )
 JoinOperator.displayName = 'JoinOperator'
@@ -70,23 +70,23 @@ let Operator = Component(
       isOpen: false,
     }),
   }),
-  ({ state, tree, child, parent, root, parentTree, index }) => (
+  ({ state, node, child, parent, root, parentTree, index }) => (
     <div>
-      {!(index !== 0 || tree.join === 'not') ? (
-        <BlankOperator {...{ state, tree, child }} />
+      {!(index !== 0 || node.join === 'not') ? (
+        <BlankOperator {...{ state, node, child }} />
       ) : (
-        <JoinOperator {...{ state, tree, child, parent }} />
+        <JoinOperator {...{ state, node, child, parent }} />
       )}
-      <OperatorMoveTarget {...{ tree, root, index }} />
+      <OperatorMoveTarget {...{ node, root, index }} />
       <Popover
         isOpen={state.lens.isOpen}
         style={{
           ...styles.operatorPopover,
-          ...styles.bdJoin(tree),
+          ...styles.bdJoin(node),
           ...(parent.wrapHover && { marginLeft: 0 }),
         }}
       >
-        <OperatorMenu {...{ tree, parent, root, parentTree }} />
+        <OperatorMenu {...{ node, parent, root, parentTree }} />
       </Popover>
     </div>
   ),

--- a/src/queryBuilder/OperatorMenu.js
+++ b/src/queryBuilder/OperatorMenu.js
@@ -6,16 +6,16 @@ import styles from '../styles'
 import { oppositeJoin } from '../utils/search'
 let { btn, joinColor, bgJoin } = styles
 
-let OperatorMenu = ({ tree, parent, root, parentTree }) => (
+let OperatorMenu = ({ node, parent, root, parentNode }) => (
   <div>
     {_.map(
       join =>
-        tree.join !== join && (
+        node.join !== join && (
           <div
             key={join}
             {...F.domLens.hover(x => (parent.joinHover = x && join))}
             style={{ ...btn, ...bgJoin(join) }}
-            onClick={() => root.join(tree, join)}
+            onClick={() => root.join(node, join)}
           >
             To {join.toUpperCase()}
           </div>
@@ -26,23 +26,23 @@ let OperatorMenu = ({ tree, parent, root, parentTree }) => (
       <div
         style={{
           ...btn,
-          color: joinColor(oppositeJoin((parentTree || tree).join)),
+          color: joinColor(oppositeJoin((parentNode || node).join)),
           marginTop: 5,
         }}
         {...F.domLens.hover(parent.lens.wrapHover)}
         onClick={() => {
-          root.indent(parentTree, tree)
+          root.indent(parentNode, node)
           F.off(parent.lens.wrapHover)()
         }}
       >
-        Wrap in {oppositeJoin((parentTree || tree).join).toUpperCase()}
+        Wrap in {oppositeJoin((parentNode || node).join).toUpperCase()}
       </div>
     </div>
     <div>
       <div
         {...F.domLens.hover(parent.lens.removeHover)}
         style={{ ...btn, marginTop: 5 }}
-        onClick={() => root.remove(parentTree, tree)}
+        onClick={() => root.remove(parentNode, node)}
       >
         Remove
       </div>

--- a/src/queryBuilder/OperatorMenu.js
+++ b/src/queryBuilder/OperatorMenu.js
@@ -6,14 +6,14 @@ import styles from '../styles'
 import { oppositeJoin } from '../utils/search'
 let { btn, joinColor, bgJoin } = styles
 
-let OperatorMenu = ({ node, parent, root, parentNode }) => (
+let OperatorMenu = ({ node, parentState, root, parent }) => (
   <div>
     {_.map(
       join =>
         node.join !== join && (
           <div
             key={join}
-            {...F.domLens.hover(x => (parent.joinHover = x && join))}
+            {...F.domLens.hover(x => (parentState.joinHover = x && join))}
             style={{ ...btn, ...bgJoin(join) }}
             onClick={() => root.join(node, join)}
           >
@@ -26,23 +26,23 @@ let OperatorMenu = ({ node, parent, root, parentNode }) => (
       <div
         style={{
           ...btn,
-          color: joinColor(oppositeJoin((parentNode || node).join)),
+          color: joinColor(oppositeJoin((parent || node).join)),
           marginTop: 5,
         }}
-        {...F.domLens.hover(parent.lens.wrapHover)}
+        {...F.domLens.hover(parentState.lens.wrapHover)}
         onClick={() => {
-          root.indent(parentNode, node)
-          F.off(parent.lens.wrapHover)()
+          root.indent(parent, node)
+          F.off(parentState.lens.wrapHover)()
         }}
       >
-        Wrap in {oppositeJoin((parentNode || node).join).toUpperCase()}
+        Wrap in {oppositeJoin((parent || node).join).toUpperCase()}
       </div>
     </div>
     <div>
       <div
-        {...F.domLens.hover(parent.lens.removeHover)}
+        {...F.domLens.hover(parentState.lens.removeHover)}
         style={{ ...btn, marginTop: 5 }}
-        onClick={() => root.remove(parentNode, node)}
+        onClick={() => root.remove(parent, node)}
       >
         Remove
       </div>

--- a/src/queryBuilder/QueryBuilder.js
+++ b/src/queryBuilder/QueryBuilder.js
@@ -91,7 +91,7 @@ export default DDContext(
       >
         <div style={{ background }}>
           {state.getNode(path) && (
-            <Group tree={state.getNode(path)} root={state} isRoot={true} />
+            <Group node={state.getNode(path)} root={state} isRoot={true} />
           )}
           <Button
             onClick={() => {

--- a/src/queryBuilder/Rule.js
+++ b/src/queryBuilder/Rule.js
@@ -7,7 +7,7 @@ import FilterContents from './FilterContents'
 import FilterDragSource from './DragDrop/FilterDragSource'
 import { oppositeJoin } from '../utils/search'
 
-let Rule = ({ state, node, tree: parent, root, connectDragSource, isDragging }) =>
+let Rule = ({ state, node, parent, root, connectDragSource, isDragging }) =>
   connectDragSource(
     <div style={styles.w100}>
       <Indentable tree={parent} indent={state.lens.indentHover}>

--- a/src/queryBuilder/Rule.js
+++ b/src/queryBuilder/Rule.js
@@ -10,7 +10,7 @@ import { oppositeJoin } from '../utils/search'
 let Rule = ({ state, node, parent, root, connectDragSource, isDragging }) =>
   connectDragSource(
     <div style={styles.w100}>
-      <Indentable tree={parent} indent={state.lens.indentHover}>
+      <Indentable node={parent} indent={state.lens.indentHover}>
         <div
           style={{
             ...styles.condition,

--- a/src/queryBuilder/Rule.js
+++ b/src/queryBuilder/Rule.js
@@ -7,14 +7,14 @@ import FilterContents from './FilterContents'
 import FilterDragSource from './DragDrop/FilterDragSource'
 import { oppositeJoin } from '../utils/search'
 
-let Rule = ({ state, node, tree, root, connectDragSource, isDragging }) =>
+let Rule = ({ state, node, tree: parent, root, connectDragSource, isDragging }) =>
   connectDragSource(
     <div style={styles.w100}>
-      <Indentable tree={tree} indent={state.lens.indentHover}>
+      <Indentable tree={parent} indent={state.lens.indentHover}>
         <div
           style={{
             ...styles.condition,
-            ...styles.bdJoin(tree),
+            ...styles.bdJoin(parent),
             ...(state.removeHover && {
               borderStyle: 'dashed',
               opacity: 0.25,
@@ -35,11 +35,11 @@ let Rule = ({ state, node, tree, root, connectDragSource, isDragging }) =>
             <button
               {...F.domLens.hover(state.lens.indentHover)}
               style={{
-                color: styles.joinColor(oppositeJoin(tree.join)),
+                color: styles.joinColor(oppositeJoin(parent.join)),
                 ...styles.btn,
                 ...styles.roundedRight0,
               }}
-              onClick={() => root.indent(tree, node)}
+              onClick={() => root.indent(parent, node)}
             >
               >
             </button>
@@ -50,7 +50,7 @@ let Rule = ({ state, node, tree, root, connectDragSource, isDragging }) =>
                 ...styles.roundedLeft0,
                 marginLeft: '-1px',
               }}
-              onClick={() => root.remove(tree, node)}
+              onClick={() => root.remove(parent, node)}
             >
               X
             </button>

--- a/src/queryBuilder/preview/Indentable.js
+++ b/src/queryBuilder/preview/Indentable.js
@@ -5,19 +5,19 @@ import styles from '../../styles'
 import { oppositeJoin } from '../../utils/search'
 import AddPreview from './AddPreview'
 
-let Indentable = ({ children, indent, tree }) => (
+let Indentable = ({ children, indent, node }) => (
   <div style={{ ...styles.dFlex, ...styles.w100 }}>
     {F.view(indent) && (
       <div
         style={{
           ...styles.indent,
-          ...styles.bgPreview(oppositeJoin(tree.join)),
+          ...styles.bgPreview(oppositeJoin(node.join)),
         }}
       />
     )}
     <div style={styles.w100}>
       {children}
-      {F.view(indent) && <AddPreview join={oppositeJoin(tree.join)} />}
+      {F.view(indent) && <AddPreview join={oppositeJoin(node.join)} />}
     </div>
   </div>
 )

--- a/stories/queryBuilder/internals/group.js
+++ b/stories/queryBuilder/internals/group.js
@@ -7,7 +7,7 @@ export default (parent, root, DnDDecorator) =>
     .addDecorator(DnDDecorator)
     .addWithJSX('One Filter', () => (
       <Group
-        tree={{
+        node={{
           key: 'root',
           join: 'and',
           children: [{ key: 'filter 1', type: 'query' }],
@@ -18,7 +18,7 @@ export default (parent, root, DnDDecorator) =>
     ))
     .addWithJSX('Multiple Filters', () => (
       <Group
-        tree={{
+        node={{
           key: 'root',
           join: 'and',
           children: [

--- a/stories/queryBuilder/internals/indentable.js
+++ b/stories/queryBuilder/internals/indentable.js
@@ -8,17 +8,17 @@ export default () =>
     module
   )
     .addWithJSX('and', () => (
-      <Indentable indent={() => true} tree={{ join: 'and' }}>
+      <Indentable indent={() => true} node={{ join: 'and' }}>
         <div style={{ height: '100px' }}>Contents</div>
       </Indentable>
     ))
     .addWithJSX('or', () => (
-      <Indentable indent={() => true} tree={{ join: 'or' }}>
+      <Indentable indent={() => true} node={{ join: 'or' }}>
         <div style={{ height: '100px' }}>Contents</div>
       </Indentable>
     ))
     .addWithJSX('not', () => (
-      <Indentable indent={() => true} tree={{ join: 'not' }}>
+      <Indentable indent={() => true} node={{ join: 'not' }}>
         <div style={{ height: '100px' }}>Contents</div>
       </Indentable>
     ))

--- a/stories/queryBuilder/internals/operator.js
+++ b/stories/queryBuilder/internals/operator.js
@@ -5,7 +5,7 @@ import Operator from '../../../src/queryBuilder/Operator'
 let operatorStory = (join, index, root) => () => (
   <Operator
     {...{
-      tree: { join },
+      node: { join },
       child: {
         join: 'and',
       },

--- a/stories/queryBuilder/internals/operatorMenu.js
+++ b/stories/queryBuilder/internals/operatorMenu.js
@@ -7,5 +7,5 @@ export default (parent, root) =>
     'Search Components (Unthemed)|QueryBuilder/Internals/OperatorMenu',
     module
   ).addWithJSX('OperatorMenu', () => (
-    <OperatorMenu {...{ tree: { join: 'and' }, parent, root }} />
+    <OperatorMenu {...{ node: { join: 'and' }, parent, root }} />
   ))


### PR DESCRIPTION
Renames all `tree` props (which are actually nodes) in QueryBuilder to `node`. 

This is a prerequisite to mopping up the rest of ContextureClientBridge, which creates a wrapper around the contexture tree and passes it to these components as `root`. After that's gone, we'll be passing a new `tree` prop with a reference to the contexture tree instead.