### PR TITLE
Remove ContextureClientBridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.49.8
+* QueryBuilder: Remove ContextureClientBridge
+
 # 1.49.7
 * Rename all instances of `tree` to `node` in QueryBuilder props
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.49.7",
+  "version": "1.49.8",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/queryBuilder/DragDrop/IndentTarget.js
+++ b/src/queryBuilder/DragDrop/IndentTarget.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import FilterDropTarget from './FilterDropTarget'
 import styles from '../../styles'
-import { oppositeJoin } from '../../utils/search'
-import { indent } from '../../utils/tree'
+import { oppositeJoin, indent } from '../../utils/search'
 
 // Indent
 let FilterIndentSpec = {

--- a/src/queryBuilder/DragDrop/IndentTarget.js
+++ b/src/queryBuilder/DragDrop/IndentTarget.js
@@ -2,6 +2,7 @@ import React from 'react'
 import FilterDropTarget from './FilterDropTarget'
 import styles from '../../styles'
 import { oppositeJoin } from '../../utils/search'
+import { indent } from '../../utils/tree'
 
 // Indent
 let FilterIndentSpec = {
@@ -9,10 +10,13 @@ let FilterIndentSpec = {
     let source = monitor.getItem()
     let isSelf = props.child === source.node
     if (isSelf) {
-      props.root.remove(props.node, props.child)
+      props.tree.remove(props.child)
     } else {
-      let newGroup = props.root.indent(props.node, props.child, true)
-      props.root.move(source.tree, source.node, newGroup, 1)
+      let newGroup = indent(props.tree, props.node, props.child, true)
+      props.tree.move(source.node.path, {
+        path: newGroup.path,
+        index: 1,
+      })
     }
   },
 }
@@ -20,7 +24,6 @@ export let FilterIndentTarget = FilterDropTarget(FilterIndentSpec)(
   ({
     child,
     node,
-    // root,
     connectDropTarget,
     // isOver,
     canDrop,

--- a/src/queryBuilder/DragDrop/MoveTargets.js
+++ b/src/queryBuilder/DragDrop/MoveTargets.js
@@ -5,8 +5,11 @@ import styles from '../../styles'
 // Move
 let FilterMoveSpec = {
   drop(props, monitor) {
-    let { tree, node } = monitor.getItem()
-    props.root.move(tree, node, props.node, props.index)
+    let { node } = monitor.getItem()
+    props.tree.move(node.path, {
+      path: props.node.path,
+      index: props.index,
+    })
   },
 }
 let FilterMoveDropTarget = style =>

--- a/src/queryBuilder/FilterContents.js
+++ b/src/queryBuilder/FilterContents.js
@@ -6,6 +6,7 @@ import { ModalPicker, Modal, NestedPicker, Dynamic, Grid } from '../layout/'
 import { fieldsToOptions } from '../FilterAdder'
 import { defaultProps } from 'recompose'
 import { get } from '../utils/mobx-utils'
+import { newNodeFromType } from '../utils/tree'
 
 let FieldPicker = defaultProps({
   Modal,
@@ -22,7 +23,7 @@ let FilterContents = inject(_.defaults)(
   observer(
     ({
       node,
-      root,
+      tree,
       fields,
       types = {},
       ContextureButton = 'button',
@@ -42,13 +43,16 @@ let FilterContents = inject(_.defaults)(
             label={nodeField ? nodeLabel : 'Pick a Field'}
             options={fieldsToOptions(fields)}
             // TODO: consider type options in case this isn't safe, e.g. a field/type change action
-            onChange={field => root.mutate(node.path, { field })}
+            onChange={field => tree.mutate(node.path, { field })}
           />
           {nodeField && (
             <div style={{ margin: '0 5px' }}>
               <select
-                onChange={({ target: { value } }) => {
-                  root.typeChange(node, value)
+                onChange={({ target: { value: type } }) => {
+                  tree.replace(
+                    node.path,
+                    newNodeFromType(type, fields, node)
+                  )
                 }}
                 value={F.when(_.isNil, undefined)(node.type)} // fix null value issue...
               >
@@ -81,7 +85,7 @@ let FilterContents = inject(_.defaults)(
             >
               <Dynamic
                 component={types[node.type] || MissingTypeComponent}
-                tree={root}
+                tree={tree}
                 node={node}
                 {...mapNodeToProps(node, fields, types)}
               />

--- a/src/queryBuilder/FilterContents.js
+++ b/src/queryBuilder/FilterContents.js
@@ -6,7 +6,7 @@ import { ModalPicker, Modal, NestedPicker, Dynamic, Grid } from '../layout/'
 import { fieldsToOptions } from '../FilterAdder'
 import { defaultProps } from 'recompose'
 import { get } from '../utils/mobx-utils'
-import { newNodeFromType } from '../utils/tree'
+import { newNodeFromType } from '../utils/search'
 
 let FieldPicker = defaultProps({
   Modal,

--- a/src/queryBuilder/FilterContents.js
+++ b/src/queryBuilder/FilterContents.js
@@ -49,10 +49,7 @@ let FilterContents = inject(_.defaults)(
             <div style={{ margin: '0 5px' }}>
               <select
                 onChange={({ target: { value: type } }) => {
-                  tree.replace(
-                    node.path,
-                    newNodeFromType(type, fields, node)
-                  )
+                  tree.replace(node.path, newNodeFromType(type, fields, node))
                 }}
                 value={F.when(_.isNil, undefined)(node.type)} // fix null value issue...
               >

--- a/src/queryBuilder/Group.js
+++ b/src/queryBuilder/Group.js
@@ -11,7 +11,7 @@ import FilterDragSource from './DragDrop/FilterDragSource'
 import { FilterIndentTarget } from './DragDrop/IndentTarget'
 import { FilterMoveTarget } from './DragDrop/MoveTargets'
 let { background } = styles
-import { blankNode } from '../utils/tree'
+import { blankNode } from '../utils/search'
 
 let GroupItem = FilterDragSource(args => {
   let {
@@ -33,6 +33,7 @@ let GroupItem = FilterDragSource(args => {
           !tree.adding && { background }),
       }}
     >
+      { `${node.type} ${child && child.type}` }
       {!(isRoot && node.children.length === 1) && (
         <Operator
           {...{ node, child, tree, parent, index, parentState: state }}

--- a/src/queryBuilder/Group.js
+++ b/src/queryBuilder/Group.js
@@ -33,7 +33,7 @@ let GroupItem = FilterDragSource(args => {
           !tree.adding && { background }),
       }}
     >
-      { `${node.type} ${child && child.type}` }
+      {`${node.type} ${child && child.type}`}
       {!(isRoot && node.children.length === 1) && (
         <Operator
           {...{ node, child, tree, parent, index, parentState: state }}

--- a/src/queryBuilder/Group.js
+++ b/src/queryBuilder/Group.js
@@ -11,6 +11,7 @@ import FilterDragSource from './DragDrop/FilterDragSource'
 import { FilterIndentTarget } from './DragDrop/IndentTarget'
 import { FilterMoveTarget } from './DragDrop/MoveTargets'
 let { background } = styles
+import { blankNode } from '../utils/tree'
 
 let GroupItem = FilterDragSource(args => {
   let {
@@ -18,7 +19,7 @@ let GroupItem = FilterDragSource(args => {
     node,
     index,
     state,
-    root,
+    tree,
     isRoot,
     parent,
     connectDragSource,
@@ -29,16 +30,16 @@ let GroupItem = FilterDragSource(args => {
       style={{
         ...styles.dFlex,
         ...(index === node.children.length - 1 &&
-          !root.adding && { background }),
+          !tree.adding && { background }),
       }}
     >
       {!(isRoot && node.children.length === 1) && (
         <Operator
-          {...{ node, child, root, parent, index, parentState: state }}
+          {...{ node, child, tree, parent, index, parentState: state }}
         />
       )}
       {child.children ? (
-        <Group node={child} root={root} parent={node} />
+        <Group node={child} tree={tree} parent={node} />
       ) : (
         <Rule {...{ ...args, parent: node, node: child }} />
       )}
@@ -55,7 +56,7 @@ let Group = Component(
     }),
   }),
   args => {
-    let { node, root, state, isRoot } = args
+    let { node, tree, state, isRoot } = args
     return (
       <Indentable node={node} indent={state.lens.wrapHover}>
         <div
@@ -89,10 +90,10 @@ let Group = Component(
               _.toArray(node.children)
             )}
             {/*<FilterMoveTarget index={tree.children.length} tree={tree} /> */}
-            {root.adding && (
+            {tree.adding && (
               <AddPreview
                 onClick={() => {
-                  root.add(node)
+                  tree.add(node.path, blankNode())
                 }}
                 join={node.join}
                 style={{

--- a/src/queryBuilder/Operator.js
+++ b/src/queryBuilder/Operator.js
@@ -73,14 +73,14 @@ let Operator = Component(
       isOpen: false,
     }),
   }),
-  ({ state, parentState, node, child, parent, root, index }) => (
+  ({ state, parentState, node, child, parent, tree, index }) => (
     <div>
       {!(index !== 0 || node.join === 'not') ? (
         <BlankOperator {...{ state, node, child }} />
       ) : (
         <JoinOperator {...{ state, node, child, parentState }} />
       )}
-      <OperatorMoveTarget {...{ node, root, index }} />
+      <OperatorMoveTarget {...{ node, tree, index }} />
       <Popover
         isOpen={state.lens.isOpen}
         style={{
@@ -89,7 +89,7 @@ let Operator = Component(
           ...(parentState.wrapHover && { marginLeft: 0 }),
         }}
       >
-        <OperatorMenu {...{ node, parentState, root, parent }} />
+        <OperatorMenu {...{ node, parentState, tree, parent }} />
       </Popover>
     </div>
   ),

--- a/src/queryBuilder/OperatorMenu.js
+++ b/src/queryBuilder/OperatorMenu.js
@@ -3,10 +3,8 @@ import _ from 'lodash/fp'
 import F from 'futil-js'
 import { Component } from '../utils/mobx-react-utils'
 import styles from '../styles'
-import { oppositeJoin } from '../utils/search'
+import { oppositeJoin, indent } from '../utils/search'
 let { btn, joinColor, bgJoin } = styles
-
-import { indent } from '../utils/tree'
 
 let OperatorMenu = ({ node, parentState, tree, parent }) => (
   <div>

--- a/src/queryBuilder/OperatorMenu.js
+++ b/src/queryBuilder/OperatorMenu.js
@@ -6,7 +6,9 @@ import styles from '../styles'
 import { oppositeJoin } from '../utils/search'
 let { btn, joinColor, bgJoin } = styles
 
-let OperatorMenu = ({ node, parentState, root, parent }) => (
+import { indent } from '../utils/tree'
+
+let OperatorMenu = ({ node, parentState, tree, parent }) => (
   <div>
     {_.map(
       join =>
@@ -15,7 +17,7 @@ let OperatorMenu = ({ node, parentState, root, parent }) => (
             key={join}
             {...F.domLens.hover(x => (parentState.joinHover = x && join))}
             style={{ ...btn, ...bgJoin(join) }}
-            onClick={() => root.join(node, join)}
+            onClick={() => tree.mutate(node.path, { join })}
           >
             To {join.toUpperCase()}
           </div>
@@ -31,7 +33,7 @@ let OperatorMenu = ({ node, parentState, root, parent }) => (
         }}
         {...F.domLens.hover(parentState.lens.wrapHover)}
         onClick={() => {
-          root.indent(parent, node)
+          indent(tree, parent, node)
           F.off(parentState.lens.wrapHover)()
         }}
       >
@@ -42,7 +44,7 @@ let OperatorMenu = ({ node, parentState, root, parent }) => (
       <div
         {...F.domLens.hover(parentState.lens.removeHover)}
         style={{ ...btn, marginTop: 5 }}
-        onClick={() => root.remove(parent, node)}
+        onClick={() => tree.remove(node.path)}
       >
         Remove
       </div>

--- a/src/queryBuilder/QueryBuilder.js
+++ b/src/queryBuilder/QueryBuilder.js
@@ -21,7 +21,7 @@ export default DDContext(
       types,
       state: observable({
         adding: false,
-        ...tree
+        ...tree,
       }),
     }),
     ({

--- a/src/queryBuilder/Rule.js
+++ b/src/queryBuilder/Rule.js
@@ -5,8 +5,7 @@ import styles from '../styles'
 import Indentable from './preview/Indentable'
 import FilterContents from './FilterContents'
 import FilterDragSource from './DragDrop/FilterDragSource'
-import { oppositeJoin } from '../utils/search'
-import { indent } from '../utils/tree'
+import { oppositeJoin, indent } from '../utils/search'
 
 let Rule = ({ state, node, parent, tree, connectDragSource, isDragging }) =>
   connectDragSource(

--- a/src/queryBuilder/Rule.js
+++ b/src/queryBuilder/Rule.js
@@ -6,8 +6,9 @@ import Indentable from './preview/Indentable'
 import FilterContents from './FilterContents'
 import FilterDragSource from './DragDrop/FilterDragSource'
 import { oppositeJoin } from '../utils/search'
+import { indent } from '../utils/tree'
 
-let Rule = ({ state, node, parent, root, connectDragSource, isDragging }) =>
+let Rule = ({ state, node, parent, tree, connectDragSource, isDragging }) =>
   connectDragSource(
     <div style={styles.w100}>
       <Indentable node={parent} indent={state.lens.indentHover}>
@@ -25,7 +26,7 @@ let Rule = ({ state, node, parent, root, connectDragSource, isDragging }) =>
           }}
           {...F.domLens.hover(state.lens.ruleHover)}
         >
-          <FilterContents {...{ node, root }} />
+          <FilterContents {...{ node, tree }} />
           <div
             style={{
               ...(state.ruleHover || { visibility: 'hidden' }),
@@ -39,7 +40,7 @@ let Rule = ({ state, node, parent, root, connectDragSource, isDragging }) =>
                 ...styles.btn,
                 ...styles.roundedRight0,
               }}
-              onClick={() => root.indent(parent, node)}
+              onClick={() => indent(tree, parent, node)}
             >
               >
             </button>
@@ -50,7 +51,7 @@ let Rule = ({ state, node, parent, root, connectDragSource, isDragging }) =>
                 ...styles.roundedLeft0,
                 marginLeft: '-1px',
               }}
-              onClick={() => root.remove(parent, node)}
+              onClick={() => tree.remove(node.path)}
             >
               X
             </button>

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -1,1 +1,32 @@
+import _ from 'lodash/fp'
+import { DefaultNodeProps as defaultNodeProps } from './schema'
+
 export let oppositeJoin = join => (join === 'and' ? 'or' : 'and')
+
+export let randomString = () =>
+  Math.random()
+    .toString(36)
+    .substring(7)
+
+export let blankNode = () => ({ key: randomString() })
+
+export let newNodeFromType = _.curry((type, fields, node) => ({
+  type,
+  ..._.pick(['key', 'field'], node),
+  ...defaultNodeProps(node.field, fields, type),
+}))
+
+export let indent = (Tree, parent, node, skipDefaultNode) => {
+  // Reactors:
+  //   OR -> And, nothing
+  //   AND -> OR, others if has value
+  //   to/from NOT, others if has value
+  let key = randomString()
+  Tree.wrapInGroup(_.toArray(node.path), {
+    key,
+    join: oppositeJoin((parent || node).join),
+  })
+  if (!skipDefaultNode)
+    Tree.add(parent ? [...parent.path, key] : [key], blankNode())
+  return Tree.getNode([...parent.path, key])
+}

--- a/src/utils/tree.js
+++ b/src/utils/tree.js
@@ -17,13 +17,11 @@ export let blankNode = () => ({ key: randomString() })
 // would also work as a "node transformer", etc -> node -> newNode,
 // for use in a hypothetical `transformReplace` contexture action:
 // (transform, node) -> replace(node.path, transform(node))
-export let newNodeFromType = _.curry(
-  (type, fields, node) => ({
-    type,
-    ..._.pick(['key', 'field'], node),
-    ...defaultNodeProps(node.field, fields, type),
-  })
-)
+export let newNodeFromType = _.curry((type, fields, node) => ({
+  type,
+  ..._.pick(['key', 'field'], node),
+  ...defaultNodeProps(node.field, fields, type),
+}))
 
 export let indent = (Tree, parent, node, skipDefaultNode) => {
   // Reactors:

--- a/src/utils/tree.js
+++ b/src/utils/tree.js
@@ -1,6 +1,41 @@
 import _ from 'lodash/fp'
 import * as F from 'futil-js'
+import { DefaultNodeProps as defaultNodeProps } from './schema'
+import { oppositeJoin } from './search'
 
 export let traverse = x => x && x.children && _.toArray(x.children) // mobx needs slice
 export let keyPath = key => (_.isString(key) ? { key } : key)
 export default F.tree(traverse, keyPath)
+
+export let randomString = () =>
+  Math.random()
+    .toString(36)
+    .substring(7)
+
+export let blankNode = () => ({ key: randomString() })
+
+// would also work as a "node transformer", etc -> node -> newNode,
+// for use in a hypothetical `transformReplace` contexture action:
+// (transform, node) -> replace(node.path, transform(node))
+export let newNodeFromType = _.curry(
+  (type, fields, node) => ({
+    type,
+    ..._.pick(['key', 'field'], node),
+    ...defaultNodeProps(node.field, fields, type),
+  })
+)
+
+export let indent = (Tree, parent, node, skipDefaultNode) => {
+  // Reactors:
+  //   OR -> And, nothing
+  //   AND -> OR, others if has value
+  //   to/from NOT, others if has value
+  let key = randomString()
+  Tree.wrapInGroup(_.toArray(node.path), {
+    key,
+    join: oppositeJoin((parent || node).join),
+  })
+  if (!skipDefaultNode)
+    Tree.add(parent ? [...parent.path, key] : [key], blankNode())
+  return Tree.getNode([...parent.path, key])
+}

--- a/src/utils/tree.js
+++ b/src/utils/tree.js
@@ -1,39 +1,6 @@
 import _ from 'lodash/fp'
 import * as F from 'futil-js'
-import { DefaultNodeProps as defaultNodeProps } from './schema'
-import { oppositeJoin } from './search'
 
 export let traverse = x => x && x.children && _.toArray(x.children) // mobx needs slice
 export let keyPath = key => (_.isString(key) ? { key } : key)
 export default F.tree(traverse, keyPath)
-
-export let randomString = () =>
-  Math.random()
-    .toString(36)
-    .substring(7)
-
-export let blankNode = () => ({ key: randomString() })
-
-// would also work as a "node transformer", etc -> node -> newNode,
-// for use in a hypothetical `transformReplace` contexture action:
-// (transform, node) -> replace(node.path, transform(node))
-export let newNodeFromType = _.curry((type, fields, node) => ({
-  type,
-  ..._.pick(['key', 'field'], node),
-  ...defaultNodeProps(node.field, fields, type),
-}))
-
-export let indent = (Tree, parent, node, skipDefaultNode) => {
-  // Reactors:
-  //   OR -> And, nothing
-  //   AND -> OR, others if has value
-  //   to/from NOT, others if has value
-  let key = randomString()
-  Tree.wrapInGroup(_.toArray(node.path), {
-    key,
-    join: oppositeJoin((parent || node).join),
-  })
-  if (!skipDefaultNode)
-    Tree.add(parent ? [...parent.path, key] : [key], blankNode())
-  return Tree.getNode([...parent.path, key])
-}


### PR DESCRIPTION
- Replace all `root` props in query builder components with `tree` props containing a reference to the contexture tree
- Replace all calls to `root` methods in query builder components with the corresponding contexture-client actions
- Move/add utility methods to `src/utils/tree.js` -- everything ContextureClientBridge did that was more than simple syrup over a contexture tree action is now here. It's not ideal and I think most of it can/should still be refactored (particularly `indent`), but this PR is already pretty big, so I decided to leave it for now.

One benefit of all this is the ability to add functionality to FilterList (basic search) that was previously restricted to QueryBuilder, because it relied on methods in ContextureClientBridge instead of in contexture-client itself. Changing a node's type (via [the new `replace` action](https://github.com/smartprocure/contexture-client/pull/99)) is one example, but anything that can be done in QueryBuilder is now possible to implement in FilterList too. 🙂