### PR TITLE
Adding one line support for the TagsInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.53.0
+* Add one line support for the TagsInput component
+
 # 1.52.0
 * Add CheckButton component
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.52.0",
+  "version": "1.53.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {
@@ -108,7 +108,7 @@
     "react-date-picker": "^7.2.0",
     "react-dnd": "^2.5.4",
     "react-dnd-html5-backend": "^2.5.4",
-    "react-outside-click-handler": "^1.2.2",
+    "react-outside-click-handler": "^1.2.3",
     "recompose": "^0.30.0"
   }
 }

--- a/src/layout/TagsInput.js
+++ b/src/layout/TagsInput.js
@@ -109,10 +109,10 @@ let TagsInput = withState('state', 'setState', () =>
             }}
           >
             <Flex
+              wrap
+              alignItems="center"
               style={{
                 cursor: 'text',
-                alignItems: 'center',
-                flexWrap: 'wrap',
                 height: '100%',
                 padding: 2,
               }}

--- a/src/layout/TagsInput.js
+++ b/src/layout/TagsInput.js
@@ -6,6 +6,7 @@ import { observable } from 'mobx'
 import { observer, inject } from 'mobx-react'
 import { Flex } from './Flex'
 import Popover from './Popover'
+import OutsideClickHandler from 'react-outside-click-handler';
 
 let isValidTag = (tag, tags) => {
   let cleanTag = _.trim(tag)
@@ -63,6 +64,7 @@ let TagsInput = withState('state', 'setState', () =>
     currentInput: '',
     selectedTag: null,
     popoverOpen: false,
+    isOneLine: true,
   })
 )(
   observer(
@@ -79,20 +81,35 @@ let TagsInput = withState('state', 'setState', () =>
       PopoverContents,
       style,
     }) => {
+      let containerRef
+      let inputRef
       if (splitCommas)
         addTag = _.flow(
           _.split(','),
           _.map(addTag)
         )
       return (
-        <div className="tags-input" style={{ ...style }}>
+        <OutsideClickHandler onOutsideClick={() => {
+          state.isOneLine = true
+          containerRef.scrollTop = 0
+        }}>
+        <div className={`tags-input ${state.isOneLine ? 'tags-input-one-line' : ''}`}
+          ref={e => (containerRef = e ? e : containerRef)}
+          style={{ ...style }}
+          onClick={() => {
+            if(state.isOneLine) {
+              state.isOneLine = false
+              inputRef.focus()
+            }
+          }}
+        >
           <Flex
             style={{
               cursor: 'text',
               alignItems: 'center',
               flexWrap: 'wrap',
               height: '100%',
-              padding: 3,
+              padding: 2,
             }}
           >
             {_.map(
@@ -117,6 +134,7 @@ let TagsInput = withState('state', 'setState', () =>
                 margin: 3,
                 minWidth: 120,
               }}
+              ref={e => (inputRef = e)}
               onChange={e => {
                 state.currentInput = e.target.value
               }}
@@ -160,6 +178,7 @@ let TagsInput = withState('state', 'setState', () =>
             </Popover>
           )}
         </div>
+        </OutsideClickHandler>
       )
     }
   )

--- a/src/themes/greyVest/index.js
+++ b/src/themes/greyVest/index.js
@@ -258,6 +258,10 @@ export let GVStyle = () => (
 
 
       /* Tags Input */
+      .tags-input-one-line {
+        max-height: 40px;
+        overflow-y: auto;
+      }
       .gv-body .tags-input > * {
         box-sizing: border-box;
       }

--- a/src/themes/greyVest/index.js
+++ b/src/themes/greyVest/index.js
@@ -262,6 +262,20 @@ export let GVStyle = () => (
         max-height: 40px;
         overflow-y: auto;
       }
+      .tags-input-one-line::-webkit-scrollbar {
+        -webkit-appearance: none;
+      }
+      .tags-input-one-line::-webkit-scrollbar-thumb {
+        border-radius: 8px;
+        border: 2.5px solid #f1f1f1; /* should match background, can't be transparent */
+        background-color: #c2c2c2;
+      }
+      .tags-input-one-line::-webkit-scrollbar-track {
+        background-color: #f1f1f1;
+        border-radius: 5px;
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+      }
       .gv-body .tags-input > * {
         box-sizing: border-box;
       }


### PR DESCRIPTION
As per https://github.com/smartprocure/bid-search/issues/2801 this makes the TagsInput always be one line unless clicked on. Then it retains its full height instead of being limited via `max-height`.

Also changed the `padding` to `2` since it hides better the color lines of the tags.

End result:

![image](https://user-images.githubusercontent.com/910303/61104131-f571c880-a429-11e9-85fb-6836b06d6c22.png)

When clicked:

![image](https://user-images.githubusercontent.com/910303/61104155-0de1e300-a42a-11e9-8966-7198d4dcb9d1.png)

Also focused the input on the container click so that user `does not` have to click 2 times (as it is the case currently) to enter tags.