### PR TITLE
Add migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # 2.0.0
+
+## Changes
 * Bump mobx-react to latest version
 * Remove usages of mobx-react Provider
 * Refactor `injectTreeNode` into `withNode` and `withLoader`
@@ -6,6 +8,17 @@
 * Remove `utils/mobx-react-utils`, `utils/dsl`, and `utils/tree`
 * Add `utils/react`, with new `useLens` and `useLensObject` functions
 * Remove `types` and `typeComponents` props from QueryBuilder and FilterList
+
+## Migration Guide
+* Stop using any utils that aren't explicitly exposed.
+  * We removed a number of internal utils which weren't technically publicly exposed, but we've seen usage where devs reach deep into the package for things like `injectTreeNode`
+* Explicitly pass `tree` to everything that was previous wrapped in a `Provider` with `tree` on it
+  * Passing `tree` via context with `Provider` from `mobx-react` is no longer supported. We might add similar functionality with native react context in a future release but do not have specific plans to do so yet. Usage by end users was dropping off and it adds a non-obvious level of indirection for only a few characters of savings.
+* Replace all usage of `types` and `typeComponents` with `mapNodeToProps` leveraging `componentForType`
+  * `QueryBuilder` and `FilterList` dropped support for `types` and `typeComponents` to simplify the API surface and reduce the number of things needed to understand the library. `mapNodeToProps` lets you completely replace the react component for a given node, so supporting both that and an type->component object map was just another thing to know about the API.
+* Create nodes explicitly on every contexture-client tree instance that was relying on the QuickStart functionality.
+  * Example types can no longer automatically add contexture nodes to the tree. This was found in the QuickStart story and was designed to reduce barriers to entry, but the abstraction was leaky and radically increased complexity of our implementation despite no known usages in the wild. More often than not, it was just a potential source of bugs for end users. We might add support for something similar in a future release.
+
 
 # 1.54.7
 * TermsStatsTable: sort descending by default


### PR DESCRIPTION
Just a quick draft at a migration guide for v2 with slightly more detail than the current changelog