### PR TITLE
Add `childSpacing` prop to Flex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.53.0
+* Add `childSpacing` prop to Flex
+
 # 1.52.0
 * Add CheckButton component
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.52.0",
+  "version": "1.53.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/layout/Flex.js
+++ b/src/layout/Flex.js
@@ -1,4 +1,8 @@
 import React from 'react'
+import F from 'futil-js'
+import _ from 'lodash/fp'
+
+let defaultPx = prop => (_.isNumber(prop) ? `${prop}px` : prop)
 
 export let Flex = ({
   as: Component = 'div',
@@ -6,8 +10,10 @@ export let Flex = ({
   alignItems,
   alignContent,
   justifyContent,
+  childSpacing,
   wrap = false,
   column = false,
+  children,
   ...props
 }) => (
   <Component
@@ -21,5 +27,12 @@ export let Flex = ({
       ...style,
     }}
     {...props}
-  />
+  >
+    {childSpacing
+      ? F.intersperse(
+          () => <div style={{ flex: `0 1 ${defaultPx(childSpacing)}` }} />,
+          children
+        )
+      : children}
+  </Component>
 )

--- a/stories/layout.stories.js
+++ b/stories/layout.stories.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import F from 'futil-js'
+import _ from 'lodash/fp'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { observer } from 'mobx-react'
@@ -65,6 +66,19 @@ let FlexDemo = ({ style, ...props }) => (
   </Flex>
 )
 
+let FlexChildSpacingDemo = ({ childSpacing }) => (
+  <Flex style={{ margin: 10 }} childSpacing={childSpacing}>
+    {_.times(
+      i => (
+        <div style={{ backgroundColor: '#F0F', padding: 10, flex: 1 }}>
+          Item{i + 1}
+        </div>
+      ),
+      6
+    )}
+  </Flex>
+)
+
 storiesOf('Components (Unthemed)|Layout', module)
   .addWithJSX('Popover', () => <PopoverDemo />)
   .addWithJSX('Modal', () => <ModalDemo />)
@@ -78,6 +92,13 @@ storiesOf('Components (Unthemed)|Layout', module)
       <Flex column alignItems="center">
         <h1>No children</h1>
         <Flex />
+      </Flex>
+      <Flex column alignItems="stretch">
+        <h1 style={{ alignSelf: 'center' }}>
+          With <code>childSpacing</code> prop
+        </h1>
+        <FlexChildSpacingDemo childSpacing={20} />
+        <FlexChildSpacingDemo childSpacing="20%" />
       </Flex>
     </>
   ))


### PR DESCRIPTION
Expands the `Flex` component API to include a `childSpacing` prop. When set, this intersperses spacer elements between `Flex`'s children:
```jsx
<div style={{ flex: `0 1 ${childSpacing}` }} />
```

This creates a div that is by default (and at most) the width of `childSpacing`, but is able to shrink if the other elements require more space.

⚠️ I know this somewhat violates our current convention for Flex (including only props that directly translate to flexbox styles), **but**:
1. in practice, we usually do want to have some space between flex children
2. intuitively, "space between items" should be a property of the presentational element containing the items, rather than a property of the individual items that can't account for being first or last in the list (which is why I think it makes sense to include it here, in spite of the convention)
3. as far as I'm aware, this is literally the least-bad way to add spacing between dynamically generated flex children

(An alternate not-that-bad strategy would be to use a CSS-in-JS framework that supports pseudoselectors and set:
```es
'> *': {
  margin: childSpacing,
  '&:first-child': {
    margin-left: `-${childSpacing}`,
  },
  '&:last-child': {
    margin-right: `-${childSpacing}`,
  },
}
```

...but this way is simpler, works just as well (if not better), and is already doable with our current tools.)