### PR TITLE
THEME DOC

### DIFF
--- a/docs/theme.md
+++ b/docs/theme.md
@@ -151,10 +151,8 @@ This section documents all of the **theme components** used by contexture-react 
 | `DateInput` | `value`, `onChange` | A generic date entry component | Date |
 | `NumberInput` | same as basic `input` | An input of type `number` | Geo, Number |
 | `TagsInput` | `tags`, `addTag`, `removeTag`, `submit`, `tagStyle`, `placeholder`, `splitCommas`, `style`, `onBlur`, `onInputChange`, `onTagClick` | A text input field that turns input into `Tag`s | TagsQuery, TagsText |
-| `PopoverTagsInput` | same as TagsInput, plus `PopoverContents` | A TagsInput that opens a popover when a tag is clicked. Uses the `TagsInput` theme component. | TagsQuery, TagsText |
 | `Tag` | `value`, `removeTag`, `tagStyle`, `onClick` | A tag component with a button to remove the tag. Used in TagsInput. | none |
-| `Picker` | `options`, `onChange` | Renders a list of selectable options | ResultTable |
-| `ModalPicker` | `options`, `onChange`, `label` | A picker inside a modal, with a button to open it. Uses `Picker`, `Button`, and `Modal` theme components. | none |
+| `NestedPicker` | `options`, `onChange` | Renders a list of selectable options | ResultTable |
 
 ### Containers
 
@@ -178,7 +176,7 @@ This section documents all of the **theme components** used by contexture-react 
 | --- | --- | --- |
 | `Globals` | `children` | This component is rendered inside `ThemeProvider`, and wraps its children. For use with other providers and/or standalone globals like stylesheets. |
 | `BarChart` | `height`, `borderColor`, `min`, `max` | Used in the DateHistogram and TermsStats example types |
-| `MissingTypeComponent` | `node` | Used as a fallback component in search interfaces when no other component is found for a node's contexture type |
+| `UnmappedNodeComponent` | `node` | Used as a fallback component in search interfaces for nodes that are not mapped to any other component |
 
 
 ## Theme Authoring

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -1,0 +1,147 @@
+# Theme API
+
+A theme in contexture-react is simply an object -- which we'll call a **theme object** for clarity -- that maps **theme keys** to React components. The theme object lives inside contexture-react's `ThemeContext`, which uses React context under the hood.
+
+Since they are really just identifiers for components, theme keys should follow the same naming conventions as React components themselves. For the purpose of consuming the API, we'll refer to a theme key together with the component it identifies as a **theme component**.
+
+## Using the Theme API
+
+To use **theme components** inside your own component definitions, your component must pull them from the theme object within contexture-react's `ThemeContext`.
+
+There are two ways to get the theme from context: the `ThemeConsumer` component, and the `withTheme` function.
+
+### ThemeConsumer
+
+The `ThemeConsumer` helper component takes a render function as its child, and passes the **theme object** from context into that function. This example demonstrates how to create a basic IconButton component using the `Icon` and `Button` **theme components**, plus `ThemeConsumer`:
+
+```jsx
+// IconButton.js
+
+import React from 'react'
+import { ThemeConsumer } from 'contexture-react/src/utils/theme'
+
+let IconButton = ({ icon, children, ...props }) => (
+  <ThemeConsumer>
+    {theme =>
+      <theme.Button {...props}>
+        <theme.Icon icon={icon} />
+        {children}
+      </theme.Button>
+    }
+  </ThemeConsumer>
+)
+export default IconButton
+```
+
+### withTheme
+
+The `withTheme` higher-order component injects the theme object from context into its component argument as the `theme` prop. Here is the same IconButton example using `withTheme`:
+
+```jsx
+// IconButton.js
+
+import React from 'react'
+import { withTheme } from 'contexture-react/src/utils/theme'
+
+let IconButton = ({ theme, icon, children, ...props }) => (
+  <theme.Button {...props}>
+    <theme.Icon icon={icon} />
+    {children}
+  </theme.Button>
+)
+export default withTheme(IconButton)
+```
+
+`ThemeConsumer` and `withTheme` both accomplish the same thing in different ways. You're free to use whichever one you like best. 🙂
+
+
+## Default theme components
+
+The default theme in contexture-react is GreyVest. The full list of **theme components** included in GreyVest is shown in the table below.
+
+| Key | Expected props | Notes |
+| --- | --- | --- |
+| `AdderPicker` | `options`, `onChange`, `label` | *this key is actually based on specific usage in the FilterAdder component, and should probably just be removed from the defaults in favor of a nested style* |
+| `BarChart` | `height`, `borderColor`, `min`, `max` | Used in the DateHistogram and TermsStats example types |
+| `Box` | `children` | A generic container element |
+| `Button` | `isActive`, `primary`, `onClick`, `children` | A generic button |
+| `Checkbox` | `checked`, `onChange` | A generic checkbox |
+| `CheckButton` | `checked`, `onClick`, `children` | A button with an `onClick` handler and an on/off state, containing a checkbox that displays this state *(this really should be extrapolated to some kind of generic BinaryStateButton)* |
+| `ExpandableTable` | `data`, `columns`, `recordKey`, `sortField`, `sortDir`, `columnSort` | Used in the TermsStatsTable and CheckableTermsStatsTable example types |
+| `Icon` | `icon`, `onClick` | A generic icon component |
+| `Fonts` | none | For holding `<link>` elements to fonts used in the theme |
+| `Input` | same as basic `input` | A generic input component |
+| `ListItem` | `children` | A generic list item |
+| `MissingTypeComponent` | `node` | Used as a fallback component in search interfaces when no other component is found for a node's contexture type |
+| `Modal` | `isOpen`, `children` | A generic modal component |
+| `PagerItem` | `active`, `disabled` | A list item for Pager components *(make this nested instead?)* |
+| `Picker` | `options`, `onChange` | Renders a list of selectable options |
+| `PickerItem` | `active`, `disabled` | A list item for Picker components *(make this nested instead?)* |
+| `Popover` | `isOpen`, `children` | A generic context-menu component |
+| `RadioList` | `options`, `value`, `onChange` | A generic list of radio buttons |
+| `Style` | none | For rendering a `<style>` block with theme-specific styles |
+| `Table` | same as basic `table` | A generic table component |
+| `TagsInput` | | Used in the TagsQuery and TagsText example types |
+| `TextHighlight` | `pattern`, `text`, `Wrap` | Renders the text given in the `text` prop, with the parts that match the `pattern` prop wrapped in the `Wrap` component |
+
+
+### The rest of the stuff currently in defaults that should probably not be there
+
+- LensInput (used in Text exampleType)
+- PopoverContents
+- RemoveTagIcon
+- SpacedList
+- Tag
+- TagComponent
+
+## Using a custom theme
+
+To create a custom theme, simply declare an object that maps one or more **theme keys** to your own components:
+
+```jsx
+// totallyTubularTheme.js
+
+import BeautifulButton from './components/BeautifulButton'
+import ImpressiveIcon from './components/ImpressiveIcon'
+
+export default {
+  Button: BeautifulButton,
+  Icon: ImpressiveIcon
+}
+```
+
+> *Note:* any theme components that are not specified in your custom theme will default to the GreyVest theme components.
+
+To use your custom theme, simply pass it to a contexture-react ThemeProvider using the `theme` prop. Here's a basic example using the IconButton component we created earlier:
+
+```jsx
+// SomeComponent.js
+
+import { ThemeProvider } from 'contexture-react/src/utils/theme'
+import theme from './totallyTubularTheme.js'
+import IconButton from './components/IconButton.js'
+
+export default props => (
+  <ThemeProvider theme={theme}>
+    {/* Some other stuff... */}
+    <IconButton icon="some-icon">
+      My icon button!
+    </IconButton>
+  </ThemeProvider>
+)
+```
+
+The IconButton component should now render your BeautifulButton and ImpressiveIcon components, rather than the GreyVest button and icon.
+
+### Using your own theme keys
+
+(nothing fancy, but there should still be an example of this)
+
+## Advanced stuff
+
+coming later
+
+### Nested themes
+
+### Overriding context with `theme` props
+

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -57,37 +57,50 @@ export default withTheme(IconButton)
 
 ## Default theme components
 
-The default theme in contexture-react is GreyVest. The full list of **theme components** included in GreyVest is shown in the table below.
+The default theme in contexture-react is GreyVest. The full list of **theme components** included in GreyVest is shown below.
+
+### Inputs
 
 | Key | Expected props | Notes |
 | --- | --- | --- |
-| `AdderPicker` | `options`, `onChange`, `label` | *this key is actually based on specific usage in the FilterAdder component, and should probably just be removed from the defaults in favor of a nested style* |
-| `BarChart` | `height`, `borderColor`, `min`, `max` | Used in the DateHistogram and TermsStats example types |
-| `Box` | `children` | A generic container element |
 | `Button` | `isActive`, `primary`, `onClick`, `children` | A generic button. Used in the Facet and Number example types. |
 | `Checkbox` | `checked`, `onChange` | A generic checkbox. Used in the CheckableResultTable and Facet example types. |
 | `CheckButton` | `checked`, `onClick`, `children` | A button with an `onClick` handler and an on/off state, containing a checkbox that displays this state *(this really should be extrapolated to some kind of generic BinaryStateButton)* |
-| `ExpandableTable` | `data`, `columns`, `recordKey`, `sortField`, `sortDir`, `columnSort` | Used in the TermsStatsTable and CheckableTermsStatsTable example types. |
+| `Link` | | Used in the ResultPager example type |
 | `Icon` | `icon`, `onClick` | A generic icon component. Used in the ResultPager example type. |
-| `Fonts` | none | For holding `<link>` elements to fonts used in the theme |
-| `ListItem` | `children` | A generic list item |
-| `MissingTypeComponent` | `node` | Used as a fallback component in search interfaces when no other component is found for a node's contexture type |
-| `Modal` | `isOpen`, `children` | A generic modal component |
-| `PagerItem` | `active`, `disabled` | A list item for Pager components *(make this nested instead?)*. Used in the ResultPager example type. |
-| `Picker` | `options`, `onChange` | Renders a list of selectable options |
-| `PickerItem` | `active`, `disabled` | A list item for Picker components *(make this nested instead?)* |
-| `Popover` | `isOpen`, `children` | A generic context-menu component |
 | `RadioList` | `options`, `value`, `onChange` | A generic list of radio buttons. Used in the Bool, Exists, and Facet example types. |
-| `Style` | none | For rendering a `<style>` block with theme-specific styles |
-| `Table` | same as basic `table` | A generic table component |
-| `Tag` | `value`, `removeTag`, `tagStyle`, `onClick` | Used in TagsInput |
-| `TagsInput` | | Used in the TagsQuery and TagsText example types |
-| `TextHighlight` | `pattern`, `text`, `Wrap` | Renders the text given in the `text` prop, with the parts that match the `pattern` prop wrapped in the `Wrap` component |
-| `TextInput` |  same as basic `input` | A generic text input component. Used in the Facet and Query example types. |
-| `ResultTable` | | Used in the CheckableResultTable example type |
-| `DateInput` | | Used in the Date example type |
 | `Select` | | Used in the Date, DateRangePicker, and Geo example types |
+| `TextInput` |  same as basic `input` | A generic text input component. Used in the Facet and Query example types. |
+| `DateInput` | | Used in the Date example type |
 | `NumberInput` | | Used in the Geo and Number example types |
+| `TagsInput` | | Used in the TagsQuery and TagsText example types |
+| `Picker` | `options`, `onChange` | Renders a list of selectable options |
+| `AdderPicker` | `options`, `onChange`, `label` | *this key is actually based on specific usage in the FilterAdder component, and should probably just be removed from the defaults in favor of a nested style* |
+
+### Containers
+
+| Key | Expected props | Notes |
+| --- | --- | --- |
+| `Box` | `children` | A generic container element |
+| `Modal` | `isOpen`, `children` | A generic modal component |
+| `Popover` | `isOpen`, `children` | A generic context-menu component |
+| `ListItem` | `children` | A generic list item |
+| `PagerItem` | `active`, `disabled` | A list item for Pager components *(make this nested instead?)*. Used in the ResultPager example type. |
+| `PickerItem` | `active`, `disabled` | A list item for Picker components *(make this nested instead?)* |
+| `Tag` | `value`, `removeTag`, `tagStyle`, `onClick` | Used in TagsInput |
+| `TextHighlight` | `pattern`, `text`, `Wrap` | Renders the text given in the `text` prop, with the parts that match the `pattern` prop wrapped in the `Wrap` component |
+| `Table` | same as basic `table` | A generic table component |
+| `ExpandableTable` | `data`, `columns`, `recordKey`, `sortField`, `sortDir`, `columnSort` | Used in the TermsStatsTable and CheckableTermsStatsTable example types. |
+
+### Other
+
+| Key | Expected props | Notes |
+| --- | --- | --- |
+| `Fonts` | none | For holding `<link>` elements to fonts used in the theme |
+| `Style` | none | For rendering a `<style>` block with theme-specific styles |
+| `BarChart` | `height`, `borderColor`, `min`, `max` | Used in the DateHistogram and TermsStats example types |
+| `MissingTypeComponent` | `node` | Used as a fallback component in search interfaces when no other component is found for a node's contexture type |
+
 
 ## Using a custom theme
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -4,7 +4,7 @@ A theme in contexture-react is simply an object -- which we'll call a **theme ob
 
 Since they are really just identifiers for components, theme keys should follow the same naming conventions as React components themselves. For the purpose of consuming the API, we'll refer to a theme key together with the component it identifies as a **theme component**.
 
-The contexture-react theme API supports two methods of overriding themes: on a per-instance basis by passing a **theme object** as a prop, and on a per-key basis through **nested themes** (which we'll talk more about in the [Nested themes](#Nested%20themes) section).
+The contexture-react theme API supports two methods of overriding themes: on a per-instance basis by passing a **theme object** as a prop, and on a per-key basis through **nested themes** (which we'll talk more about in the [Nested themes](#nested-themes) section).
 
 ## Initializing the Theme API
 
@@ -25,7 +25,7 @@ function App() {
 
 `ThemeProvider` accepts a `theme` prop containing a **theme object**.
 
-> ℹ️ **Note:** contexture-react provides a basic **fallback theme** to all components that consume its theme API, to help prevent render errors if you forget to initialize `ThemeProvider` with a `theme` prop (or even leave out `ThemeProvider` altogether 😱). See the [Default theme components](#Default%20theme%20components) section for more details.
+> ℹ️ **Note:** contexture-react provides a basic **fallback theme** to all components that consume its theme API, to help prevent render errors if you forget to initialize `ThemeProvider` with a `theme` prop (or even leave out `ThemeProvider` altogether 😱). See the [Default theme components](#default-theme-components) section for more details.
 
 ### Globals
 
@@ -75,7 +75,7 @@ let IconButton = ({ icon, children, ...props }) => (
 export default IconButton
 ```
 
-The `ThemeConsumer` component takes two optional props: `name`, which accepts a string and can be used to supply a name for [nested theming](#Nested%20themes), and `theme`, which accepts a **theme object** that is merged with the context theme, overriding its values where applicable.
+The `ThemeConsumer` component takes two optional props: `name`, which accepts a string and can be used to supply a name for [nested theming](#nested-themes), and `theme`, which accepts a **theme object** that is merged with the context theme, overriding its values where applicable.
 
 When a nested theme is merged, or when the context theme is overridden by a `theme` prop, `ThemeConsumer` *creates a theme provider with the new theme object*. This ensures that that any of its children or grandchildren or grandchildren that consume the theme API will be able to access the updated theme object from context.
 
@@ -100,7 +100,7 @@ export default withTheme(IconButton)
 
 Directly passing a `theme` prop to the `withTheme` component -- in our case, the `IconButton` component that is exported from this file -- overrides the context theme for the component and its children, just like `ThemeConsumer`'s `theme` prop does.
 
-If you need to give your component a `name` for nested themes, use the `withNamedTheme` function instead. (See the [Nested themes](#Nested%20themes) section for more details.)
+If you need to give your component a `name` for nested themes, use the `withNamedTheme` function instead. (See the [Nested themes](#nested-themes) section for more details.)
 
 `ThemeConsumer` and `withTheme` both accomplish the same thing in different ways. You're free to use whichever one you like best. 🙂
 
@@ -197,7 +197,7 @@ export default {
 }
 ```
 
-> ℹ️ **Note:** Any theme component that is not specified in your custom theme will default to a generic fallback component, as long as its key is in the [list above](#Default%20theme%20components).
+> ℹ️ **Note:** Any theme component that is not specified in your custom theme will default to a generic fallback component, as long as its key is in the [list above](#default-theme-components).
 
 To use your custom theme, pass it to a contexture-react `ThemeProvider` using the `theme` prop. Here's a basic example using the `IconButton` component we created earlier:
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -136,7 +136,7 @@ These potential modifications to the context theme *do* affect `useTheme`'s retu
 
 ## Default theme components
 
-This section documents all of the **theme components** used by contexture-react itself, along with the API for each one. The items in this list all have fallback components available, so 
+This section documents all of the **theme components** used by contexture-react itself, along with the API for each one. The **theme keys** in this list all have fallback components available, so overriding them in custom themes is optional.
 
 ### Inputs
 
@@ -150,7 +150,7 @@ This section documents all of the **theme components** used by contexture-react 
 | `TextInput` |  same as basic `input` | A generic text input component | Facet, Query, TermsStatsTable, Text |
 | `DateInput` | `value`, `onChange` | A generic date entry component | Date |
 | `NumberInput` | same as basic `input` | An input of type `number` | Geo, Number |
-| `TagsInput` | `tags`, `addTag`, `removeTagp`, `submit`, `tagStyle`, `placeholder`, `splitCommas`, `style`, `onBlur`, `onInputChange`, `onTagClick` | A text input field that turns input into `Tag`s | TagsQuery, TagsText |
+| `TagsInput` | `tags`, `addTag`, `removeTag`, `submit`, `tagStyle`, `placeholder`, `splitCommas`, `style`, `onBlur`, `onInputChange`, `onTagClick` | A text input field that turns input into `Tag`s | TagsQuery, TagsText |
 | `PopoverTagsInput` | same as TagsInput, plus `PopoverContents` | A TagsInput that opens a popover when a tag is clicked. Uses the `TagsInput` theme component. | TagsQuery, TagsText |
 | `Tag` | `value`, `removeTag`, `tagStyle`, `onClick` | A tag component with a button to remove the tag. Used in TagsInput. | none |
 | `Picker` | `options`, `onChange` | Renders a list of selectable options | ResultTable |

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -65,32 +65,30 @@ The default theme in contexture-react is GreyVest. The full list of **theme comp
 | --- | --- | --- | --- |
 | `Button` | `isActive`, `primary`, `onClick`, `children` | A generic button | Facet, Number, TagsQuery, TermsStatsTable |
 | `Checkbox` | `checked`, `onChange` | A generic checkbox | CheckableResultTable, CheckableTermsStatsTable, Facet, TagsQuery |
-| `CheckButton` | `checked`, `onClick`, `children` | A button with an `onClick` handler and an on/off state, containing a checkbox that displays this state *(this really should be extrapolated to some kind of generic BinaryStateButton)* |
-| `Link` | same as basic `a` |  | ResultPager |
 | `Icon` | `icon`, `onClick` | A generic icon component | ResultPager, ResultTable |
-| `RadioList` | `options`, `value`, `onChange` | A generic list of radio buttons | Bool, Date, Exists, Facet, TagsQuery |
-| `Select` | same as `select` | A generic dropdown select component | Date, DateRangePicker, Geo, TagsJoinPicker, TagsQuery, TagsText, TermsStatsTable |
+| `RadioList` | `options`, `value`, `onChange` | A generic list of radio buttons. The `options` prop is an array of `{ value, label }` objects. | Bool, Date, Exists, Facet, TagsQuery |
+| `Select` | same as basic `select` | A generic dropdown select component | Date, DateRangePicker, Geo, TagsJoinPicker, TagsQuery, TagsText, TermsStatsTable |
 | `TextInput` |  same as basic `input` | A generic text input component | Facet, Query, TermsStatsTable, Text |
-| `DateInput` | | A generic date entry component | Date |
-| `NumberInput` | | An input of type `number` | Geo, Number |
-| `TagsInput` | | A text input field that turns input into `Tag`s | TagsQuery, TagsText |
-| `Tag` | `value`, `removeTag`, `tagStyle`, `onClick` | A tag component with a button to remove the tag. Used in TagsInput. |
+| `DateInput` | `value`, `onChange` | A generic date entry component | Date |
+| `NumberInput` | same as basic `input` | An input of type `number` | Geo, Number |
+| `TagsInput` | `tags`, `addTag`, `removeTagp`, `submit`, `tagStyle`, `placeholder`, `splitCommas`, `style`, `onBlur`, `onInputChange`, `onTagClick` | A text input field that turns input into `Tag`s | TagsQuery, TagsText |
+| `PopoverTagsInput` | same as TagsInput, plus `PopoverContents` | A TagsInput that opens a popover when a tag is clicked. Uses the `TagsInput` theme component. | TagsQuery, TagsText |
+| `Tag` | `value`, `removeTag`, `tagStyle`, `onClick` | A tag component with a button to remove the tag. Used in TagsInput. | none |
 | `Picker` | `options`, `onChange` | Renders a list of selectable options | ResultTable |
-| `AdderPicker` | `options`, `onChange`, `label` | *this key is actually based on specific usage in the FilterAdder component, and should probably just be removed from the defaults in favor of a nested style* |
+| `ModalPicker` | `options`, `onChange`, `label` | A picker inside a modal, with a button to open it. Uses `Picker`, `Button`, and `Modal` theme components. | none |
 
 ### Containers
 
 | Key | Expected props | Notes | ExampleTypes usage |
 | --- | --- | --- | --- |
-| `Box` | `children` | A generic container element |
+| `Box` | `children` | A generic container element | none |
 | `Modal` | `isOpen`, `children` | A generic modal component | ResultTable |
 | `Popover` | `isOpen`, `children` | A generic context-menu component | ResultTable |
 | `ListItem` | `children` | A generic list item | ResultTable |
-| `PagerItem` | `active`, `disabled` | A list item for Pager components *(make this nested instead?)* | ResultPager |
-| `PickerItem` | `active`, `disabled` | A list item for Picker components *(make this nested instead?)* |
-| `TextHighlight` | `pattern`, `text`, `Wrap` | Renders the text given in the `text` prop, with the parts that match the `pattern` prop wrapped in the `Wrap` component |
-| `Table` | same as basic `table` | A generic table component |
-| `ExpandableTable` | `data`, `columns`, `recordKey`, `sortField`, `sortDir`, `columnSort` | | TermsStatsTable, CheckableTermsStatsTable |
+| `PagerItem` | `active`, `disabled` | A list item for Pager components | ResultPager |
+| `PickerItem` | `active`, `disabled` | A list item for Picker components | none |
+| `TextHighlight` | `pattern`, `text`, `Wrap` | Renders the text given in the `text` prop, with the parts that match the `pattern` prop wrapped in the `Wrap` component | none |
+| `Table` | same as basic `table` | A generic table component | ResultTable |
 | `TableCell` | same as `td` | A generic table cell | ResultTable |
 | `TableHeaderCell` | same as `th` | A generic table header | ResultTable |
 | `TableRow` | same as `tr` | A generic table row | ResultTable |
@@ -99,8 +97,7 @@ The default theme in contexture-react is GreyVest. The full list of **theme comp
 
 | Key | Expected props | Notes |
 | --- | --- | --- |
-| `Fonts` | none | For holding `<link>` elements to fonts used in the theme |
-| `Style` | none | For rendering a `<style>` block with theme-specific styles |
+| `Globals` | `children` | This component is rendered inside `ThemeProvider`, and wraps its children. For use with other providers and/or standalone globals like stylesheets. |
 | `BarChart` | `height`, `borderColor`, `min`, `max` | Used in the DateHistogram and TermsStats example types |
 | `MissingTypeComponent` | `node` | Used as a fallback component in search interfaces when no other component is found for a node's contexture type |
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -64,26 +64,30 @@ The default theme in contexture-react is GreyVest. The full list of **theme comp
 | `AdderPicker` | `options`, `onChange`, `label` | *this key is actually based on specific usage in the FilterAdder component, and should probably just be removed from the defaults in favor of a nested style* |
 | `BarChart` | `height`, `borderColor`, `min`, `max` | Used in the DateHistogram and TermsStats example types |
 | `Box` | `children` | A generic container element |
-| `Button` | `isActive`, `primary`, `onClick`, `children` | A generic button |
-| `Checkbox` | `checked`, `onChange` | A generic checkbox |
+| `Button` | `isActive`, `primary`, `onClick`, `children` | A generic button. Used in the Facet and Number example types. |
+| `Checkbox` | `checked`, `onChange` | A generic checkbox. Used in the CheckableResultTable and Facet example types. |
 | `CheckButton` | `checked`, `onClick`, `children` | A button with an `onClick` handler and an on/off state, containing a checkbox that displays this state *(this really should be extrapolated to some kind of generic BinaryStateButton)* |
-| `ExpandableTable` | `data`, `columns`, `recordKey`, `sortField`, `sortDir`, `columnSort` | Used in the TermsStatsTable and CheckableTermsStatsTable example types |
-| `Icon` | `icon`, `onClick` | A generic icon component |
+| `ExpandableTable` | `data`, `columns`, `recordKey`, `sortField`, `sortDir`, `columnSort` | Used in the TermsStatsTable and CheckableTermsStatsTable example types. |
+| `Icon` | `icon`, `onClick` | A generic icon component. Used in the ResultPager example type. |
 | `Fonts` | none | For holding `<link>` elements to fonts used in the theme |
-| `Input` | same as basic `input` | A generic input component |
 | `ListItem` | `children` | A generic list item |
 | `MissingTypeComponent` | `node` | Used as a fallback component in search interfaces when no other component is found for a node's contexture type |
 | `Modal` | `isOpen`, `children` | A generic modal component |
-| `PagerItem` | `active`, `disabled` | A list item for Pager components *(make this nested instead?)* |
+| `PagerItem` | `active`, `disabled` | A list item for Pager components *(make this nested instead?)*. Used in the ResultPager example type. |
 | `Picker` | `options`, `onChange` | Renders a list of selectable options |
 | `PickerItem` | `active`, `disabled` | A list item for Picker components *(make this nested instead?)* |
 | `Popover` | `isOpen`, `children` | A generic context-menu component |
-| `RadioList` | `options`, `value`, `onChange` | A generic list of radio buttons |
+| `RadioList` | `options`, `value`, `onChange` | A generic list of radio buttons. Used in the Bool, Exists, and Facet example types. |
 | `Style` | none | For rendering a `<style>` block with theme-specific styles |
 | `Table` | same as basic `table` | A generic table component |
 | `Tag` | `value`, `removeTag`, `tagStyle`, `onClick` | Used in TagsInput |
 | `TagsInput` | | Used in the TagsQuery and TagsText example types |
 | `TextHighlight` | `pattern`, `text`, `Wrap` | Renders the text given in the `text` prop, with the parts that match the `pattern` prop wrapped in the `Wrap` component |
+| `TextInput` |  same as basic `input` | A generic text input component. Used in the Facet and Query example types. |
+| `ResultTable` | | Used in the CheckableResultTable example type |
+| `DateInput` | | Used in the Date example type |
+| `Select` | | Used in the Date, DateRangePicker, and Geo example types |
+| `NumberInput` | | Used in the Geo and Number example types |
 
 ## Using a custom theme
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -81,18 +81,9 @@ The default theme in contexture-react is GreyVest. The full list of **theme comp
 | `RadioList` | `options`, `value`, `onChange` | A generic list of radio buttons |
 | `Style` | none | For rendering a `<style>` block with theme-specific styles |
 | `Table` | same as basic `table` | A generic table component |
+| `Tag` | `value`, `removeTag`, `tagStyle`, `onClick` | Used in TagsInput |
 | `TagsInput` | | Used in the TagsQuery and TagsText example types |
 | `TextHighlight` | `pattern`, `text`, `Wrap` | Renders the text given in the `text` prop, with the parts that match the `pattern` prop wrapped in the `Wrap` component |
-
-
-### The rest of the stuff currently in defaults that should probably not be there
-
-- LensInput (used in Text exampleType)
-- PopoverContents
-- RemoveTagIcon
-- SpacedList
-- Tag
-- TagComponent
 
 ## Using a custom theme
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -57,40 +57,43 @@ export default withTheme(IconButton)
 
 ## Default theme components
 
-The default theme in contexture-react is GreyVest. The full list of **theme components** included in GreyVest is shown below.
+The default theme in contexture-react is GreyVest. The full list of **theme components** included in GreyVest is shown in the table below.
 
 ### Inputs
 
-| Key | Expected props | Notes |
-| --- | --- | --- |
-| `Button` | `isActive`, `primary`, `onClick`, `children` | A generic button. Used in the Facet and Number example types. |
-| `Checkbox` | `checked`, `onChange` | A generic checkbox. Used in the CheckableResultTable and Facet example types. |
+| Key | Expected props | Notes | ExampleTypes usage |
+| --- | --- | --- | --- |
+| `Button` | `isActive`, `primary`, `onClick`, `children` | A generic button | Facet, Number, TagsQuery, TermsStatsTable |
+| `Checkbox` | `checked`, `onChange` | A generic checkbox | CheckableResultTable, CheckableTermsStatsTable, Facet, TagsQuery |
 | `CheckButton` | `checked`, `onClick`, `children` | A button with an `onClick` handler and an on/off state, containing a checkbox that displays this state *(this really should be extrapolated to some kind of generic BinaryStateButton)* |
-| `Link` | | Used in the ResultPager example type |
-| `Icon` | `icon`, `onClick` | A generic icon component. Used in the ResultPager example type. |
-| `RadioList` | `options`, `value`, `onChange` | A generic list of radio buttons. Used in the Bool, Exists, and Facet example types. |
-| `Select` | | Used in the Date, DateRangePicker, and Geo example types |
-| `TextInput` |  same as basic `input` | A generic text input component. Used in the Facet and Query example types. |
-| `DateInput` | | Used in the Date example type |
-| `NumberInput` | | Used in the Geo and Number example types |
-| `TagsInput` | | Used in the TagsQuery and TagsText example types |
-| `Picker` | `options`, `onChange` | Renders a list of selectable options |
+| `Link` | same as basic `a` |  | ResultPager |
+| `Icon` | `icon`, `onClick` | A generic icon component | ResultPager, ResultTable |
+| `RadioList` | `options`, `value`, `onChange` | A generic list of radio buttons | Bool, Date, Exists, Facet, TagsQuery |
+| `Select` | same as `select` | A generic dropdown select component | Date, DateRangePicker, Geo, TagsJoinPicker, TagsQuery, TagsText, TermsStatsTable |
+| `TextInput` |  same as basic `input` | A generic text input component | Facet, Query, TermsStatsTable, Text |
+| `DateInput` | | A generic date entry component | Date |
+| `NumberInput` | | An input of type `number` | Geo, Number |
+| `TagsInput` | | A text input field that turns input into `Tag`s | TagsQuery, TagsText |
+| `Tag` | `value`, `removeTag`, `tagStyle`, `onClick` | A tag component with a button to remove the tag. Used in TagsInput. |
+| `Picker` | `options`, `onChange` | Renders a list of selectable options | ResultTable |
 | `AdderPicker` | `options`, `onChange`, `label` | *this key is actually based on specific usage in the FilterAdder component, and should probably just be removed from the defaults in favor of a nested style* |
 
 ### Containers
 
-| Key | Expected props | Notes |
-| --- | --- | --- |
+| Key | Expected props | Notes | ExampleTypes usage |
+| --- | --- | --- | --- |
 | `Box` | `children` | A generic container element |
-| `Modal` | `isOpen`, `children` | A generic modal component |
-| `Popover` | `isOpen`, `children` | A generic context-menu component |
-| `ListItem` | `children` | A generic list item |
-| `PagerItem` | `active`, `disabled` | A list item for Pager components *(make this nested instead?)*. Used in the ResultPager example type. |
+| `Modal` | `isOpen`, `children` | A generic modal component | ResultTable |
+| `Popover` | `isOpen`, `children` | A generic context-menu component | ResultTable |
+| `ListItem` | `children` | A generic list item | ResultTable |
+| `PagerItem` | `active`, `disabled` | A list item for Pager components *(make this nested instead?)* | ResultPager |
 | `PickerItem` | `active`, `disabled` | A list item for Picker components *(make this nested instead?)* |
-| `Tag` | `value`, `removeTag`, `tagStyle`, `onClick` | Used in TagsInput |
 | `TextHighlight` | `pattern`, `text`, `Wrap` | Renders the text given in the `text` prop, with the parts that match the `pattern` prop wrapped in the `Wrap` component |
 | `Table` | same as basic `table` | A generic table component |
-| `ExpandableTable` | `data`, `columns`, `recordKey`, `sortField`, `sortDir`, `columnSort` | Used in the TermsStatsTable and CheckableTermsStatsTable example types. |
+| `ExpandableTable` | `data`, `columns`, `recordKey`, `sortField`, `sortDir`, `columnSort` | | TermsStatsTable, CheckableTermsStatsTable |
+| `TableCell` | same as `td` | A generic table cell | ResultTable |
+| `TableHeaderCell` | same as `th` | A generic table header | ResultTable |
+| `TableRow` | same as `tr` | A generic table row | ResultTable |
 
 ### Other
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -4,21 +4,63 @@ A theme in contexture-react is simply an object -- which we'll call a **theme ob
 
 Since they are really just identifiers for components, theme keys should follow the same naming conventions as React components themselves. For the purpose of consuming the API, we'll refer to a theme key together with the component it identifies as a **theme component**.
 
-## Using the Theme API
+The contexture-react theme API supports two methods of overriding themes: on a per-instance basis by passing a **theme object** as a prop, and on a per-key basis through **nested themes** (which we'll talk more about in the [Nested themes](#Nested%20themes) section).
 
-To use **theme components** inside your own component definitions, your component must pull them from the theme object within contexture-react's `ThemeContext`.
+## Initializing the Theme API
 
-There are two ways to get the theme from context: the `ThemeConsumer` component, and the `withTheme` function.
+To start using themes, simply wrap your application in contexture-react's `ThemeProvider`:
+
+```jsx
+import { ThemeProvider } from 'contexture-react'
+import { greyVest } from 'contexture-react/themes' // or use your own!
+
+function App() {
+  return (
+    <ThemeProvider theme={greyVest}>
+      {/* rest of your app */}
+    </ThemeProvider>
+  );
+}
+```
+
+`ThemeProvider` accepts a `theme` prop containing a **theme object**.
+
+> ℹ️ **Note:** contexture-react provides a basic **fallback theme** to all components that consume its theme API, to help prevent render errors if you forget to initialize `ThemeProvider` with a `theme` prop (or even leave out `ThemeProvider` altogether 😱). See the [Default theme components](#Default%20theme%20components) section for more details.
+
+### Globals
+
+`Globals` is a special **theme key** that allows you to include global components such as styles, fonts, or other providers within your theme. When `ThemeProvider` is rendered, it *wraps its own children in the `Globals` **theme component*** if one exists on the provided theme:
+
+```jsx
+export let ThemeProvider = ({ theme, children }) => {
+  theme = { ...defaultTheme, ...theme }
+  let Globals = theme.Globals || React.Fragment
+  return (
+    <ThemeContext.Provider value={theme}>
+      <Globals>{children}</Globals>
+    </ThemeContext.Provider>
+  )
+}
+```
+<sup>^ The actual source code for ThemeProvider</source>
+
+> ⚠️ **IMPORTANT:** If you use a `Globals` theme component, it ***must*** handle its `children` prop, or nothing inside of `ThemeProvider` will render!
+
+## Consuming the Theme API
+
+To use **theme components** inside your own component definitions, your component must pull them from the **theme object** within `ThemeContext`.
+
+There are three ways to get the theme from context: the `ThemeConsumer` component, the `withTheme` function, and the `useTheme` hook.
 
 ### ThemeConsumer
 
-The `ThemeConsumer` helper component takes a render function as its child, and passes the **theme object** from context into that function. This example demonstrates how to create a basic IconButton component using the `Icon` and `Button` **theme components**, plus `ThemeConsumer`:
+The `ThemeConsumer` helper component takes a render function as its child, and passes the **theme object** from context into that function. This example demonstrates how to create a basic `IconButton` component using the `Icon` and `Button` **theme components**, plus `ThemeConsumer`:
 
 ```jsx
 // IconButton.js
 
 import React from 'react'
-import { ThemeConsumer } from 'contexture-react/src/utils/theme'
+import { ThemeConsumer } from 'contexture-react'
 
 let IconButton = ({ icon, children, ...props }) => (
   <ThemeConsumer>
@@ -33,15 +75,19 @@ let IconButton = ({ icon, children, ...props }) => (
 export default IconButton
 ```
 
+The `ThemeConsumer` component takes two optional props: `name`, which accepts a string and can be used to supply a name for [nested theming](#Nested%20themes), and `theme`, which accepts a **theme object** that is merged with the context theme, overriding its values where applicable.
+
+When a nested theme is merged, or when the context theme is overridden by a `theme` prop, `ThemeConsumer` *creates a theme provider with the new theme object*. This ensures that that any of its children or grandchildren or grandchildren that consume the theme API will be able to access the updated theme object from context.
+
 ### withTheme
 
-The `withTheme` higher-order component injects the theme object from context into its component argument as the `theme` prop. Here is the same IconButton example using `withTheme`:
+The `withTheme` higher-order component injects the theme object from context into its component argument as a `theme` prop. Here is the same `IconButton` example using `withTheme`:
 
 ```jsx
 // IconButton.js
 
 import React from 'react'
-import { withTheme } from 'contexture-react/src/utils/theme'
+import { withTheme } from 'contexture-react'
 
 let IconButton = ({ theme, icon, children, ...props }) => (
   <theme.Button {...props}>
@@ -52,18 +98,51 @@ let IconButton = ({ theme, icon, children, ...props }) => (
 export default withTheme(IconButton)
 ```
 
+Directly passing a `theme` prop to the `withTheme` component -- in our case, the `IconButton` component that is exported from this file -- overrides the context theme for the component and its children, just like `ThemeConsumer`'s `theme` prop does.
+
+If you need to give your component a `name` for nested themes, use the `withNamedTheme` function instead. (See the [Nested themes](#Nested%20themes) section for more details.)
+
 `ThemeConsumer` and `withTheme` both accomplish the same thing in different ways. You're free to use whichever one you like best. 🙂
 
+### useTheme
+
+The `useTheme` hook functions just like the other two methods, with one important exception: *`useTheme` does **not** create a new theme provider, so it cannot affect the theme context for the component's children.*
+
+Here's the IconButton example with `useTheme`:
+
+```jsx
+// IconButton.js
+
+import React from 'react'
+import { useTheme } from 'contexture-react'
+
+let IconButton = ({ icon, children, ...props }) => {
+  let theme = useTheme()
+  return (
+    <theme.Button {...props}>
+      <theme.Icon icon={icon} />
+      {children}
+    </theme.Button>
+  )
+}
+export default IconButton
+```
+
+`useTheme` takes two optional arguments, `name` and `theme`, and returns a **theme object**. Just like with `ThemeConsumer`, the `name` parameter accepts a string and is used to merge nested themes, while the `theme` parameter accepts a **theme object** that is used to selectively override the context theme.
+
+These potential modifications to the context theme *do* affect `useTheme`'s return value, so they are still useful for the component itself. However, as noted, `useTheme` does *not* create a new theme provider for its children, so any overrides will *not* be propagated further down the component tree.
+
+> 💁 **Trivia:** The `useTheme` hook is used internally by both `ThemeConsumer` and `withTheme`.
 
 ## Default theme components
 
-The default theme in contexture-react is GreyVest. The full list of **theme components** included in GreyVest is shown in the table below.
+This section documents all of the **theme components** used by contexture-react itself, along with the API for each one. The items in this list all have fallback components available, so 
 
 ### Inputs
 
 | Key | Expected props | Notes | ExampleTypes usage |
 | --- | --- | --- | --- |
-| `Button` | `isActive`, `primary`, `onClick`, `children` | A generic button | Facet, Number, TagsQuery, TermsStatsTable |
+| `Button` | `isActive`, `primary`, `onClick`, `children` | A generic button | Facet, Number, TagsQuery, TermsStatsTable |s
 | `Checkbox` | `checked`, `onChange` | A generic checkbox | CheckableResultTable, CheckableTermsStatsTable, Facet, TagsQuery |
 | `Icon` | `icon`, `onClick` | A generic icon component | ResultPager, ResultTable |
 | `RadioList` | `options`, `value`, `onChange` | A generic list of radio buttons. The `options` prop is an array of `{ value, label }` objects. | Bool, Date, Exists, Facet, TagsQuery |
@@ -84,7 +163,7 @@ The default theme in contexture-react is GreyVest. The full list of **theme comp
 | `Box` | `children` | A generic container element | none |
 | `Modal` | `isOpen`, `children` | A generic modal component | ResultTable |
 | `Popover` | `isOpen`, `children` | A generic context-menu component | ResultTable |
-| `ListItem` | `children` | A generic list item | ResultTable |
+| `DropdownItem` | `children` | A generic list item used in dropdown menus | ResultTable |
 | `PagerItem` | `active`, `disabled` | A list item for Pager components | ResultPager |
 | `PickerItem` | `active`, `disabled` | A list item for Picker components | none |
 | `TextHighlight` | `pattern`, `text`, `Wrap` | Renders the text given in the `text` prop, with the parts that match the `pattern` prop wrapped in the `Wrap` component | none |
@@ -102,9 +181,9 @@ The default theme in contexture-react is GreyVest. The full list of **theme comp
 | `MissingTypeComponent` | `node` | Used as a fallback component in search interfaces when no other component is found for a node's contexture type |
 
 
-## Using a custom theme
+## Theme Authoring
 
-To create a custom theme, simply declare an object that maps one or more **theme keys** to your own components:
+To create a theme, simply declare an object that maps one or more **theme keys** to your own components:
 
 ```jsx
 // totallyTubularTheme.js
@@ -118,19 +197,19 @@ export default {
 }
 ```
 
-> *Note:* any theme components that are not specified in your custom theme will default to the GreyVest theme components.
+> ℹ️ **Note:** Any theme component that is not specified in your custom theme will default to a generic fallback component, as long as its key is in the [list above](#Default%20theme%20components).
 
-To use your custom theme, simply pass it to a contexture-react ThemeProvider using the `theme` prop. Here's a basic example using the IconButton component we created earlier:
+To use your custom theme, pass it to a contexture-react `ThemeProvider` using the `theme` prop. Here's a basic example using the `IconButton` component we created earlier:
 
 ```jsx
 // SomeComponent.js
 
 import { ThemeProvider } from 'contexture-react/src/utils/theme'
-import theme from './totallyTubularTheme.js'
+import totallyTubularTheme from './totallyTubularTheme.js'
 import IconButton from './components/IconButton.js'
 
 export default props => (
-  <ThemeProvider theme={theme}>
+  <ThemeProvider theme={totallyTubularTheme}>
     {/* Some other stuff... */}
     <IconButton icon="some-icon">
       My icon button!
@@ -139,17 +218,82 @@ export default props => (
 )
 ```
 
-The IconButton component should now render your BeautifulButton and ImpressiveIcon components, rather than the GreyVest button and icon.
+The `IconButton` component should now render your `BeautifulButton` and `ImpressiveIcon` components, rather than the default button and icon.
 
-### Using your own theme keys
+## Nested themes
 
-(nothing fancy, but there should still be an example of this)
+A **nested theme** is a special case of **theme component**: one whose **theme key** is a *path* rather than a *string*. Nested themes allow a single **theme key** -- like, say, `Icon` -- to have an alternate value for some specific parent or chain of parents, in addition to its normal value.
 
-## Advanced stuff
+To illustrate nested themes, we'll be modifying our `totallyTubularTheme` from the previous section to use a **nested key** for `IconButton`'s `Icon`, in addition to the standard `Icon`:
 
-coming later
+```jsx
+// totallyTubularTheme.js
 
-### Nested themes
+import BeautifulButton from './components/BeautifulButton'
+import ImpressiveIcon from './components/ImpressiveIcon'
+import InvisibleIcon from './components/InvisibleIcon'
 
-### Overriding context with `theme` props
+export default {
+  Button: BeautifulButton,
+  Icon: ImpressiveIcon,
+  'IconButton.Icon': InvisibleIcon
+}
+```
 
+This theme object tells contexture-react to use `InvisibleIcon` as the `Icon` component for `IconButton` and its children, while still using `ImpressiveIcon` as the `Icon` component throughout the rest of our app.
+
+Now that our theme is configured to use a nested theme for `IconButton`, we need to assign a name to our component in order to use it.
+
+### Naming components
+
+> ⚠️ **IMPORTANT:** *Only named components support nested themes.* A component ***must*** be given a `name` in order to support nested themes.
+
+When a component is given a `name` through `ThemeConsumer`, `withNamedTheme`, or `useTheme`, contexture-react performs an additional step after it fetches the theme from context: it looks for **nested keys** that start with that `name`, chops the `name` off of each one, and merges the resulting theme components on top of the context theme, overriding its existing components where applicable. Thus, for any component named `'IconButton'`, the theme object it receives will look like this:
+
+```js
+{
+  Button: BeautifulButton,
+  Icon: InvisibleIcon, // <-- overridden!
+  'IconButton.Icon': InvisibleIcon
+}
+```
+
+This behavior *does not mutate the context theme*, so `IconButton`'s siblings and parents are not affected. However, both `ThemeConsumer` and `withTheme`/`withNamedTheme` initialize new theme providers, so that the overrides will remain in context for their children's children. 
+
+> ℹ️ **Note:** Remember that `useTheme` does *not* initialize a new provider, so it is **not** the best choice for use with nested themes.
+
+Naming your components is dead simple:
+
+#### Using `ThemeConsumer`
+```jsx
+let IconButton = ({ icon, children, ...props }) => (
+  <ThemeConsumer name="IconButton">
+    {/* theme => ... */}
+  </ThemeConsumer>
+)
+export default IconButton
+```
+
+#### Using `withNamedTheme`
+
+`withNamedTheme` takes a `name` argument and returns `withTheme`. It's used like this:
+
+```jsx
+import { withNamedTheme } from 'contexture-react'
+
+/* let IconButton = ... */
+
+export default withNamedTheme('IconButton')(IconButton)
+```
+
+#### Using `useTheme`
+
+(Again, seriously not recommended unless you really know what you're doing):
+
+```jsx
+let IconButton = ({ icon, children, ...props }) => {
+  let theme = useTheme('IconButton')
+  /* return ( ... */
+}
+export default IconButton
+```

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -27,24 +27,24 @@ function App() {
 
 > ℹ️ **Note:** contexture-react provides a basic **fallback theme** to all components that consume its theme API, to help prevent render errors if you forget to initialize `ThemeProvider` with a `theme` prop (or even leave out `ThemeProvider` altogether 😱). See the [Default theme components](#default-theme-components) section for more details.
 
-### Globals
+### The Root component
 
-`Globals` is a special **theme key** that allows you to include global components such as styles, fonts, or other providers within your theme. When `ThemeProvider` is rendered, it *wraps its own children in the `Globals` **theme component*** if one exists on the provided theme:
+`Root` is a special **theme key** that allows you to include global components such as styles, fonts, or other providers within your theme. When `ThemeProvider` is rendered, it *wraps its own children in the `Root` **theme component*** if one exists on the provided theme:
 
 ```jsx
 export let ThemeProvider = ({ theme, children }) => {
   theme = { ...defaultTheme, ...theme }
-  let Globals = theme.Globals || React.Fragment
+  let Root = theme.Root || React.Fragment
   return (
     <ThemeContext.Provider value={theme}>
-      <Globals>{children}</Globals>
+      <Root>{children}</Root>
     </ThemeContext.Provider>
   )
 }
 ```
 <sup>^ The actual source code for ThemeProvider</source>
 
-> ⚠️ **IMPORTANT:** If you use a `Globals` theme component, it ***must*** handle its `children` prop, or nothing inside of `ThemeProvider` will render!
+> ⚠️ **IMPORTANT:** If you use a `Root` theme component, it ***must*** handle its `children` prop, or nothing inside of `ThemeProvider` will render!
 
 ## Consuming the Theme API
 
@@ -140,7 +140,7 @@ This section documents all of the **theme components** used by contexture-react 
 
 ### Inputs
 
-| Key | Expected props | Notes | ExampleTypes usage |
+| Key | Expected props | Notes | contexture-react usage |
 | --- | --- | --- | --- |
 | `Button` | `isActive`, `primary`, `onClick`, `children` | A generic button | Facet, Number, TagsQuery, TermsStatsTable |
 | `AlternateButton` | same as `Button` | An alternate style of generic button. Defaults to a text button. | |
@@ -160,6 +160,7 @@ This section documents all of the **theme components** used by contexture-react 
 | Key | Expected props | Notes | ExampleTypes usage |
 | --- | --- | --- | --- |
 | `Box` | `children` | A generic container element | none |
+| `ButtonGroup` | `children` | A container for holding |
 | `Modal` | `isOpen`, `children` | A generic modal component | ResultTable |
 | `Popover` | `isOpen`, `children` | A generic context-menu component | ResultTable |
 | `DropdownItem` | `children` | A generic list item used in dropdown menus | ResultTable |
@@ -171,7 +172,7 @@ This section documents all of the **theme components** used by contexture-react 
 
 | Key | Expected props | Notes |
 | --- | --- | --- |
-| `Globals` | `children` | This component is rendered inside `ThemeProvider`, and wraps its children. For use with other providers and/or standalone globals like stylesheets. |
+| `Root` | `children` | This component is rendered inside `ThemeProvider`, and wraps its children. For use with other providers and/or standalone globals like stylesheets. |
 | `BarChart` | `height`, `borderColor`, `min`, `max` | Used in the DateHistogram and TermsStats example types |
 | `UnmappedNodeComponent` | `node` | Used as a fallback component in search interfaces for nodes that are not mapped to any other component |
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -152,7 +152,7 @@ This section documents all of the **theme components** used by contexture-react 
 | `NumberInput` | same as basic `input` | An input of type `number` | Geo, Number |
 | `TagsInput` | `tags`, `addTag`, `removeTag`, `submit`, `tagStyle`, `placeholder`, `splitCommas`, `style`, `onBlur`, `onInputChange`, `onTagClick` | A text input field that turns input into `Tag`s | TagsQuery, TagsText |
 | `Tag` | `value`, `removeTag`, `tagStyle`, `onClick` | A tag component with a button to remove the tag. Used in TagsInput. | none |
-| `NestedPicker` | `options`, `onChange` | Renders a list of selectable options | ResultTable |
+| `NestedPicker` | `options`, `onChange`, `PickerItem` | Renders a list of selectable options | ResultTable |
 
 ### Containers
 
@@ -163,12 +163,8 @@ This section documents all of the **theme components** used by contexture-react 
 | `Popover` | `isOpen`, `children` | A generic context-menu component | ResultTable |
 | `DropdownItem` | `children` | A generic list item used in dropdown menus | ResultTable |
 | `PagerItem` | `active`, `disabled` | A list item for Pager components | ResultPager |
-| `PickerItem` | `active`, `disabled` | A list item for Picker components | none |
 | `TextHighlight` | `pattern`, `text`, `Wrap` | Renders the text given in the `text` prop, with the parts that match the `pattern` prop wrapped in the `Wrap` component | none |
 | `Table` | same as basic `table` | A generic table component | ResultTable |
-| `TableCell` | same as `td` | A generic table cell | ResultTable |
-| `TableHeaderCell` | same as `th` | A generic table header | ResultTable |
-| `TableRow` | same as `tr` | A generic table row | ResultTable |
 
 ### Other
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -142,7 +142,8 @@ This section documents all of the **theme components** used by contexture-react 
 
 | Key | Expected props | Notes | ExampleTypes usage |
 | --- | --- | --- | --- |
-| `Button` | `isActive`, `primary`, `onClick`, `children` | A generic button | Facet, Number, TagsQuery, TermsStatsTable |s
+| `Button` | `isActive`, `primary`, `onClick`, `children` | A generic button | Facet, Number, TagsQuery, TermsStatsTable |
+| `AlternateButton` | same as `Button` | An alternate style of generic button. Defaults to a text button. | |
 | `Checkbox` | `checked`, `onChange` | A generic checkbox | CheckableResultTable, CheckableTermsStatsTable, Facet, TagsQuery |
 | `Icon` | `icon`, `onClick` | A generic icon component | ResultPager, ResultTable |
 | `RadioList` | `options`, `value`, `onChange` | A generic list of radio buttons. The `options` prop is an array of `{ value, label }` objects. | Bool, Date, Exists, Facet, TagsQuery |

--- a/stories/devNotes.stories.js
+++ b/stories/devNotes.stories.js
@@ -20,3 +20,12 @@ storiesOf('Developer Notes|Docs', module)
       header: false,
     })(() => null)
   )
+  .add(
+    'Theme API',
+    withInfo({
+      text: require('../docs/theme.md'),
+      inline: true,
+      source: false,
+      header: false,
+    })(() => null)
+  )


### PR DESCRIPTION
Let's take another shot at the whole "document the theme API" thing, except (hopefully) make it actually useful this time

The main point of interest here is the list of default theme components. It's meant to be totally comprehensive - the source of truth for what should and should *not* be in the GreyVest theme (ie, stuff that just lives in and is exportable from the GreyVest component library).

Which would make this PR a convenient place for those sorts of discussions, I think 🙂

Marked as WIP because there are still a couple of open questions regarding certain keys -- mostly having to do with whether specific usages of some generic thing like List or Adder should have their own top-level keys (possible theme bloat), or just be nested (cognitive load and other complications). The documentation itself also deserves to be expanded a bit, though I believe the priority on that is pretty low.