### PR TITLE
TagsInput is now smarter with input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.54.8
+* TagsInput: Better validation and input logic for new tags
+
 # 1.54.7
 * TermsStatsTable: sort descending by default
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.54.7",
+  "version": "1.54.8",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/layout/TagsInput.js
+++ b/src/layout/TagsInput.js
@@ -10,14 +10,18 @@ import OutsideClickHandler from 'react-outside-click-handler'
 
 let isValidInput = (tag, tags) => !_.isEmpty(tag) && !_.includes(tag, tags)
 
-let getUniqueTagsFromInput = (tag, tags, splitCommas = true) => {
+// extracts only the unique (and not already used tags) from the user tags input
+// e.g. if "x,y,z" are already entered then only "d" would be added if the user tris to enter "x,y,d"
+// returns a string with either single tag or multiple unique tags separated by comma
+let getUniqueTagsStringFromInput = (tag, tags, useCommaSeparator = true) => {
   let trimmedTag = _.trim(tag)
-  if (splitCommas && _.includes(',', trimmedTag)) {
-    // Extract only the unique and not present in the current tags collection tags from the string
+  if (useCommaSeparator && _.includes(',', trimmedTag)) {
+    // Extract only the unique (and not present in the current tags collection) tags from the string
     let newUniqTags = _.difference(
       _.uniq(_.compact(_.split(',', trimmedTag))),
       tags
     )
+    // if not empty return the joined string which would be split to separate tags in `addTag` if splitCommas is set
     return _.isEmpty(newUniqTags) ? null : newUniqTags.join(',')
   }
   return trimmedTag
@@ -155,7 +159,7 @@ let TagsInput = withState('state', 'setState', () =>
                   state.currentInput = e.target.value
                 }}
                 onBlur={() => {
-                  let input = getUniqueTagsFromInput(
+                  let input = getUniqueTagsStringFromInput(
                     state.currentInput,
                     tags,
                     splitCommas
@@ -166,7 +170,7 @@ let TagsInput = withState('state', 'setState', () =>
                   }
                 }}
                 onKeyDown={e => {
-                  let input = getUniqueTagsFromInput(
+                  let input = getUniqueTagsStringFromInput(
                     state.currentInput,
                     tags,
                     splitCommas

--- a/src/layout/TagsInput.js
+++ b/src/layout/TagsInput.js
@@ -81,14 +81,18 @@ let TagsInput = withState('state', 'setState', () =>
     }) => {
       let containerRef
       let inputRef
-      if (splitCommas)
-        addTag = _.flow(
-          _.split(','),
-          _.invokeMap('trim'),
-          _.compact,
-          _.uniq,
-          _.difference(_, tags),
-          _.map(addTag)
+      addTag = splitCommas
+        ? _.flow(
+            _.split(','),
+            _.invokeMap('trim'),
+            _.compact,
+            _.uniq,
+            _.difference(_, tags),
+            _.map(addTag)
+          )
+        : _.flow(
+            _.trim,
+            addTag
         )
       return (
         <OutsideClickHandler

--- a/src/layout/TagsInput.js
+++ b/src/layout/TagsInput.js
@@ -8,9 +8,16 @@ import { Flex } from './Flex'
 import Popover from './Popover'
 import OutsideClickHandler from 'react-outside-click-handler'
 
-let isValidTag = (tag, tags) => {
-  let cleanTag = _.trim(tag)
-  return !_.isEmpty(cleanTag) && !_.includes(cleanTag, tags)
+let isValidInput = (tag, tags) => !_.isEmpty(tag) && !_.includes(tag, tags)
+
+let getUniqueTagsFromInput = (tag, tags, splitCommas=true) => {
+  let trimmedTag = _.trim(tag)
+  if(splitCommas && _.includes(',', trimmedTag)) {
+    // Extract only the unique and not present in the current tags collection tags from the string
+    let newUniqTags = _.difference(_.uniq(_.compact(_.split(',', trimmedTag))), tags)
+    return _.isEmpty(newUniqTags) ? null : newUniqTags.join(',')
+  }
+  return trimmedTag
 }
 
 let Tag = observer(({ value, removeTag, tagStyle, RemoveIcon, onClick }) => (
@@ -145,21 +152,18 @@ let TagsInput = withState('state', 'setState', () =>
                   state.currentInput = e.target.value
                 }}
                 onBlur={() => {
-                  if (isValidTag(state.currentInput, tags)) {
-                    addTag(state.currentInput)
+                  let input = getUniqueTagsFromInput(state.currentInput, tags, splitCommas)
+                  if (isValidInput(input, tags)) {
+                    addTag(input)
                     state.currentInput = ''
                   }
                 }}
                 onKeyDown={e => {
-                  let currentInput = _.trim(state.currentInput)
-                  if (e.key === 'Enter' && !currentInput) submit()
-                  if (
-                    (e.key === 'Enter' ||
-                      e.key === 'Tab' ||
-                      (splitCommas && e.key === ',')) &&
-                    isValidTag(currentInput, tags)
+                  let input = getUniqueTagsFromInput(state.currentInput, tags, splitCommas)
+                  if (e.key === 'Enter' && !input) submit()
+                  if ((_.includes(e.key, ['Enter','Tab']) || (splitCommas && e.key === ',')) && isValidInput(input, tags)
                   ) {
-                    addTag(currentInput)
+                    addTag(input)
                     state.currentInput = ''
                     e.preventDefault()
                   }

--- a/src/layout/TagsInput.js
+++ b/src/layout/TagsInput.js
@@ -93,7 +93,7 @@ let TagsInput = withState('state', 'setState', () =>
         : _.flow(
             _.trim,
             addTag
-        )
+          )
       return (
         <OutsideClickHandler
           onOutsideClick={() => {

--- a/src/layout/TagsInput.js
+++ b/src/layout/TagsInput.js
@@ -10,11 +10,14 @@ import OutsideClickHandler from 'react-outside-click-handler'
 
 let isValidInput = (tag, tags) => !_.isEmpty(tag) && !_.includes(tag, tags)
 
-let getUniqueTagsFromInput = (tag, tags, splitCommas=true) => {
+let getUniqueTagsFromInput = (tag, tags, splitCommas = true) => {
   let trimmedTag = _.trim(tag)
-  if(splitCommas && _.includes(',', trimmedTag)) {
+  if (splitCommas && _.includes(',', trimmedTag)) {
     // Extract only the unique and not present in the current tags collection tags from the string
-    let newUniqTags = _.difference(_.uniq(_.compact(_.split(',', trimmedTag))), tags)
+    let newUniqTags = _.difference(
+      _.uniq(_.compact(_.split(',', trimmedTag))),
+      tags
+    )
     return _.isEmpty(newUniqTags) ? null : newUniqTags.join(',')
   }
   return trimmedTag
@@ -152,16 +155,27 @@ let TagsInput = withState('state', 'setState', () =>
                   state.currentInput = e.target.value
                 }}
                 onBlur={() => {
-                  let input = getUniqueTagsFromInput(state.currentInput, tags, splitCommas)
+                  let input = getUniqueTagsFromInput(
+                    state.currentInput,
+                    tags,
+                    splitCommas
+                  )
                   if (isValidInput(input, tags)) {
                     addTag(input)
                     state.currentInput = ''
                   }
                 }}
                 onKeyDown={e => {
-                  let input = getUniqueTagsFromInput(state.currentInput, tags, splitCommas)
+                  let input = getUniqueTagsFromInput(
+                    state.currentInput,
+                    tags,
+                    splitCommas
+                  )
                   if (e.key === 'Enter' && !input) submit()
-                  if ((_.includes(e.key, ['Enter','Tab']) || (splitCommas && e.key === ',')) && isValidInput(input, tags)
+                  if (
+                    (_.includes(e.key, ['Enter', 'Tab']) ||
+                      (splitCommas && e.key === ',')) &&
+                    isValidInput(input, tags)
                   ) {
                     addTag(input)
                     state.currentInput = ''


### PR DESCRIPTION
Related: https://github.com/smartprocure/bid-search/issues/3024

Issue: Entering strings separated by ‘,’ was broken. Users could enter ‘,’ and it would result in two empty tags, or enter ‘a’, after which ‘a,a’ which would result in 3 ‘a’ in the tags input.

![image](https://user-images.githubusercontent.com/910303/62402572-3480ce80-b53d-11e9-8f5a-9dbc662cbe83.png)

![image](https://user-images.githubusercontent.com/910303/62402574-39de1900-b53d-11e9-8740-764825b085d8.png)

New logic fixes that and also filters and adds only the new unique and new tags. So if you have ‘a,b,c’ and you enter ‘d,a,b,c’ only ‘d’ would be added etc.

Tags entry:

![TagsInput1](https://user-images.githubusercontent.com/910303/62403572-07371f00-b543-11e9-86ec-21896da4f2fa.gif)

Tags Copy/Paste:

![TagsInput2](https://user-images.githubusercontent.com/910303/62403624-672dc580-b543-11e9-87c0-5e1e2ac4c7b2.gif)
