### PR TITLE
Use tree.replace instead of tree.mutate to change a node's field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.54.1
+* New helper function `newNodeFromField`
+
 # 1.54.0
 * Add one line support for the TagsInput component
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.52.0",
+  "version": "1.54.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5334,12 +5334,12 @@
       }
     },
     "contexture-client": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/contexture-client/-/contexture-client-2.22.1.tgz",
-      "integrity": "sha512-xCLGlxADaUM5ztD3coXYpDGf5AJJcutb/kcqW3ZWQi/AxlltPCT2eiB/cI2Yk7XK7aL5NOM1MrtzHMU0pizf7g==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/contexture-client/-/contexture-client-2.25.0.tgz",
+      "integrity": "sha512-uyTcs8B6LqGxDlRYm28J/IR5QiYm1nGiZfXhrGvuRKxU/9FZxEuXAD3F02/ofiv1+qr28OEAB/kwKfyuUKK/cA==",
       "dev": true,
       "requires": {
-        "futil-js": "^1.49.0",
+        "futil-js": "^1.58.0",
         "lodash": "^4.17.4"
       }
     },
@@ -13948,6 +13948,50 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
         "scheduler": "^0.13.6"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.8.6",
+          "bundled": true,
+          "dev": true
+        },
+        "scheduler": {
+          "version": "0.13.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-addons-create-fragment": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "babel-jest": "^23.4.2",
     "babel-plugin-require-context-hook": "^1.0.0",
     "contexture": "^0.2.1",
-    "contexture-client": "^2.22.1",
+    "contexture-client": "^2.25.0",
     "contexture-elasticsearch": "^0.10.2",
     "danger": "^6.1.13",
     "duti": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.54.0",
+  "version": "1.54.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/FilterAdder.js
+++ b/src/FilterAdder.js
@@ -2,21 +2,13 @@ import _ from 'lodash/fp'
 import React from 'react'
 import { observer } from 'mobx-react'
 import InjectTreeNode from './utils/injectTreeNode'
-import { DefaultNodeProps } from './utils/schema'
+import { newNodeFromField } from './utils/search'
 
 export let fieldsToOptions = _.map(x => ({ value: x.field, ...x }))
 
 let getGroupFields = node => _.map('field', _.getOr([], 'children', node))
 
-let FilterAdder = ({
-  tree,
-  node,
-  path,
-  fields,
-  Picker,
-  uniqueFields,
-  defaultNodeProps = DefaultNodeProps,
-}) => {
+let FilterAdder = ({ tree, node, path, fields, Picker, uniqueFields }) => {
   let options = fieldsToOptions(fields)
   if (uniqueFields) {
     options = _.reject(x => _.includes(x.field, getGroupFields(node)), options)
@@ -25,12 +17,7 @@ let FilterAdder = ({
     <Picker
       options={options}
       onChange={field => {
-        tree.add(path, {
-          key: _.uniqueId('add'),
-          field,
-          type: fields[field].typeDefault,
-          ...defaultNodeProps(field, fields, fields[field].typeDefault, tree),
-        })
+        tree.add(path, newNodeFromField({ field, fields }))
       }}
     />
   )

--- a/src/FilterAdder.js
+++ b/src/FilterAdder.js
@@ -16,9 +16,7 @@ let FilterAdder = ({ tree, node, path, fields, Picker, uniqueFields }) => {
   return (
     <Picker
       options={options}
-      onChange={field => {
-        tree.add(path, newNodeFromField({ field, fields }))
-      }}
+      onChange={field => tree.add(path, newNodeFromField({ field, fields }))}
     />
   )
 }

--- a/src/FilterList.js
+++ b/src/FilterList.js
@@ -15,7 +15,7 @@ import InjectTreeNode from './utils/injectTreeNode'
 import DefaultIcon from './DefaultIcon'
 import DefaultMissingTypeComponent from './DefaultMissingTypeComponent'
 import { bdJoin } from './styles/generic'
-import { newNodeFromType, changeNodeField } from './utils/search'
+import { newNodeFromType, newNodeFromField } from './utils/search'
 
 export let FilterActions = withStateLens({ modal: false })(
   observer(
@@ -25,7 +25,10 @@ export let FilterActions = withStateLens({ modal: false })(
           <Picker
             options={fieldsToOptions(fields)}
             onChange={field => {
-              changeNodeField(tree, node, field)
+              tree.replace(
+                node.path,
+                newNodeFromField({ field, fields, key: node.key })
+              )
               F.off(modal)()
             }}
           />

--- a/src/FilterList.js
+++ b/src/FilterList.js
@@ -15,7 +15,7 @@ import InjectTreeNode from './utils/injectTreeNode'
 import DefaultIcon from './DefaultIcon'
 import DefaultMissingTypeComponent from './DefaultMissingTypeComponent'
 import { bdJoin } from './styles/generic'
-import { newNodeFromType, newNodeFromField } from './utils/search'
+import { newNodeFromType, transformNodeFromField } from './utils/search'
 
 export let FilterActions = withStateLens({ modal: false })(
   observer(
@@ -27,7 +27,7 @@ export let FilterActions = withStateLens({ modal: false })(
             onChange={field => {
               tree.replace(
                 node.path,
-                newNodeFromField({ field, fields, key: node.key })
+                transformNodeFromField({ field, fields })
               )
               F.off(modal)()
             }}

--- a/src/FilterList.js
+++ b/src/FilterList.js
@@ -25,10 +25,7 @@ export let FilterActions = withStateLens({ modal: false })(
           <Picker
             options={fieldsToOptions(fields)}
             onChange={field => {
-              tree.replace(
-                node.path,
-                transformNodeFromField({ field, fields })
-              )
+              tree.replace(node.path, transformNodeFromField({ field, fields }))
               F.off(modal)()
             }}
           />

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -13,6 +13,7 @@ import {
   getResults,
   inferSchema,
 } from '../utils/schema'
+import { newNodeFromField } from '../utils/search'
 
 let getIncludes = (schema, node) =>
   F.when(_.isEmpty, _.map('field', schema))(node.include)
@@ -332,11 +333,7 @@ let ResultTable = InjectTreeNode(
       includes,
       addOptions: fieldsToOptions(hiddenFields),
       addFilter: field =>
-        tree.add(criteria, {
-          key: _.uniqueId('add'),
-          field,
-          type: _.find({ field }, schema).typeDefault,
-        }),
+        tree.add(criteria, newNodeFromField({ field, fields })),
       tree,
       node,
       mutate,

--- a/src/queryBuilder/FilterContents.js
+++ b/src/queryBuilder/FilterContents.js
@@ -7,7 +7,7 @@ import { fieldsToOptions } from '../FilterAdder'
 import DefaultMissingTypeComponent from '../DefaultMissingTypeComponent'
 import { defaultProps } from 'recompose'
 import { get } from '../utils/mobx-utils'
-import { newNodeFromType, newNodeFromField } from '../utils/search'
+import { newNodeFromType, transformNodeFromField } from '../utils/search'
 
 let FieldPicker = defaultProps({
   Modal,
@@ -42,7 +42,7 @@ let FilterContents = inject(_.defaults)(
             onChange={field =>
               tree.replace(
                 node.path,
-                newNodeFromField({ key: node.key, field, fields })
+                transformNodeFromField({ field, fields })
               )
             }
           />

--- a/src/queryBuilder/FilterContents.js
+++ b/src/queryBuilder/FilterContents.js
@@ -40,10 +40,7 @@ let FilterContents = inject(_.defaults)(
             label={nodeField ? nodeLabel : 'Pick a Field'}
             options={fieldsToOptions(fields)}
             onChange={field =>
-              tree.replace(
-                node.path,
-                transformNodeFromField({ field, fields })
-              )
+              tree.replace(node.path, transformNodeFromField({ field, fields }))
             }
           />
           {nodeField && (

--- a/src/queryBuilder/FilterContents.js
+++ b/src/queryBuilder/FilterContents.js
@@ -7,7 +7,7 @@ import { fieldsToOptions } from '../FilterAdder'
 import DefaultMissingTypeComponent from '../DefaultMissingTypeComponent'
 import { defaultProps } from 'recompose'
 import { get } from '../utils/mobx-utils'
-import { newNodeFromType, changeNodeField } from '../utils/search'
+import { newNodeFromType, newNodeFromField } from '../utils/search'
 
 let FieldPicker = defaultProps({
   Modal,
@@ -25,7 +25,9 @@ let FilterContents = inject(_.defaults)(
       mapNodeToProps = _.noop,
       MissingTypeComponent = DefaultMissingTypeComponent,
     }) => {
-      // `get` allows us to create a dependency on field before we know it exists (because the client will only add it if it's a type that uses it as it wouldn't make sense for something like `results`)
+      // `get` allows us to create a dependency on field before we know it
+      // exists (because the client will only add it if it's a type that uses it
+      // as it wouldn't make sense for something like `results`)
       let nodeField = get(node, 'field')
       let typeOptions = _.get([nodeField, 'typeOptions'], fields) || []
       if (node.type && !_.includes(node.type, typeOptions))
@@ -37,8 +39,12 @@ let FilterContents = inject(_.defaults)(
             Button={ContextureButton}
             label={nodeField ? nodeLabel : 'Pick a Field'}
             options={fieldsToOptions(fields)}
-            // TODO: consider type options in case this isn't safe, e.g. a field/type change action
-            onChange={field => changeNodeField(tree, node, field)}
+            onChange={field =>
+              tree.replace(
+                node.path,
+                newNodeFromField({ key: node.key, field, fields })
+              )
+            }
           />
           {nodeField && (
             <div style={{ margin: '0 5px' }}>

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -18,13 +18,15 @@ export let newNodeFromType = _.curry((type, fields, node) => ({
   ...defaultNodeProps(node.field, fields, type),
 }))
 
-// In the future, we will have logic here to handle intelligently updating
-// a node's types when its field is mutated. When that happens, we'll also
-// need to pass the `fields` schema to look up typeOptions for the current
-// and future field. Could also be a node transformer like newNodeFromType
-// if we decide to use Tree.replace() for fields instead of Tree.mutate().
-export let changeNodeField = (Tree, node, field) => {
-  Tree.mutate(node.path, { field })
+export let newNodeFromField = ({ key, field, fields, ...rest }) => {
+  let type = _.get([field, 'typeDefault'], fields)
+  return {
+    type,
+    field,
+    key: key || _.uniqueId('add'),
+    ...defaultNodeProps(field, fields, type),
+    ...rest,
+  }
 }
 
 export let indent = (Tree, parent, node, skipDefaultNode) => {

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -18,16 +18,20 @@ export let newNodeFromType = _.curry((type, fields, node) => ({
   ...defaultNodeProps(node.field, fields, type),
 }))
 
-export let newNodeFromField = ({ key, field, fields, ...rest }) => {
+export let newNodeFromField = ({ field, fields, ...optionalNodeProps }) => {
   let type = _.get([field, 'typeDefault'], fields)
   return {
     type,
     field,
-    key: key || _.uniqueId('add'),
     ...defaultNodeProps(field, fields, type),
-    ...rest,
+    ...optionalNodeProps,
   }
 }
+
+export let transformNodeFromField = args => node => ({
+  ..._.pick('key', node),
+  ...newNodeFromField(args),
+})
 
 export let indent = (Tree, parent, node, skipDefaultNode) => {
   // Reactors:


### PR DESCRIPTION
With this we'll change the exampleType component correctly as well as take into account custom default node props