### PR TITLE
Wizard fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.54.6
+* Tweaks and fixes to QueryWizard & StepsAccordion
+
 # 1.54.5
 * Add support for type labels to type selection options in FilterList/QueryBuilder
 * ResultTable: Pass additional props to Row

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.54.5",
+  "version": "1.54.6",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/layout/StepsAccordion.js
+++ b/src/layout/StepsAccordion.js
@@ -53,18 +53,19 @@ export let AccordionStep = ({
       className={`accordion-step ${className ? className : ''}`}
       style={style}
     >
-      <Flex alignItems="center" justifyContent="space-between">
+      <Flex
+        alignItems="center"
+        justifyContent="space-between"
+        onClick={F.sets(isOpen ? -1 : step, currentStep)}
+        style={{ cursor: 'pointer' }}
+      >
         <Flex alignItems="center">
           <div className="accordion-step-title">
             {F.callOrReturn(title, step)}
           </div>
           {!isRequired && <em style={{ marginLeft: 6 }}>(Optional)</em>}
         </Flex>
-        <div
-          className="filter-field-label-icon"
-          style={{ cursor: 'pointer' }}
-          onClick={F.sets(isOpen ? -1 : step, currentStep)}
-        >
+        <div className="filter-field-label-icon">
           <Icon icon={isOpen ? 'FilterListCollapse' : 'FilterListExpand'} />
         </div>
       </Flex>

--- a/src/queryWizard/QueryWizard.js
+++ b/src/queryWizard/QueryWizard.js
@@ -44,6 +44,7 @@ let QueryWizard = InjectTreeNode(
       {F.mapIndexed(
         (child, i) => (
           <AccordionStep
+            key={i}
             isRequired={i === 0}
             title={generateStepTitle(node, title)}
           >


### PR DESCRIPTION
Wizard fixes on the contexture-react side 🧙‍♂️

~~Most importantly, this adds a `useLoader` flag to the config parameter for `injectTreeNode`, and the ability to turn off the loader wrapper by setting it to `false` - which stops those components from rerendering when their node becomes marked for update.~~

Per feedback, everything to do with `injectTreeNode` has been removed from here and included in a separate PR. There are now only two changes:

- StepsAccordion: make clicking on a step's title fold/unfold that step
- QueryWizard: add missing `key` prop so React stops complaining