### PR TITLE
Add 'view less' link to Facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.54.6
+* Facet: add "view less" link
+
 # 1.54.5
 * Add support for type labels to type selection options in FilterList/QueryBuilder
 * ResultTable: Pass additional props to Row

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.54.7
+* Grid: Add `rows` prop
+
 # 1.54.6
 * Facet: add "view less" link
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.54.6",
+  "version": "1.54.7",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.54.5",
+  "version": "1.54.6",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -6,16 +6,6 @@ import { exampleTypes } from 'contexture-client'
 import { Flex } from '../layout/Flex'
 import injectTreeNode from '../utils/injectTreeNode'
 
-/*
-_.max([
-  _.min([
-    ceilTens(node.context.cardinality), 
-    node.size
-  ]) - 10,
-  10
-])
-*/
-
 let ceilTens = _.partial(_.ceil.convert({fixed: false}), [_, -1])
 
 let CheckboxDefault = props => <input type="checkbox" {...props} />
@@ -186,7 +176,7 @@ let Facet = injectTreeNode(
                   <a
                     key="more"
                     onClick={() =>
-                      tree.mutate(node.path, { size: node.size + sizeIncrement })
+                      tree.mutate(node.path, { size: (node.size || minSize) + sizeIncrement })
                     }
                     style={{ cursor: 'pointer' }}
                   >

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -1,12 +1,13 @@
 import React, { useState } from 'react'
 import _ from 'lodash/fp'
+import { ciel } from 'lodash'
 import F from 'futil-js'
 import { observer, Observer } from 'mobx-react'
 import { exampleTypes } from 'contexture-client'
 import { Flex } from '../layout/Flex'
 import injectTreeNode from '../utils/injectTreeNode'
 
-let ceilTens = _.partial(_.ceil.convert({ fixed: false }), [_, -1])
+let ceilTens = x => ciel(x, -1)
 
 let CheckboxDefault = props => <input type="checkbox" {...props} />
 let RadioListDefault = ({ value, onChange, options }) => (

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -6,7 +6,7 @@ import { exampleTypes } from 'contexture-client'
 import { Flex } from '../layout/Flex'
 import injectTreeNode from '../utils/injectTreeNode'
 
-let ceilTens = _.partial(_.ceil.convert({fixed: false}), [_, -1])
+let ceilTens = _.partial(_.ceil.convert({ fixed: false }), [_, -1])
 
 let CheckboxDefault = props => <input type="checkbox" {...props} />
 let RadioListDefault = ({ value, onChange, options }) => (
@@ -145,7 +145,8 @@ let Facet = injectTreeNode(
             justifyContent="space-between"
           >
             <div>
-              Showing {_.min([node.size || minSize, node.context.options.length])} of{' '}
+              Showing{' '}
+              {_.min([node.size || minSize, node.context.options.length])} of{' '}
               {node.context.cardinality}
             </div>
             <div>
@@ -157,14 +158,14 @@ let Facet = injectTreeNode(
                   <a
                     key="less"
                     onClick={() =>
-                      tree.mutate(node.path, { 
+                      tree.mutate(node.path, {
                         size: _.max([
                           _.min([
                             node.size,
-                            ceilTens(node.context.options.length)
+                            ceilTens(node.context.options.length),
                           ]) - sizeIncrement,
-                          minSize
-                        ])
+                          minSize,
+                        ]),
                       })
                     }
                     style={{ cursor: 'pointer' }}
@@ -176,13 +177,15 @@ let Facet = injectTreeNode(
                   <a
                     key="more"
                     onClick={() =>
-                      tree.mutate(node.path, { size: (node.size || minSize) + sizeIncrement })
+                      tree.mutate(node.path, {
+                        size: (node.size || minSize) + sizeIncrement,
+                      })
                     }
                     style={{ cursor: 'pointer' }}
                   >
                     View More
                   </a>
-                )
+                ),
               ])}
             </div>
           </Flex>

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -110,6 +110,8 @@ let Facet = injectTreeNode(
       displayBlank = () => <i>Not Specified</i>,
       formatCount = x => x,
       ButtonGroup = 'div',
+      minSize = 10,
+      sizeIncrement = 10,
     }) => (
       <div className="contexture-facet">
         <RadioList
@@ -153,7 +155,7 @@ let Facet = injectTreeNode(
             justifyContent="space-between"
           >
             <div>
-              Showing {_.min([node.size || 10, node.context.options.length])} of{' '}
+              Showing {_.min([node.size || minSize, node.context.options.length])} of{' '}
               {node.context.cardinality}
             </div>
             <div>
@@ -161,17 +163,17 @@ let Facet = injectTreeNode(
                 _.compact,
                 F.intersperse(' — ')
               )([
-                _.min([node.context.cardinality, node.size || 0]) > 10 && (
+                _.min([node.size, node.context.options.length]) > minSize && (
                   <a
                     key="less"
                     onClick={() =>
                       tree.mutate(node.path, { 
                         size: _.max([
                           _.min([
-                            ceilTens(node.context.cardinality), 
-                            node.size
-                          ]) - 10,
-                          10
+                            node.size,
+                            ceilTens(node.context.options.length)
+                          ]) - sizeIncrement,
+                          minSize
                         ])
                       })
                     }
@@ -180,11 +182,11 @@ let Facet = injectTreeNode(
                     View Less
                   </a>
                 ),
-                node.context.cardinality > (node.size || 10) && (
+                node.context.cardinality > (node.size || minSize) && (
                   <a
                     key="more"
                     onClick={() =>
-                      tree.mutate(node.path, { size: (node.size || 10) + 10 })
+                      tree.mutate(node.path, { size: node.size + sizeIncrement })
                     }
                     style={{ cursor: 'pointer' }}
                   >

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -6,6 +6,18 @@ import { exampleTypes } from 'contexture-client'
 import { Flex } from '../layout/Flex'
 import injectTreeNode from '../utils/injectTreeNode'
 
+/*
+_.max([
+  _.min([
+    ceilTens(node.context.cardinality), 
+    node.size
+  ]) - 10,
+  10
+])
+*/
+
+let ceilTens = _.partial(_.ceil.convert({fixed: false}), [_, -1])
+
 let CheckboxDefault = props => <input type="checkbox" {...props} />
 let RadioListDefault = ({ value, onChange, options }) => (
   <Flex style={{ justifyContent: 'space-between', alignItems: 'baseline' }}>
@@ -135,29 +147,54 @@ let Facet = injectTreeNode(
             </label>
           )
         }, _.get('context.options', node))}
-        <Flex
-          className="contexture-facet-cardinality"
-          style={{ justifyContent: 'space-between' }}
-        >
-          {!!node.context.cardinality && (
+        {!!node.context.cardinality && (
+          <Flex
+            className="contexture-facet-cardinality"
+            justifyContent="space-between"
+          >
             <div>
               Showing {_.min([node.size || 10, node.context.options.length])} of{' '}
               {node.context.cardinality}
             </div>
-          )}
-          {node.context.cardinality > (node.size || 10) && (
             <div>
-              <a
-                onClick={() =>
-                  tree.mutate(node.path, { size: (node.size || 10) + 10 })
-                }
-                style={{ cursor: 'pointer' }}
-              >
-                View More
-              </a>
+              {_.flow(
+                _.compact,
+                F.intersperse(' — ')
+              )([
+                _.min([node.context.cardinality, node.size || 0]) > 10 && (
+                  <a
+                    key="less"
+                    onClick={() =>
+                      tree.mutate(node.path, { 
+                        size: _.max([
+                          _.min([
+                            ceilTens(node.context.cardinality), 
+                            node.size
+                          ]) - 10,
+                          10
+                        ])
+                      })
+                    }
+                    style={{ cursor: 'pointer' }}
+                  >
+                    View Less
+                  </a>
+                ),
+                node.context.cardinality > (node.size || 10) && (
+                  <a
+                    key="more"
+                    onClick={() =>
+                      tree.mutate(node.path, { size: (node.size || 10) + 10 })
+                    }
+                    style={{ cursor: 'pointer' }}
+                  >
+                    View More
+                  </a>
+                )
+              ])}
             </div>
-          )}
-        </Flex>
+          </Flex>
+        )}
       </div>
     )
   ),

--- a/src/layout/Grid.js
+++ b/src/layout/Grid.js
@@ -1,12 +1,16 @@
 import React from 'react'
 
-export let Grid = ({ style, columns, gap, ...x }) => (
+export let Grid = ({ style, columns, rows, gap, ...x }) => (
   <div
     style={{
       display: 'grid',
       ...(columns && {
         gridTemplateColumns: columns,
         msGridTemplateColumns: columns,
+      }),
+      ...(rows && {
+        gridTemplateRows: rows,
+        msGridTemplateRows: rows,
       }),
       ...(gap && { gridGap: gap }),
       ...style,


### PR DESCRIPTION
Being able to increase the size of a facet but not decrease or reset it was getting annoying, so I threw this together:

<img width="358" alt="Screen Shot 2019-07-24 at 6 00 29 AM" src="https://user-images.githubusercontent.com/35466670/61784809-632dd500-add8-11e9-9121-b1fd6245552d.png">

This also factors out the magic `10`s into `minSize` and `sizeIncrement` variables, and exposes  them as props on Facet so that it's possible to set them with mapNodeToProps or defaultProps if we ever want to 🙂
