### PR TITLE
Picker props for GreyVest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.54.1
+* GreyVest: Standardize FieldPicker modal across FilterList & QueryBuilder
+
 # 1.54.0
 * Add one line support for the TagsInput component
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.54.0",
+  "version": "1.54.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.54.1",
+  "version": "1.54.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/queryBuilder/FilterContents.js
+++ b/src/queryBuilder/FilterContents.js
@@ -2,17 +2,11 @@ import * as F from 'futil-js'
 import _ from 'lodash/fp'
 import React from 'react'
 import { inject, observer } from 'mobx-react'
-import { ModalPicker, Modal, NestedPicker, Dynamic, Grid } from '../layout/'
+import { ModalPicker, Modal as DefaultModal, NestedPicker, Dynamic, Grid } from '../layout/'
 import { fieldsToOptions } from '../FilterAdder'
 import DefaultMissingTypeComponent from '../DefaultMissingTypeComponent'
-import { defaultProps } from 'recompose'
 import { get } from '../utils/mobx-utils'
 import { newNodeFromType, changeNodeField } from '../utils/search'
-
-let FieldPicker = defaultProps({
-  Modal,
-  Picker: NestedPicker,
-})(ModalPicker)
 
 let FilterContents = inject(_.defaults)(
   observer(
@@ -21,7 +15,9 @@ let FilterContents = inject(_.defaults)(
       tree,
       fields,
       types = {},
-      ContextureButton = 'button',
+      Button = 'button',
+      Modal = DefaultModal,
+      Picker = NestedPicker,
       mapNodeToProps = _.noop,
       MissingTypeComponent = DefaultMissingTypeComponent,
     }) => {
@@ -33,8 +29,8 @@ let FilterContents = inject(_.defaults)(
       let nodeLabel = _.get([nodeField, 'label'], fields) || nodeField
       return (
         <Grid columns="auto auto 1fr" style={{ width: '100%' }}>
-          <FieldPicker
-            Button={ContextureButton}
+          <ModalPicker
+            {...{ Modal, Picker, Button }}
             label={nodeField ? nodeLabel : 'Pick a Field'}
             options={fieldsToOptions(fields)}
             // TODO: consider type options in case this isn't safe, e.g. a field/type change action

--- a/src/queryBuilder/FilterContents.js
+++ b/src/queryBuilder/FilterContents.js
@@ -2,7 +2,13 @@ import * as F from 'futil-js'
 import _ from 'lodash/fp'
 import React from 'react'
 import { inject, observer } from 'mobx-react'
-import { ModalPicker, Modal as DefaultModal, NestedPicker, Dynamic, Grid } from '../layout/'
+import {
+  ModalPicker,
+  Modal as DefaultModal,
+  NestedPicker,
+  Dynamic,
+  Grid,
+} from '../layout/'
 import { fieldsToOptions } from '../FilterAdder'
 import DefaultMissingTypeComponent from '../DefaultMissingTypeComponent'
 import { get } from '../utils/mobx-utils'

--- a/src/queryBuilder/Group.js
+++ b/src/queryBuilder/Group.js
@@ -25,6 +25,7 @@ let GroupItem = FilterDragSource(args => {
     connectDragSource,
     //connectDragPreview, isDragging
   } = args
+  let Component = child.children ? Group : Rule
   return connectDragSource(
     <div
       style={{
@@ -38,11 +39,7 @@ let GroupItem = FilterDragSource(args => {
           {...{ node, child, tree, parent, index, parentState: state }}
         />
       )}
-      {child.children ? (
-        <Group node={child} tree={tree} parent={node} />
-      ) : (
-        <Rule {...{ ...args, parent: node, node: child }} />
-      )}
+      <Component {...args} node={child} parent={node} />
     </div>
   )
 })

--- a/src/queryBuilder/QueryBuilder.js
+++ b/src/queryBuilder/QueryBuilder.js
@@ -3,6 +3,7 @@ import { observable } from 'mobx'
 import { Provider } from 'mobx-react'
 import DDContext from './DragDrop/DDContext'
 import { Component } from '../utils/mobx-react-utils'
+import { Modal as DefaultModal, NestedPicker } from '../layout/'
 import Group from './Group'
 import styles from '../styles'
 
@@ -30,6 +31,8 @@ export default DDContext(
       fields,
       types = {},
       Button = 'button',
+      Modal = DefaultModal,
+      Picker = NestedPicker,
       mapNodeToProps,
       MissingTypeComponent,
     }) => (
@@ -39,7 +42,7 @@ export default DDContext(
       >
         <div style={{ background }}>
           {state.getNode(path) && (
-            <Group node={state.getNode(path)} tree={state} isRoot={true} />
+            <Group node={state.getNode(path)} tree={state} isRoot={true}  {...{ Button, Modal, Picker }} />
           )}
           <Button
             onClick={() => {

--- a/src/queryBuilder/QueryBuilder.js
+++ b/src/queryBuilder/QueryBuilder.js
@@ -42,7 +42,12 @@ export default DDContext(
       >
         <div style={{ background }}>
           {state.getNode(path) && (
-            <Group node={state.getNode(path)} tree={state} isRoot={true}  {...{ Button, Modal, Picker }} />
+            <Group
+              node={state.getNode(path)}
+              tree={state}
+              isRoot={true}
+              {...{ Button, Modal, Picker }}
+            />
           )}
           <Button
             onClick={() => {

--- a/src/queryBuilder/Rule.js
+++ b/src/queryBuilder/Rule.js
@@ -7,7 +7,7 @@ import FilterContents from './FilterContents'
 import FilterDragSource from './DragDrop/FilterDragSource'
 import { oppositeJoin, indent } from '../utils/search'
 
-let Rule = ({ state, node, parent, tree, connectDragSource, isDragging }) =>
+let Rule = ({ state, node, parent, tree, Button, Modal, Picker, connectDragSource, isDragging }) =>
   connectDragSource(
     <div style={styles.w100}>
       <Indentable parent={parent} indent={state.lens.indentHover}>
@@ -25,7 +25,7 @@ let Rule = ({ state, node, parent, tree, connectDragSource, isDragging }) =>
           }}
           {...F.domLens.hover(state.lens.ruleHover)}
         >
-          <FilterContents {...{ node, tree }} />
+          <FilterContents {...{ node, tree, Button, Modal, Picker }} />
           <div
             style={{
               ...(state.ruleHover || { visibility: 'hidden' }),

--- a/src/queryBuilder/Rule.js
+++ b/src/queryBuilder/Rule.js
@@ -7,7 +7,17 @@ import FilterContents from './FilterContents'
 import FilterDragSource from './DragDrop/FilterDragSource'
 import { oppositeJoin, indent } from '../utils/search'
 
-let Rule = ({ state, node, parent, tree, Button, Modal, Picker, connectDragSource, isDragging }) =>
+let Rule = ({
+  state,
+  node,
+  parent,
+  tree,
+  Button,
+  Modal,
+  Picker,
+  connectDragSource,
+  isDragging,
+}) =>
   connectDragSource(
     <div style={styles.w100}>
       <Indentable parent={parent} indent={state.lens.indentHover}>

--- a/src/themes/greyVest/index.js
+++ b/src/themes/greyVest/index.js
@@ -898,7 +898,7 @@ export let TagsInput = defaultProps({ TagComponent })(BaseTagsInput)
 let FieldPicker = defaultProps({
   Input,
   Highlight,
-  Item: FilterListItem
+  Item: FilterListItem,
 })(NestedPicker)
 
 export let ExampleTypes = ExampleTypeConstructor({
@@ -947,7 +947,7 @@ export let FilterList = defaultProps({
   Icon,
   ListItem,
   MissingTypeComponent,
-  Picker: FieldPicker
+  Picker: FieldPicker,
 })(BaseFilterList)
 
 export let AddableFilterList = props => (
@@ -963,9 +963,11 @@ export let FiltersBox = props => (
   </div>
 )
 
-export let QueryBuilder = defaultProps({ Button, MissingTypeComponent, Picker: FieldPicker })(
-  QueryBuilderComponent
-)
+export let QueryBuilder = defaultProps({
+  Button,
+  MissingTypeComponent,
+  Picker: FieldPicker,
+})(QueryBuilderComponent)
 
 export let SearchFilters = defaultProps({ QueryBuilder, FiltersBox })(
   BaseSearchFilters

--- a/src/themes/greyVest/index.js
+++ b/src/themes/greyVest/index.js
@@ -895,15 +895,19 @@ let TagComponent = defaultProps({
 })(Tag)
 export let TagsInput = defaultProps({ TagComponent })(BaseTagsInput)
 
+let FieldPicker = defaultProps({
+  Input,
+  Highlight,
+  Item: FilterListItem
+})(NestedPicker)
+
 export let ExampleTypes = ExampleTypeConstructor({
   Button,
   Input,
   Checkbox,
   RadioList,
   Table,
-  FieldPicker: defaultProps({ Input, Highlight, Item: FilterListItem })(
-    NestedPicker
-  ),
+  FieldPicker,
   ListGroupItem,
   TagsInput,
   Icon,
@@ -938,9 +942,13 @@ export let MissingTypeComponent = InjectTreeNode(({ node = {} }) => (
     </ErrorText>
   </Flex>
 ))
-export let FilterList = defaultProps({ Icon, ListItem, MissingTypeComponent })(
-  BaseFilterList
-)
+
+export let FilterList = defaultProps({
+  Icon,
+  ListItem,
+  MissingTypeComponent,
+  Picker: FieldPicker
+})(BaseFilterList)
 
 export let AddableFilterList = props => (
   <>
@@ -955,7 +963,7 @@ export let FiltersBox = props => (
   </div>
 )
 
-export let QueryBuilder = defaultProps({ Button, MissingTypeComponent })(
+export let QueryBuilder = defaultProps({ Button, MissingTypeComponent, Picker: FieldPicker })(
   QueryBuilderComponent
 )
 


### PR DESCRIPTION
GreyVest now passes the same modal-adder-picker-etc components to FilterList and QueryBuilder that it's currently using in the adder in basic search, so all the field pickers are consistent.

Before:
<img width="386" alt="Screen Shot 2019-07-17 at 4 27 15 AM" src="https://user-images.githubusercontent.com/35466670/61359820-37947300-a84b-11e9-8852-7723fe5dd70d.png">

After:
<img width="467" alt="Screen Shot 2019-07-17 at 4 27 01 AM" src="https://user-images.githubusercontent.com/35466670/61359828-395e3680-a84b-11e9-9d77-f4562a3ffb2e.png">

QueryBuilder in particular was missing these component props completely, so they had to be glued onto the side (I would've liked to use context, but this didn't seem like the best time/place to experiment). On the other hand, since that's Coming Soon to deprecate most of this PR anyway, the prop drilling changes are intentionally somewhat quick & dirty.