### PR TITLE
Fix Select placeholder rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.49.5
+* Fix Select placeholder rendering
+
 # 1.49.4
 * Add minWidth to TagsInput
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.49.4",
+  "version": "1.49.5",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/layout/Select.js
+++ b/src/layout/Select.js
@@ -7,8 +7,7 @@ let Select = React.forwardRef(
     <Observer>
       {() => (
         <select {...props} ref={ref}>
-          (() => if (placeholder) <option value="">{placeholder}</option>
-          )()
+          {placeholder && <option value="">{placeholder}</option>}
           {_.map(
             x => (
               <option key={x.value} value={x.value}>


### PR DESCRIPTION
The conditional rendering was wrong, so an empty option would always
render even when placeholder was explictly being set to null