### PR TITLE
Theme context API & demo stories

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,5 +3,8 @@
   "parser": "babel-eslint",
   "parserOptions": {
     "sourceType": "module"
+  },
+  "env": {
+    "jest": true
   }
 }

--- a/__tests__/theme.test.js
+++ b/__tests__/theme.test.js
@@ -1,0 +1,49 @@
+import { mergeNestedTheme } from '../src/utils/theme'
+import _ from 'lodash/fp'
+
+test('mergeNestedTheme', () => {
+  let theme = {
+    A: 'a',
+    B: 'b',
+    'A.B': 'a.b',
+    'A.C': 'a.c',
+    'A.C.B': 'a.c.b',
+    'B.B': 'b.b',
+    'B.B.B': 'b.b.b'
+  }
+  expect(mergeNestedTheme(theme, 'A')).toEqual({
+    A: 'a',
+    B: 'a.b', // <--
+    C: 'a.c', // <--
+    'A.B': 'a.b',
+    'A.C': 'a.c',
+    'A.C.B': 'a.c.b',
+    'B.B': 'b.b',
+    'B.B.B': 'b.b.b',
+    'C.B': 'a.c.b' // <--
+  })
+  expect(mergeNestedTheme(theme, 'B')).toEqual({
+    A: 'a',
+    B: 'b.b', // <--
+    'A.B': 'a.b',
+    'A.C': 'a.c',
+    'A.C.B': 'a.c.b',
+    'B.B': 'b.b.b', // <--
+    'B.B.B': 'b.b.b'
+  })
+  expect(mergeNestedTheme(theme, 'C')).toEqual(theme)
+  expect(_.reduce(mergeNestedTheme, theme, ['A', 'C'])).toEqual({
+    A: 'a',
+    B: 'a.c.b', // <--<--
+    C: 'a.c', // <--
+    'A.B': 'a.b',
+    'A.C': 'a.c',
+    'A.C.B': 'a.c.b',
+    'B.B': 'b.b',
+    'B.B.B': 'b.b.b',
+    'C.B': 'a.c.b' // <--
+  })
+  expect(mergeNestedTheme(theme)).toEqual(theme)
+  // edge case: do we want this to equal {} instead?
+  expect(mergeNestedTheme()).toEqual(undefined)
+})

--- a/src/utils/futil.js
+++ b/src/utils/futil.js
@@ -13,4 +13,6 @@ export let FlattenTreeLeaves = Tree =>
 export let PlainObjectTree = F.tree(onlyWhen(_.isPlainObject))
 export let flattenPlainObject = F.whenExists(FlattenTreeLeaves(PlainObjectTree))
 
-export let mergeOrReturn = _.curry((a, b) => a && b && _.merge(a, b) || a || b || {})
+export let mergeOrReturn = _.curry(
+  (a, b) => (a && b && _.merge(a, b)) || a || b || {}
+)

--- a/src/utils/futil.js
+++ b/src/utils/futil.js
@@ -14,5 +14,5 @@ export let PlainObjectTree = F.tree(onlyWhen(_.isPlainObject))
 export let flattenPlainObject = F.whenExists(FlattenTreeLeaves(PlainObjectTree))
 
 export let mergeOrReturn = _.curry(
-  (a, b) => (a && b && _.merge(a, b)) || a || b || {}
+  (a, b) => a && b && _.merge(a, b) || a || b || {}
 )

--- a/src/utils/futil.js
+++ b/src/utils/futil.js
@@ -14,5 +14,5 @@ export let PlainObjectTree = F.tree(onlyWhen(_.isPlainObject))
 export let flattenPlainObject = F.whenExists(FlattenTreeLeaves(PlainObjectTree))
 
 export let mergeOrReturn = _.curry(
-  (a, b) => a && b && _.merge(a, b) || a || b || {}
+  (a, b) => (a && b && _.merge(a, b)) || a || b || {}
 )

--- a/src/utils/futil.js
+++ b/src/utils/futil.js
@@ -12,3 +12,5 @@ export let FlattenTreeLeaves = Tree =>
   )
 export let PlainObjectTree = F.tree(onlyWhen(_.isPlainObject))
 export let flattenPlainObject = F.whenExists(FlattenTreeLeaves(PlainObjectTree))
+
+export let mergeOrReturn = _.curry((a, b) => a && b && _.merge(a, b) || a || b || {})

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -3,26 +3,31 @@ import _ from 'lodash/fp'
 
 let ThemeContext = React.createContext()
 
-export let ThemeProvider = ({ children, theme }) =>
-  <ThemeContext.Provider value={theme}>
-    {children}
-  </ThemeContext.Provider>
-
-export let mergeNestedTheme = (key = '', theme) => _.flow(
-  _.pickBy((val, k) => _.startsWith(`${key}.`, k)),
-  _.mapKeys(x => _.replace(`${key}.`, '', x)),
-  _.defaults(theme)
-)(theme || React.useContext(ThemeContext))
-
-export let mergeNestedThemePath = (path, theme) => _.reduce(
-  (acc, key) => mergeNestedTheme(key, acc), 
-  theme || React.useContext(ThemeContext), 
-  path || []
+export let ThemeProvider = ({ children, theme }) => (
+  <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>
 )
 
-export let ThemeConsumer = ({ children, path }) => children(mergeNestedThemePath(path))
+export let mergeNestedTheme = (key = '', theme) =>
+  _.flow(
+    _.pickBy((val, k) => _.startsWith(`${key}.`, k)),
+    _.mapKeys(x => _.replace(`${key}.`, '', x)),
+    _.defaults(theme)
+  )(theme || React.useContext(ThemeContext))
 
-export let withTheme = (defaults = {}, name) => Component => ({ theme: propTheme, ...props }) => {
+export let mergeNestedThemePath = (path, theme) =>
+  _.reduce(
+    (acc, key) => mergeNestedTheme(key, acc),
+    theme || React.useContext(ThemeContext),
+    path || []
+  )
+
+export let ThemeConsumer = ({ children, path }) =>
+  children(mergeNestedThemePath(path))
+
+export let withTheme = (defaults = {}, name) => Component => ({
+  theme: propTheme,
+  ...props
+}) => {
   name = name || Component.displayName || Component.name
   let contextTheme = mergeNestedTheme(name, React.useContext(ThemeContext))
 

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import _ from 'lodash/fp'
+
+let ThemeContext = React.createContext()
+
+export let ThemeProvider = ({ children, theme }) =>
+  <ThemeContext.Provider value={theme}>
+    {children}
+  </ThemeContext.Provider>
+
+export let mergeNestedTheme = (key = '', theme) => _.flow(
+  _.pickBy((val, k) => _.startsWith(`${key}.`, k)),
+  _.mapKeys(x => _.replace(`${key}.`, '', x)),
+  _.defaults(theme)
+)(theme || React.useContext(ThemeContext))
+
+export let mergeNestedThemePath = (path, theme) => _.reduce(
+  (acc, key) => mergeNestedTheme(key, acc), 
+  theme || React.useContext(ThemeContext), 
+  path || []
+)
+
+export let ThemeConsumer = ({ children, path }) => children(mergeNestedThemePath(path))
+
+export let withTheme = (defaults = {}, name) => Component => ({ theme: propTheme, ...props }) => {
+  name = name || Component.displayName || Component.name
+  let contextTheme = mergeNestedTheme(name, React.useContext(ThemeContext))
+
+  let newTheme = _.mergeAll([defaults, contextTheme, propTheme])
+
+  return (
+    <ThemeProvider theme={newTheme}>
+      <Component {...props} theme={newTheme} />
+    </ThemeProvider>
+  )
+}

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -28,7 +28,8 @@ export let ThemeConsumer = ({ name, children, theme: propTheme }) => {
   )
 }
 
-export let withTheme = name => Component => ({ theme, ...props }) => 
+export let withTheme = name => Component => ({ theme, ...props }) => (
   <ThemeConsumer {...{ theme, name }}>
     {newTheme => <Component {...props} theme={newTheme} />}
   </ThemeConsumer>
+)

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -4,32 +4,34 @@ import F from 'futil-js'
 
 export let ThemeContext = React.createContext()
 
-let hasNested = _.curry((key, theme) =>
-  key && theme && F.findIndexed((v, k) => _.startsWith(`${key}.`, k), theme)
+let hasNested = _.curry(
+  (key, theme) =>
+    key && theme && F.findIndexed((v, k) => _.startsWith(`${key}.`, k), theme)
 )
 
-export let mergeNestedTheme = (theme, key) => 
-F.when(
-  hasNested(key),
-  _.flow(
-    _.pickBy((val, k) => _.startsWith(`${key}.`, k)),
-    _.mapKeys(x => _.replace(`${key}.`, '', x)),
-    _.defaults(theme)
-  )
-)(theme)
+export let mergeNestedTheme = (theme, key) =>
+  F.when(
+    hasNested(key),
+    _.flow(
+      _.pickBy((val, k) => _.startsWith(`${key}.`, k)),
+      _.mapKeys(x => _.replace(`${key}.`, '', x)),
+      _.defaults(theme)
+    )
+  )(theme)
 
-export let mergeNestedThemePath = (theme, path) => _.reduce(
-  (acc, key) => mergeNestedTheme(acc, key),
-  theme,
-  path || []
-)
+export let mergeNestedThemePath = (theme, path) =>
+  _.reduce((acc, key) => mergeNestedTheme(acc, key), theme, path || [])
 
-export let ThemeConsumer = ({ children, path }) =>
+export let ThemeConsumer = ({ children, path }) => (
   <ThemeContext.Consumer>
     {theme => children(mergeNestedThemePath(theme, path))}
   </ThemeContext.Consumer>
+)
 
-export let withTheme = name => Component => ({ theme: propTheme, ...props }) => {
+export let withTheme = name => Component => ({
+  theme: propTheme,
+  ...props
+}) => {
   let contextTheme = mergeNestedTheme(React.useContext(ThemeContext), name)
   let newTheme = _.merge(contextTheme, propTheme)
   return (

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import _ from 'lodash/fp'
 import F from 'futil-js'
+import { mergeOrReturn } from './futil'
 
-let ThemeContext = React.createContext()
+let ThemeContext = React.createContext({})
 export let ThemeProvider = ThemeContext.Provider
 
 let hasNested = key => F.findIndexed((v, k) => _.startsWith(`${key}.`, k))
@@ -12,14 +13,14 @@ export let mergeNestedTheme = (theme, key) =>
     hasNested(key),
     _.flow(
       _.pickBy((val, k) => _.startsWith(`${key}.`, k)),
-      _.mapKeys(x => _.replace(`${key}.`, '', x)),
+      _.mapKeys(_.replace(`${key}.`, '')),
       _.defaults(theme)
     )
   )(theme)
 
 export let ThemeConsumer = ({ name, children, theme: propTheme }) => {
   let contextTheme = mergeNestedTheme(React.useContext(ThemeContext), name)
-  let newTheme = _.merge(contextTheme, propTheme)
+  let newTheme = mergeOrReturn(contextTheme, propTheme)
   return (
     <ThemeContext.Provider value={newTheme}>
       {children(newTheme)}

--- a/stories/theme.stories.js
+++ b/stories/theme.stories.js
@@ -3,35 +3,50 @@ import F from 'futil-js'
 import { storiesOf } from '@storybook/react'
 import { ThemeProvider, ThemeConsumer, withTheme } from '../src/utils/theme'
 
-let withStyle = (style, Component) => props => <Component style={style} {...props} />
+let withStyle = (style, Component) => props => (
+  <Component style={style} {...props} />
+)
 
-let VanillaButton = withStyle({
-  backgroundColor: 'cornsilk',
-  border: '2px solid tan',
-  color: 'rosybrown'
-}, 'button')
+let VanillaButton = withStyle(
+  {
+    backgroundColor: 'cornsilk',
+    border: '2px solid tan',
+    color: 'rosybrown',
+  },
+  'button'
+)
 
-let StrawberryButton = withStyle({
-  backgroundColor: 'lightcoral',
-  border: '2px solid limegreen',
-  color: 'greenyellow'
-}, 'button')
+let StrawberryButton = withStyle(
+  {
+    backgroundColor: 'lightcoral',
+    border: '2px solid limegreen',
+    color: 'greenyellow',
+  },
+  'button'
+)
 
-let PearButton = withStyle({
-  border: '2px solid olive',
-  color: 'darkolivegreen',
-  backgroundColor: 'yellowgreen'
-}, 'button')
+let PearButton = withStyle(
+  {
+    border: '2px solid olive',
+    color: 'darkolivegreen',
+    backgroundColor: 'yellowgreen',
+  },
+  'button'
+)
 
-let GrapeButton = withStyle({
-  border: '2px solid blueviolet',
-  color: 'chartreuse',
-  backgroundColor: 'mediumorchid'
-}, 'button')
+let GrapeButton = withStyle(
+  {
+    border: '2px solid blueviolet',
+    color: 'chartreuse',
+    backgroundColor: 'mediumorchid',
+  },
+  'button'
+)
 
-let ButtonGroup = ({ theme, buttons = [] }) => F.mapIndexed(
-  (button, i) => <theme.Button key={i}>{button}</theme.Button>
-)(buttons)
+let ButtonGroup = ({ theme, buttons = [] }) =>
+  F.mapIndexed((button, i) => <theme.Button key={i}>{button}</theme.Button>)(
+    buttons
+  )
 
 let ThemedButtonGroup = withTheme({ Button: 'button' })(ButtonGroup)
 
@@ -45,33 +60,42 @@ storiesOf('Theme API|withTheme', module)
     )
   })
   .addWithJSX('Theme precedence', () => (
-      <ThemeProvider
-        theme={{
-          Button: VanillaButton,
-          'ButtonGroup.Button': StrawberryButton
-        }}
-      >
-        <ThemedButtonGroup buttons={['Nested themes override top-level themes']} />
-        <ThemedButtonGroup theme={{ Button: PearButton }} buttons={['Theme props override theme context']} />
-      </ThemeProvider>
-    )
-  )
+    <ThemeProvider
+      theme={{
+        Button: VanillaButton,
+        'ButtonGroup.Button': StrawberryButton,
+      }}
+    >
+      <ThemedButtonGroup
+        buttons={['Nested themes override top-level themes']}
+      />
+      <ThemedButtonGroup
+        theme={{ Button: PearButton }}
+        buttons={['Theme props override theme context']}
+      />
+    </ThemeProvider>
+  ))
   .addWithJSX('Explicit naming', () => {
-    let UnnamedComponent = withTheme()(
-      ({ theme }) => 
+    let UnnamedComponent = withTheme()(({ theme }) => (
       <>
         <div>I am an anonymous component</div>
         <theme.Button>Top-level buttons are Vanilla</theme.Button>
       </>
-    )
+    ))
     let ExplicitlyNamedComponent = withTheme({ Button: 'button' }, 'Jerry')(
-      ({ theme }) => 
-      <>
-        <div>I am also an anonymous component, but <code>withTheme</code> knows me as "Jerry"</div>
-        <theme.Button>Jerry buttons are Strawberry!</theme.Button>
-      </>
+      ({ theme }) => (
+        <>
+          <div>
+            I am also an anonymous component, but <code>withTheme</code> knows
+            me as "Jerry"
+          </div>
+          <theme.Button>Jerry buttons are Strawberry!</theme.Button>
+        </>
+      )
     )
-    let ButtonGroupGeorge = withTheme({ Button: 'button' }, 'George')(ButtonGroup)
+    let ButtonGroupGeorge = withTheme({ Button: 'button' }, 'George')(
+      ButtonGroup
+    )
     return (
       <ThemeProvider
         theme={{
@@ -84,7 +108,10 @@ storiesOf('Theme API|withTheme', module)
         <div style={{ height: 20 }} />
         <ExplicitlyNamedComponent />
         <div style={{ height: 20 }} />
-        <div>This component is a ButtonGroup, but <code>withTheme</code> knows it as "George":</div>
+        <div>
+          This component is a ButtonGroup, but <code>withTheme</code> knows it
+          as "George":
+        </div>
         <ButtonGroupGeorge buttons={['George buttons are Pear!']} />
       </ThemeProvider>
     )
@@ -92,14 +119,26 @@ storiesOf('Theme API|withTheme', module)
 
 storiesOf('Theme API|ThemeConsumer', module)
   .addWithJSX('Without path', () => (
-    <ThemeProvider theme={{ Button: VanillaButton, ButtonGroup, 'ButtonGroup.Button': PearButton }}>
+    <ThemeProvider
+      theme={{
+        Button: VanillaButton,
+        ButtonGroup,
+        'ButtonGroup.Button': PearButton,
+      }}
+    >
       <ThemeConsumer>
         {theme => <theme.Button>Top-level buttons are Vanilla</theme.Button>}
       </ThemeConsumer>
     </ThemeProvider>
   ))
   .addWithJSX('With path', () => (
-    <ThemeProvider theme={{ Button: VanillaButton, ButtonGroup, 'ButtonGroup.Button': GrapeButton }}>
+    <ThemeProvider
+      theme={{
+        Button: VanillaButton,
+        ButtonGroup,
+        'ButtonGroup.Button': GrapeButton,
+      }}
+    >
       {/* 
         If ThemeConsumer is given a `path` prop containing an array, it will merge
         all of the theme components along that path into the `theme` object that is
@@ -117,7 +156,10 @@ let IconButton = ({ theme, children }) => (
     {children}
   </theme.Button>
 )
-let ThemedIconButton = withTheme({ Button: 'button', Icon: () => <span>[icon]</span>})(IconButton)
+let ThemedIconButton = withTheme({
+  Button: 'button',
+  Icon: () => <span>[icon]</span>,
+})(IconButton)
 
 storiesOf('Theme API|Multi-level nesting', module)
   .addWithJSX('With theme context', () => (
@@ -127,7 +169,7 @@ storiesOf('Theme API|Multi-level nesting', module)
         Button: VanillaButton,
         'ButtonGroup.Button': ThemedIconButton,
         'ButtonGroup.IconButton.Icon': () => <span>🍓</span>,
-        'ButtonGroup.IconButton.Button': StrawberryButton
+        'ButtonGroup.IconButton.Button': StrawberryButton,
       }}
     >
       <ThemedIconButton>Top-level Icon & Button theme</ThemedIconButton>
@@ -146,7 +188,7 @@ storiesOf('Theme API|Multi-level nesting', module)
         theme={{
           Button: ThemedIconButton,
           'IconButton.Icon': () => <span>🍇</span>,
-          'IconButton.Button': GrapeButton
+          'IconButton.Button': GrapeButton,
         }}
         buttons={['ButtonGroup Icon & Button theme']}
       />

--- a/stories/theme.stories.js
+++ b/stories/theme.stories.js
@@ -1,104 +1,87 @@
 import React from 'react'
 import F from 'futil-js'
 import { storiesOf } from '@storybook/react'
-import { ThemeProvider, ThemeConsumer, withTheme } from '../src/utils/theme'
+import { ThemeContext, ThemeConsumer, withTheme } from '../src/utils/theme'
 
-let withStyle = (style, Component) => props => (
-  <Component style={style} {...props} />
+let withStyle = (style, Component) => props => <Component style={style} {...props} />
+
+let VanillaButton = withStyle({
+  backgroundColor: 'cornsilk',
+  border: '2px solid tan',
+  color: 'rosybrown'
+}, 'button')
+
+let StrawberryButton = withStyle({
+  backgroundColor: 'lightcoral',
+  border: '2px solid limegreen',
+  color: 'greenyellow'
+}, 'button')
+
+let PearButton = withStyle({
+  border: '2px solid olive',
+  color: 'darkolivegreen',
+  backgroundColor: 'yellowgreen'
+}, 'button')
+
+let GrapeButton = withStyle({
+  border: '2px solid blueviolet',
+  color: 'chartreuse',
+  backgroundColor: 'mediumorchid'
+}, 'button')
+
+let ThemedButton = withTheme('Button')(
+  ({ theme: { Button = 'button' }, children }) => <Button>{children}</Button>
 )
 
-let VanillaButton = withStyle(
-  {
-    backgroundColor: 'cornsilk',
-    border: '2px solid tan',
-    color: 'rosybrown',
-  },
-  'button'
-)
+let ButtonGroup = ({ theme: { Button = 'button' }, buttons = [] }) => F.mapIndexed(
+  (button, i) => <Button key={i}>{button}</Button>
+)(buttons)
 
-let StrawberryButton = withStyle(
-  {
-    backgroundColor: 'lightcoral',
-    border: '2px solid limegreen',
-    color: 'greenyellow',
-  },
-  'button'
-)
-
-let PearButton = withStyle(
-  {
-    border: '2px solid olive',
-    color: 'darkolivegreen',
-    backgroundColor: 'yellowgreen',
-  },
-  'button'
-)
-
-let GrapeButton = withStyle(
-  {
-    border: '2px solid blueviolet',
-    color: 'chartreuse',
-    backgroundColor: 'mediumorchid',
-  },
-  'button'
-)
-
-let ButtonGroup = ({ theme, buttons = [] }) =>
-  F.mapIndexed((button, i) => <theme.Button key={i}>{button}</theme.Button>)(
-    buttons
-  )
-
-let ThemedButtonGroup = withTheme({ Button: 'button' })(ButtonGroup)
+let ThemedButtonGroup = withTheme('ButtonGroup')(ButtonGroup)
 
 storiesOf('Theme API|withTheme', module)
   .addWithJSX('Setting defaults', () => {
-    let VanillaButtonGroup = withTheme({ Button: VanillaButton })(ButtonGroup)
+    let DefaultVanillaButton = withTheme('ButtonGroup')(
+      ({ theme: { Button = VanillaButton }, children }) => <Button>{children}</Button>
+    )
     return (
-      <ThemeProvider>
-        <VanillaButtonGroup buttons={['Vanilla', 'Buttons!']} />
-      </ThemeProvider>
+      <ThemeContext.Provider>
+        <ThemedButton>My default is a plain button!</ThemedButton>
+        <DefaultVanillaButton>My default is Vanilla!</DefaultVanillaButton>
+      </ThemeContext.Provider>
     )
   })
   .addWithJSX('Theme precedence', () => (
-    <ThemeProvider
-      theme={{
-        Button: VanillaButton,
-        'ButtonGroup.Button': StrawberryButton,
-      }}
-    >
-      <ThemedButtonGroup
-        buttons={['Nested themes override top-level themes']}
-      />
-      <ThemedButtonGroup
-        theme={{ Button: PearButton }}
-        buttons={['Theme props override theme context']}
-      />
-    </ThemeProvider>
-  ))
+      <ThemeContext.Provider
+        value={{
+          Button: VanillaButton,
+          'ButtonGroup.Button': StrawberryButton
+        }}
+      >
+        <ThemedButtonGroup buttons={['Nested themes override top-level themes']} />
+        <ThemedButtonGroup theme={{ Button: PearButton }} buttons={['Theme props override theme context']} />
+      </ThemeContext.Provider>
+    )
+  )
   .addWithJSX('Explicit naming', () => {
-    let UnnamedComponent = withTheme()(({ theme }) => (
+    let UnnamedComponent = withTheme()(
+      ({ theme: { Button = 'button' } }) => 
       <>
         <div>I am an anonymous component</div>
-        <theme.Button>Top-level buttons are Vanilla</theme.Button>
+        <Button>Top-level buttons are Vanilla</Button>
       </>
-    ))
-    let ExplicitlyNamedComponent = withTheme({ Button: 'button' }, 'Jerry')(
-      ({ theme }) => (
-        <>
-          <div>
-            I am also an anonymous component, but <code>withTheme</code> knows
-            me as "Jerry"
-          </div>
-          <theme.Button>Jerry buttons are Strawberry!</theme.Button>
-        </>
-      )
     )
-    let ButtonGroupGeorge = withTheme({ Button: 'button' }, 'George')(
-      ButtonGroup
+    let ExplicitlyNamedComponent = withTheme('Jerry')(
+      ({ theme: { Button = 'button' } }) => 
+      <>
+        <div>I am also an anonymous component, but <code>withTheme</code> knows me as "Jerry"</div>
+        <Button>Jerry buttons are Strawberry!</Button>
+      </>
     )
+    let ButtonGroupGeorge = withTheme('George')(ButtonGroup)
     return (
-      <ThemeProvider
-        theme={{
+      <ThemeContext.Provider
+        value={{
           Button: VanillaButton,
           'Jerry.Button': StrawberryButton,
           'George.Button': PearButton,
@@ -108,37 +91,22 @@ storiesOf('Theme API|withTheme', module)
         <div style={{ height: 20 }} />
         <ExplicitlyNamedComponent />
         <div style={{ height: 20 }} />
-        <div>
-          This component is a ButtonGroup, but <code>withTheme</code> knows it
-          as "George":
-        </div>
+        <div>This component is a ButtonGroup, but <code>withTheme</code> knows it as "George":</div>
         <ButtonGroupGeorge buttons={['George buttons are Pear!']} />
-      </ThemeProvider>
+      </ThemeContext.Provider>
     )
   })
 
 storiesOf('Theme API|ThemeConsumer', module)
   .addWithJSX('Without path', () => (
-    <ThemeProvider
-      theme={{
-        Button: VanillaButton,
-        ButtonGroup,
-        'ButtonGroup.Button': PearButton,
-      }}
-    >
+    <ThemeContext.Provider value={{ Button: VanillaButton, ButtonGroup, 'ButtonGroup.Button': PearButton }}>
       <ThemeConsumer>
         {theme => <theme.Button>Top-level buttons are Vanilla</theme.Button>}
       </ThemeConsumer>
-    </ThemeProvider>
+    </ThemeContext.Provider>
   ))
   .addWithJSX('With path', () => (
-    <ThemeProvider
-      theme={{
-        Button: VanillaButton,
-        ButtonGroup,
-        'ButtonGroup.Button': GrapeButton,
-      }}
-    >
+    <ThemeContext.Provider value={{ Button: VanillaButton, ButtonGroup, 'ButtonGroup.Button': GrapeButton }}>
       {/* 
         If ThemeConsumer is given a `path` prop containing an array, it will merge
         all of the theme components along that path into the `theme` object that is
@@ -147,38 +115,35 @@ storiesOf('Theme API|ThemeConsumer', module)
       <ThemeConsumer path={['ButtonGroup']}>
         {theme => <theme.Button>ButtonGroup buttons are Grape!</theme.Button>}
       </ThemeConsumer>
-    </ThemeProvider>
+    </ThemeContext.Provider>
   ))
 
-let IconButton = ({ theme, children }) => (
-  <theme.Button>
-    <theme.Icon />
+let IconButton = ({ theme: { Button = 'button', Icon = () => <span>[icon]</span> }, children }) => (
+  <Button>
+    <Icon />
     {children}
-  </theme.Button>
+  </Button>
 )
-let ThemedIconButton = withTheme({
-  Button: 'button',
-  Icon: () => <span>[icon]</span>,
-})(IconButton)
+let ThemedIconButton = withTheme('IconButton')(IconButton)
 
 storiesOf('Theme API|Multi-level nesting', module)
   .addWithJSX('With theme context', () => (
-    <ThemeProvider
-      theme={{
+    <ThemeContext.Provider
+      value={{
         Icon: () => <span>🍨</span>,
         Button: VanillaButton,
         'ButtonGroup.Button': ThemedIconButton,
         'ButtonGroup.IconButton.Icon': () => <span>🍓</span>,
-        'ButtonGroup.IconButton.Button': StrawberryButton,
+        'ButtonGroup.IconButton.Button': StrawberryButton
       }}
     >
       <ThemedIconButton>Top-level Icon & Button theme</ThemedIconButton>
       <ThemedButtonGroup buttons={['ButtonGroup Icon & Button theme']} />
-    </ThemeProvider>
+    </ThemeContext.Provider>
   ))
   .addWithJSX('With theme props', () => (
-    <ThemeProvider
-      theme={{
+    <ThemeContext.Provider
+      value={{
         Icon: () => <span>🍨</span>,
         Button: VanillaButton,
       }}
@@ -188,9 +153,9 @@ storiesOf('Theme API|Multi-level nesting', module)
         theme={{
           Button: ThemedIconButton,
           'IconButton.Icon': () => <span>🍇</span>,
-          'IconButton.Button': GrapeButton,
+          'IconButton.Button': GrapeButton
         }}
         buttons={['ButtonGroup Icon & Button theme']}
       />
-    </ThemeProvider>
+    </ThemeContext.Provider>
   ))

--- a/stories/theme.stories.js
+++ b/stories/theme.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import F from 'futil-js'
 import { storiesOf } from '@storybook/react'
-import { ThemeContext, ThemeConsumer, withTheme } from '../src/utils/theme'
+import { ThemeProvider, ThemeConsumer, withTheme } from '../src/utils/theme'
 
 let withStyle = (style, Component) => props => (
   <Component style={style} {...props} />
@@ -60,28 +60,24 @@ storiesOf('Theme API|withTheme', module)
       )
     )
     return (
-      <ThemeContext.Provider>
+      <ThemeProvider>
         <ThemedButton>My default is a plain button!</ThemedButton>
         <DefaultVanillaButton>My default is Vanilla!</DefaultVanillaButton>
-      </ThemeContext.Provider>
+      </ThemeProvider>
     )
   })
   .addWithJSX('Theme precedence', () => (
-    <ThemeContext.Provider
-      value={{
-        Button: VanillaButton,
-        'ButtonGroup.Button': StrawberryButton,
-      }}
-    >
-      <ThemedButtonGroup
-        buttons={['Nested themes override top-level themes']}
-      />
-      <ThemedButtonGroup
-        theme={{ Button: PearButton }}
-        buttons={['Theme props override theme context']}
-      />
-    </ThemeContext.Provider>
-  ))
+      <ThemeProvider
+        value={{
+          Button: VanillaButton,
+          'ButtonGroup.Button': StrawberryButton
+        }}
+      >
+        <ThemedButtonGroup buttons={['Nested themes override top-level themes']} />
+        <ThemedButtonGroup theme={{ Button: PearButton }} buttons={['Theme props override theme context']} />
+      </ThemeProvider>
+    )
+  )
   .addWithJSX('Explicit naming', () => {
     let UnnamedComponent = withTheme()(({ theme: { Button = 'button' } }) => (
       <>
@@ -102,7 +98,7 @@ storiesOf('Theme API|withTheme', module)
     )
     let ButtonGroupGeorge = withTheme('George')(ButtonGroup)
     return (
-      <ThemeContext.Provider
+      <ThemeProvider
         value={{
           Button: VanillaButton,
           'Jerry.Button': StrawberryButton,
@@ -118,41 +114,29 @@ storiesOf('Theme API|withTheme', module)
           as "George":
         </div>
         <ButtonGroupGeorge buttons={['George buttons are Pear!']} />
-      </ThemeContext.Provider>
+      </ThemeProvider>
     )
   })
 
 storiesOf('Theme API|ThemeConsumer', module)
   .addWithJSX('Without path', () => (
-    <ThemeContext.Provider
-      value={{
-        Button: VanillaButton,
-        ButtonGroup,
-        'ButtonGroup.Button': PearButton,
-      }}
-    >
-      <ThemeConsumer>
-        {theme => <theme.Button>Top-level buttons are Vanilla</theme.Button>}
+    <ThemeProvider value={{ Button: VanillaButton, ButtonGroup, 'ButtonGroup.Button': PearButton }}>
+      <ThemeConsumer name="Button">
+        {({ Button = 'button' }) => <Button>Top-level buttons are Vanilla</Button>}
       </ThemeConsumer>
-    </ThemeContext.Provider>
+    </ThemeProvider>
   ))
   .addWithJSX('With path', () => (
-    <ThemeContext.Provider
-      value={{
-        Button: VanillaButton,
-        ButtonGroup,
-        'ButtonGroup.Button': GrapeButton,
-      }}
-    >
+    <ThemeProvider value={{ Button: VanillaButton, ButtonGroup, 'ButtonGroup.Button': GrapeButton }}>
       {/* 
         If ThemeConsumer is given a `path` prop containing an array, it will merge
         all of the theme components along that path into the `theme` object that is
         passed to its child function.
       */}
-      <ThemeConsumer path={['ButtonGroup']}>
-        {theme => <theme.Button>ButtonGroup buttons are Grape!</theme.Button>}
+      <ThemeConsumer name="ButtonGroup">
+        {({ Button = 'button' }) => <Button>ButtonGroup buttons are Grape!</Button>}
       </ThemeConsumer>
-    </ThemeContext.Provider>
+    </ThemeProvider>
   ))
 
 let IconButton = ({
@@ -168,7 +152,7 @@ let ThemedIconButton = withTheme('IconButton')(IconButton)
 
 storiesOf('Theme API|Multi-level nesting', module)
   .addWithJSX('With theme context', () => (
-    <ThemeContext.Provider
+    <ThemeProvider
       value={{
         Icon: () => <span>🍨</span>,
         Button: VanillaButton,
@@ -179,10 +163,10 @@ storiesOf('Theme API|Multi-level nesting', module)
     >
       <ThemedIconButton>Top-level Icon & Button theme</ThemedIconButton>
       <ThemedButtonGroup buttons={['ButtonGroup Icon & Button theme']} />
-    </ThemeContext.Provider>
+    </ThemeProvider>
   ))
   .addWithJSX('With theme props', () => (
-    <ThemeContext.Provider
+    <ThemeProvider
       value={{
         Icon: () => <span>🍨</span>,
         Button: VanillaButton,
@@ -197,5 +181,5 @@ storiesOf('Theme API|Multi-level nesting', module)
         }}
         buttons={['ButtonGroup Icon & Button theme']}
       />
-    </ThemeContext.Provider>
+    </ThemeProvider>
   ))

--- a/stories/theme.stories.js
+++ b/stories/theme.stories.js
@@ -67,17 +67,21 @@ storiesOf('Theme API|withTheme', module)
     )
   })
   .addWithJSX('Theme precedence', () => (
-      <ThemeProvider
-        value={{
-          Button: VanillaButton,
-          'ButtonGroup.Button': StrawberryButton
-        }}
-      >
-        <ThemedButtonGroup buttons={['Nested themes override top-level themes']} />
-        <ThemedButtonGroup theme={{ Button: PearButton }} buttons={['Theme props override theme context']} />
-      </ThemeProvider>
-    )
-  )
+    <ThemeProvider
+      value={{
+        Button: VanillaButton,
+        'ButtonGroup.Button': StrawberryButton,
+      }}
+    >
+      <ThemedButtonGroup
+        buttons={['Nested themes override top-level themes']}
+      />
+      <ThemedButtonGroup
+        theme={{ Button: PearButton }}
+        buttons={['Theme props override theme context']}
+      />
+    </ThemeProvider>
+  ))
   .addWithJSX('Explicit naming', () => {
     let UnnamedComponent = withTheme()(({ theme: { Button = 'button' } }) => (
       <>
@@ -120,21 +124,37 @@ storiesOf('Theme API|withTheme', module)
 
 storiesOf('Theme API|ThemeConsumer', module)
   .addWithJSX('Without path', () => (
-    <ThemeProvider value={{ Button: VanillaButton, ButtonGroup, 'ButtonGroup.Button': PearButton }}>
+    <ThemeProvider
+      value={{
+        Button: VanillaButton,
+        ButtonGroup,
+        'ButtonGroup.Button': PearButton,
+      }}
+    >
       <ThemeConsumer name="Button">
-        {({ Button = 'button' }) => <Button>Top-level buttons are Vanilla</Button>}
+        {({ Button = 'button' }) => (
+          <Button>Top-level buttons are Vanilla</Button>
+        )}
       </ThemeConsumer>
     </ThemeProvider>
   ))
   .addWithJSX('With path', () => (
-    <ThemeProvider value={{ Button: VanillaButton, ButtonGroup, 'ButtonGroup.Button': GrapeButton }}>
+    <ThemeProvider
+      value={{
+        Button: VanillaButton,
+        ButtonGroup,
+        'ButtonGroup.Button': GrapeButton,
+      }}
+    >
       {/* 
         If ThemeConsumer is given a `path` prop containing an array, it will merge
         all of the theme components along that path into the `theme` object that is
         passed to its child function.
       */}
       <ThemeConsumer name="ButtonGroup">
-        {({ Button = 'button' }) => <Button>ButtonGroup buttons are Grape!</Button>}
+        {({ Button = 'button' }) => (
+          <Button>ButtonGroup buttons are Grape!</Button>
+        )}
       </ThemeConsumer>
     </ThemeProvider>
   ))

--- a/stories/theme.stories.js
+++ b/stories/theme.stories.js
@@ -1,0 +1,154 @@
+import React from 'react'
+import F from 'futil-js'
+import { storiesOf } from '@storybook/react'
+import { ThemeProvider, ThemeConsumer, withTheme } from '../src/utils/theme'
+
+let withStyle = (style, Component) => props => <Component style={style} {...props} />
+
+let VanillaButton = withStyle({
+  backgroundColor: 'cornsilk',
+  border: '2px solid tan',
+  color: 'rosybrown'
+}, 'button')
+
+let StrawberryButton = withStyle({
+  backgroundColor: 'lightcoral',
+  border: '2px solid limegreen',
+  color: 'greenyellow'
+}, 'button')
+
+let PearButton = withStyle({
+  border: '2px solid olive',
+  color: 'darkolivegreen',
+  backgroundColor: 'yellowgreen'
+}, 'button')
+
+let GrapeButton = withStyle({
+  border: '2px solid blueviolet',
+  color: 'chartreuse',
+  backgroundColor: 'mediumorchid'
+}, 'button')
+
+let ButtonGroup = ({ theme, buttons = [] }) => F.mapIndexed(
+  (button, i) => <theme.Button key={i}>{button}</theme.Button>
+)(buttons)
+
+let ThemedButtonGroup = withTheme({ Button: 'button' })(ButtonGroup)
+
+storiesOf('Theme API|withTheme', module)
+  .addWithJSX('Setting defaults', () => {
+    let VanillaButtonGroup = withTheme({ Button: VanillaButton })(ButtonGroup)
+    return (
+      <ThemeProvider>
+        <VanillaButtonGroup buttons={['Vanilla', 'Buttons!']} />
+      </ThemeProvider>
+    )
+  })
+  .addWithJSX('Theme precedence', () => (
+      <ThemeProvider
+        theme={{
+          Button: VanillaButton,
+          'ButtonGroup.Button': StrawberryButton
+        }}
+      >
+        <ThemedButtonGroup buttons={['Nested themes override top-level themes']} />
+        <ThemedButtonGroup theme={{ Button: PearButton }} buttons={['Theme props override theme context']} />
+      </ThemeProvider>
+    )
+  )
+  .addWithJSX('Explicit naming', () => {
+    let UnnamedComponent = withTheme()(
+      ({ theme }) => 
+      <>
+        <div>I am an anonymous component</div>
+        <theme.Button>Top-level buttons are Vanilla</theme.Button>
+      </>
+    )
+    let ExplicitlyNamedComponent = withTheme({ Button: 'button' }, 'Jerry')(
+      ({ theme }) => 
+      <>
+        <div>I am also an anonymous component, but <code>withTheme</code> knows me as "Jerry"</div>
+        <theme.Button>Jerry buttons are Strawberry!</theme.Button>
+      </>
+    )
+    let ButtonGroupGeorge = withTheme({ Button: 'button' }, 'George')(ButtonGroup)
+    return (
+      <ThemeProvider
+        theme={{
+          Button: VanillaButton,
+          'Jerry.Button': StrawberryButton,
+          'George.Button': PearButton,
+        }}
+      >
+        <UnnamedComponent />
+        <div style={{ height: 20 }} />
+        <ExplicitlyNamedComponent />
+        <div style={{ height: 20 }} />
+        <div>This component is a ButtonGroup, but <code>withTheme</code> knows it as "George":</div>
+        <ButtonGroupGeorge buttons={['George buttons are Pear!']} />
+      </ThemeProvider>
+    )
+  })
+
+storiesOf('Theme API|ThemeConsumer', module)
+  .addWithJSX('Without path', () => (
+    <ThemeProvider theme={{ Button: VanillaButton, ButtonGroup, 'ButtonGroup.Button': PearButton }}>
+      <ThemeConsumer>
+        {theme => <theme.Button>Top-level buttons are Vanilla</theme.Button>}
+      </ThemeConsumer>
+    </ThemeProvider>
+  ))
+  .addWithJSX('With path', () => (
+    <ThemeProvider theme={{ Button: VanillaButton, ButtonGroup, 'ButtonGroup.Button': GrapeButton }}>
+      {/* 
+        If ThemeConsumer is given a `path` prop containing an array, it will merge
+        all of the theme components along that path into the `theme` object that is
+        passed to its child function.
+      */}
+      <ThemeConsumer path={['ButtonGroup']}>
+        {theme => <theme.Button>ButtonGroup buttons are Grape!</theme.Button>}
+      </ThemeConsumer>
+    </ThemeProvider>
+  ))
+
+let IconButton = ({ theme, children }) => (
+  <theme.Button>
+    <theme.Icon />
+    {children}
+  </theme.Button>
+)
+let ThemedIconButton = withTheme({ Button: 'button', Icon: () => <span>[icon]</span>})(IconButton)
+
+storiesOf('Theme API|Multi-level nesting', module)
+  .addWithJSX('With theme context', () => (
+    <ThemeProvider
+      theme={{
+        Icon: () => <span>🍨</span>,
+        Button: VanillaButton,
+        'ButtonGroup.Button': ThemedIconButton,
+        'ButtonGroup.IconButton.Icon': () => <span>🍓</span>,
+        'ButtonGroup.IconButton.Button': StrawberryButton
+      }}
+    >
+      <ThemedIconButton>Top-level Icon & Button theme</ThemedIconButton>
+      <ThemedButtonGroup buttons={['ButtonGroup Icon & Button theme']} />
+    </ThemeProvider>
+  ))
+  .addWithJSX('With theme props', () => (
+    <ThemeProvider
+      theme={{
+        Icon: () => <span>🍨</span>,
+        Button: VanillaButton,
+      }}
+    >
+      <ThemedIconButton>Top-level Icon & Button theme</ThemedIconButton>
+      <ThemedButtonGroup
+        theme={{
+          Button: ThemedIconButton,
+          'IconButton.Icon': () => <span>🍇</span>,
+          'IconButton.Button': GrapeButton
+        }}
+        buttons={['ButtonGroup Icon & Button theme']}
+      />
+    </ThemeProvider>
+  ))

--- a/stories/theme.stories.js
+++ b/stories/theme.stories.js
@@ -3,46 +3,61 @@ import F from 'futil-js'
 import { storiesOf } from '@storybook/react'
 import { ThemeContext, ThemeConsumer, withTheme } from '../src/utils/theme'
 
-let withStyle = (style, Component) => props => <Component style={style} {...props} />
+let withStyle = (style, Component) => props => (
+  <Component style={style} {...props} />
+)
 
-let VanillaButton = withStyle({
-  backgroundColor: 'cornsilk',
-  border: '2px solid tan',
-  color: 'rosybrown'
-}, 'button')
+let VanillaButton = withStyle(
+  {
+    backgroundColor: 'cornsilk',
+    border: '2px solid tan',
+    color: 'rosybrown',
+  },
+  'button'
+)
 
-let StrawberryButton = withStyle({
-  backgroundColor: 'lightcoral',
-  border: '2px solid limegreen',
-  color: 'greenyellow'
-}, 'button')
+let StrawberryButton = withStyle(
+  {
+    backgroundColor: 'lightcoral',
+    border: '2px solid limegreen',
+    color: 'greenyellow',
+  },
+  'button'
+)
 
-let PearButton = withStyle({
-  border: '2px solid olive',
-  color: 'darkolivegreen',
-  backgroundColor: 'yellowgreen'
-}, 'button')
+let PearButton = withStyle(
+  {
+    border: '2px solid olive',
+    color: 'darkolivegreen',
+    backgroundColor: 'yellowgreen',
+  },
+  'button'
+)
 
-let GrapeButton = withStyle({
-  border: '2px solid blueviolet',
-  color: 'chartreuse',
-  backgroundColor: 'mediumorchid'
-}, 'button')
+let GrapeButton = withStyle(
+  {
+    border: '2px solid blueviolet',
+    color: 'chartreuse',
+    backgroundColor: 'mediumorchid',
+  },
+  'button'
+)
 
 let ThemedButton = withTheme('Button')(
   ({ theme: { Button = 'button' }, children }) => <Button>{children}</Button>
 )
 
-let ButtonGroup = ({ theme: { Button = 'button' }, buttons = [] }) => F.mapIndexed(
-  (button, i) => <Button key={i}>{button}</Button>
-)(buttons)
+let ButtonGroup = ({ theme: { Button = 'button' }, buttons = [] }) =>
+  F.mapIndexed((button, i) => <Button key={i}>{button}</Button>)(buttons)
 
 let ThemedButtonGroup = withTheme('ButtonGroup')(ButtonGroup)
 
 storiesOf('Theme API|withTheme', module)
   .addWithJSX('Setting defaults', () => {
     let DefaultVanillaButton = withTheme('ButtonGroup')(
-      ({ theme: { Button = VanillaButton }, children }) => <Button>{children}</Button>
+      ({ theme: { Button = VanillaButton }, children }) => (
+        <Button>{children}</Button>
+      )
     )
     return (
       <ThemeContext.Provider>
@@ -52,31 +67,38 @@ storiesOf('Theme API|withTheme', module)
     )
   })
   .addWithJSX('Theme precedence', () => (
-      <ThemeContext.Provider
-        value={{
-          Button: VanillaButton,
-          'ButtonGroup.Button': StrawberryButton
-        }}
-      >
-        <ThemedButtonGroup buttons={['Nested themes override top-level themes']} />
-        <ThemedButtonGroup theme={{ Button: PearButton }} buttons={['Theme props override theme context']} />
-      </ThemeContext.Provider>
-    )
-  )
+    <ThemeContext.Provider
+      value={{
+        Button: VanillaButton,
+        'ButtonGroup.Button': StrawberryButton,
+      }}
+    >
+      <ThemedButtonGroup
+        buttons={['Nested themes override top-level themes']}
+      />
+      <ThemedButtonGroup
+        theme={{ Button: PearButton }}
+        buttons={['Theme props override theme context']}
+      />
+    </ThemeContext.Provider>
+  ))
   .addWithJSX('Explicit naming', () => {
-    let UnnamedComponent = withTheme()(
-      ({ theme: { Button = 'button' } }) => 
+    let UnnamedComponent = withTheme()(({ theme: { Button = 'button' } }) => (
       <>
         <div>I am an anonymous component</div>
         <Button>Top-level buttons are Vanilla</Button>
       </>
-    )
+    ))
     let ExplicitlyNamedComponent = withTheme('Jerry')(
-      ({ theme: { Button = 'button' } }) => 
-      <>
-        <div>I am also an anonymous component, but <code>withTheme</code> knows me as "Jerry"</div>
-        <Button>Jerry buttons are Strawberry!</Button>
-      </>
+      ({ theme: { Button = 'button' } }) => (
+        <>
+          <div>
+            I am also an anonymous component, but <code>withTheme</code> knows
+            me as "Jerry"
+          </div>
+          <Button>Jerry buttons are Strawberry!</Button>
+        </>
+      )
     )
     let ButtonGroupGeorge = withTheme('George')(ButtonGroup)
     return (
@@ -91,7 +113,10 @@ storiesOf('Theme API|withTheme', module)
         <div style={{ height: 20 }} />
         <ExplicitlyNamedComponent />
         <div style={{ height: 20 }} />
-        <div>This component is a ButtonGroup, but <code>withTheme</code> knows it as "George":</div>
+        <div>
+          This component is a ButtonGroup, but <code>withTheme</code> knows it
+          as "George":
+        </div>
         <ButtonGroupGeorge buttons={['George buttons are Pear!']} />
       </ThemeContext.Provider>
     )
@@ -99,14 +124,26 @@ storiesOf('Theme API|withTheme', module)
 
 storiesOf('Theme API|ThemeConsumer', module)
   .addWithJSX('Without path', () => (
-    <ThemeContext.Provider value={{ Button: VanillaButton, ButtonGroup, 'ButtonGroup.Button': PearButton }}>
+    <ThemeContext.Provider
+      value={{
+        Button: VanillaButton,
+        ButtonGroup,
+        'ButtonGroup.Button': PearButton,
+      }}
+    >
       <ThemeConsumer>
         {theme => <theme.Button>Top-level buttons are Vanilla</theme.Button>}
       </ThemeConsumer>
     </ThemeContext.Provider>
   ))
   .addWithJSX('With path', () => (
-    <ThemeContext.Provider value={{ Button: VanillaButton, ButtonGroup, 'ButtonGroup.Button': GrapeButton }}>
+    <ThemeContext.Provider
+      value={{
+        Button: VanillaButton,
+        ButtonGroup,
+        'ButtonGroup.Button': GrapeButton,
+      }}
+    >
       {/* 
         If ThemeConsumer is given a `path` prop containing an array, it will merge
         all of the theme components along that path into the `theme` object that is
@@ -118,7 +155,10 @@ storiesOf('Theme API|ThemeConsumer', module)
     </ThemeContext.Provider>
   ))
 
-let IconButton = ({ theme: { Button = 'button', Icon = () => <span>[icon]</span> }, children }) => (
+let IconButton = ({
+  theme: { Button = 'button', Icon = () => <span>[icon]</span> },
+  children,
+}) => (
   <Button>
     <Icon />
     {children}
@@ -134,7 +174,7 @@ storiesOf('Theme API|Multi-level nesting', module)
         Button: VanillaButton,
         'ButtonGroup.Button': ThemedIconButton,
         'ButtonGroup.IconButton.Icon': () => <span>🍓</span>,
-        'ButtonGroup.IconButton.Button': StrawberryButton
+        'ButtonGroup.IconButton.Button': StrawberryButton,
       }}
     >
       <ThemedIconButton>Top-level Icon & Button theme</ThemedIconButton>
@@ -153,7 +193,7 @@ storiesOf('Theme API|Multi-level nesting', module)
         theme={{
           Button: ThemedIconButton,
           'IconButton.Icon': () => <span>🍇</span>,
-          'IconButton.Button': GrapeButton
+          'IconButton.Button': GrapeButton,
         }}
         buttons={['ButtonGroup Icon & Button theme']}
       />


### PR DESCRIPTION
For this PR, I ended up going with a super-simple but (hopefully) clear and informative set of stories to demonstrate the API, rather than eg. reproducing an actual search interface like FilterList using themeContext. The goal is for this to go into the storybook as-is and function as documentation.

Example:

<img width="903" alt="Screen Shot 2019-08-09 at 11 17 22 AM" src="https://user-images.githubusercontent.com/35466670/62789620-51665600-ba97-11e9-9769-a90d56ccb847.png">
