### PR TITLE
Feature/pass through pops tags query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.54.1
+* Allow to pass-through props from TagsQuery to the actual input in TagsInput
+
 # 1.54.0
 * Add one line support for the TagsInput component
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.54.0",
+  "version": "1.54.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/TagsQuery.js
+++ b/src/exampleTypes/TagsQuery.js
@@ -124,7 +124,7 @@ let TagsQuery = ({
       submit={tree.triggerUpdate}
       placeholder={placeholder}
       PopoverContents={TagQueryPopever}
-      {...props }
+      {...props}
     />
   )
 }

--- a/src/exampleTypes/TagsQuery.js
+++ b/src/exampleTypes/TagsQuery.js
@@ -21,6 +21,7 @@ let TagsQuery = ({
   Select = DefaultSelect,
   Button = 'button',
   placeholder,
+  ...props
 }) => {
   let getTag = tag => _.find({ [tagValueField]: tag }, node.tags)
   let TagQueryPopever = observer(({ tag }) => {
@@ -123,6 +124,7 @@ let TagsQuery = ({
       submit={tree.triggerUpdate}
       placeholder={placeholder}
       PopoverContents={TagQueryPopever}
+      {...props }
     />
   )
 }

--- a/src/layout/TagsInput.js
+++ b/src/layout/TagsInput.js
@@ -80,6 +80,7 @@ let TagsInput = withState('state', 'setState', () =>
       splitCommas,
       PopoverContents,
       style,
+      ...props
     }) => {
       let containerRef
       let inputRef
@@ -175,6 +176,7 @@ let TagsInput = withState('state', 'setState', () =>
                 }}
                 value={state.currentInput}
                 placeholder={placeholder}
+                {...props}
               />
             </Flex>
             {PopoverContents && (

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -258,7 +258,7 @@ export default () => (
           </ToggleFiltersHeader>
           <div className="gv-search-bar">
             <Box>
-              <TagsQuery tree={tree} path={['root', 'bar']} autoFocus/>
+              <TagsQuery tree={tree} path={['root', 'bar']} autoFocus />
             </Box>
             <div className="gv-button-group">
               <Button

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -258,7 +258,7 @@ export default () => (
           </ToggleFiltersHeader>
           <div className="gv-search-bar">
             <Box>
-              <TagsQuery tree={tree} path={['root', 'bar']} />
+              <TagsQuery tree={tree} path={['root', 'bar']} autoFocus/>
             </Box>
             <div className="gv-button-group">
               <Button


### PR DESCRIPTION
Related to https://github.com/smartprocure/bid-search/issues/2722

Allow to pass-through props from TagsQuery to the actual input of TagsInput. This would be useful to actually make the Search box focused by default by simply passing through the autoFocus prop.