### PR TITLE
Cleanup dist directory on babel start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.56.3
+* Cleanup dist directory before starting babel
+
 # 1.56.2
 * Removed 'Please Select...' from TagsJoinPicker
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "contexture-react",
-  "version": "1.56.2",
+  "version": "1.56.3",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {
     "start": "npm run storybook",
-    "pre-build": "rm -rf ./dist",
-    "build": "babel ./src --out-dir ./dist --source-maps",
+    "build": "babel ./src --out-dir ./dist --source-maps --delete-dir-on-start",
     "prepublish": "npm run build",
     "storybook": "start-storybook -p 3000",
     "build-storybook": "build-storybook",


### PR DESCRIPTION
This is cleaner than the pre-build step