### PR TITLE
Use _.findLast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.55.1
+* TermsStatsTable: Fix AddAsFilter include/exclude
+
 # 1.55.0
 * Fix inputs issue with FireFox
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "1.55.0",
+  "version": "1.55.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/TermsStatsTable.js
+++ b/src/exampleTypes/TermsStatsTable.js
@@ -79,17 +79,15 @@ let TermsStatsTable = injectTreeNode(
                                   { field },
                                   tree.getNode(criteria).children
                                 )
-
                               if (
                                 !filter ||
                                 _.get('mode', filter) === 'exclude'
                               ) {
                                 await tree.add(criteria, {
-                                  key: _.uniqueId('add'),
                                   field,
                                   type: 'facet',
                                 })
-                                filter = _.find(
+                                filter = _.findLast(
                                   { field },
                                   tree.getNode(criteria).children
                                 )

--- a/stories/imdb/stories/greyVest.js
+++ b/stories/imdb/stories/greyVest.js
@@ -310,9 +310,12 @@ export default () => (
             <Tab value="analytics" label="Analytics">
               <TermsStatsTable
                 tree={tree}
+                criteria={['root', 'criteria']}
+                criteriaField="genres"
                 path={['root', 'genreScores']}
                 tableAttrs={{ className: 'gv-table' }}
                 sizeOptions={[10, 25, 50]}
+                getValue="key"
               >
                 <Column field="key" label="Genre" />
                 <Column field="count" label="Found" />


### PR DESCRIPTION
Related to https://github.com/smartprocure/bid-search/issues/3041

Fixes the include/exclude issue with the termStats table. 

Also adds the `Add as Filter` to the grayVest demo book.

![image](https://user-images.githubusercontent.com/910303/63039389-08881600-be78-11e9-9374-c4a4a09e110d.png)
