### PR TITLE
Organize storybook

### DIFF
--- a/stories/exampleTypes/ResultTable.stories.js
+++ b/stories/exampleTypes/ResultTable.stories.js
@@ -5,7 +5,7 @@ import TestTree from '../testTree'
 import { ResultTable } from '../../src/exampleTypes'
 import ThemePicker from '../themePicker'
 
-storiesOf('Components|Search components/ExampleTypes/ResultTable', module)
+storiesOf('Components|ExampleTypes/ResultTable', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('Customizations', () => (
     <div>

--- a/stories/exampleTypes/TagsQuery.stories.js
+++ b/stories/exampleTypes/TagsQuery.stories.js
@@ -12,7 +12,7 @@ let treeWithTags = TestTree(testTree => {
   return testTree
 })
 
-storiesOf('Components|Search components/ExampleTypes/Tags Query', module)
+storiesOf('Components|ExampleTypes/Tags Query', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('Default', () => (
     <TagsQuery tree={treeWithTags} path={['tagsQuery']} />

--- a/stories/exampleTypes/index.stories.js
+++ b/stories/exampleTypes/index.stories.js
@@ -22,7 +22,7 @@ import {
   Geo,
 } from '../../src/exampleTypes'
 
-storiesOf('Components|Search components/ExampleTypes', module)
+storiesOf('Components|Search Components/ExampleTypes', module)
   .addWithJSX('Full Demo', () => {
     let tree = TestTree()
     return (

--- a/stories/greyVest/awaiter.stories.js
+++ b/stories/greyVest/awaiter.stories.js
@@ -4,7 +4,7 @@ import { fromPromise } from 'mobx-utils'
 import { Awaiter, Button, Box } from '../../src/greyVest'
 import decorator from './decorator'
 
-storiesOf('Components|GreyVest library/', module)
+storiesOf('Components|GreyVest Library/', module)
   .addDecorator(decorator)
   .addWithJSX('Awaiter', () => {
     let resolve

--- a/stories/greyVest/box.stories.js
+++ b/stories/greyVest/box.stories.js
@@ -3,6 +3,6 @@ import { storiesOf } from '@storybook/react'
 import { Box } from './../../src/greyVest'
 import decorator from './decorator'
 
-storiesOf('Components|GreyVest library', module)
+storiesOf('Components|GreyVest Library', module)
   .addDecorator(decorator)
   .addWithJSX('Box', () => <Box>Box Contents</Box>)

--- a/stories/greyVest/button.stories.js
+++ b/stories/greyVest/button.stories.js
@@ -4,7 +4,7 @@ import { action } from '@storybook/addon-actions'
 import { Button } from './../../src/greyVest'
 import decorator from './decorator'
 
-storiesOf('Components|GreyVest library/Button', module)
+storiesOf('Components|GreyVest Library/Button', module)
   .addDecorator(decorator)
   .addWithJSX('Basic Usage', () => (
     <Button onClick={() => action('clicked')()}>Click</Button>

--- a/stories/greyVest/checkbox.stories.js
+++ b/stories/greyVest/checkbox.stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react'
 import { Checkbox } from '../../src/greyVest'
 import decorator from './decorator'
 
-storiesOf('Components|GreyVest library', module)
+storiesOf('Components|GreyVest Library', module)
   .addDecorator(decorator)
   .addWithJSX('Checkbox', () => (
     <>

--- a/stories/greyVest/error.stories.js
+++ b/stories/greyVest/error.stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react'
 import { Flex, Box, ErrorList, TextInput } from './../../src/greyVest'
 import decorator from './decorator'
 
-storiesOf('Components|GreyVest library/Error', module)
+storiesOf('Components|GreyVest Library/Error', module)
   .addDecorator(decorator)
   .addWithJSX('Text', () => <ErrorList>I am an error</ErrorList>)
   .addWithJSX('Block', () => (

--- a/stories/greyVest/flex.stories.js
+++ b/stories/greyVest/flex.stories.js
@@ -23,7 +23,7 @@ let FlexDemo = ({ style, ...props }) => (
   </Flex>
 )
 
-storiesOf('Components|GreyVest library/Flex', module)
+storiesOf('Components|GreyVest Library/Flex', module)
   .addWithJSX('As button', () => (
     <Flex column alignItems="center">
       <FlexDemo as="button" />

--- a/stories/greyVest/linkButton.stories.js
+++ b/stories/greyVest/linkButton.stories.js
@@ -6,7 +6,7 @@ import decorator from './decorator'
 
 let click = action('clicked')
 
-storiesOf('Components|GreyVest library', module)
+storiesOf('Components|GreyVest Library', module)
   .addDecorator(decorator)
   .addWithJSX('LinkButton', () => (
     <LinkButton onClick={() => click()}>Click</LinkButton>

--- a/stories/greyVest/modal.stories.js
+++ b/stories/greyVest/modal.stories.js
@@ -16,6 +16,6 @@ let ModalDemo = observer(() => {
   )
 })
 
-storiesOf('Components|GreyVest library', module)
+storiesOf('Components|GreyVest Library', module)
   .addDecorator(decorator)
   .addWithJSX('Modal', () => <ModalDemo />)

--- a/stories/greyVest/nestedPicker.stories.js
+++ b/stories/greyVest/nestedPicker.stories.js
@@ -4,7 +4,7 @@ import { action } from '@storybook/addon-actions'
 import { NestedPicker } from '../../src/greyVest'
 import decorator from './decorator'
 
-storiesOf('Components|GreyVest library', module)
+storiesOf('Components|GreyVest Library', module)
   .addDecorator(decorator)
   .addWithJSX('NestedPicker', () => (
     <NestedPicker

--- a/stories/greyVest/popover.stories.js
+++ b/stories/greyVest/popover.stories.js
@@ -17,6 +17,6 @@ let PopoverDemo = observer(() => {
   )
 })
 
-storiesOf('Components|GreyVest library', module)
+storiesOf('Components|GreyVest Library', module)
   .addDecorator(decorator)
   .addWithJSX('Popover', () => <PopoverDemo />)

--- a/stories/greyVest/refs.stories.js
+++ b/stories/greyVest/refs.stories.js
@@ -7,9 +7,9 @@ let input
 let select
 let textArea
 
-storiesOf('Components|GreyVest library', module)
+storiesOf('Components|GreyVest Library', module)
   .addDecorator(decorator)
-  .addWithJSX('refs', () => (
+  .addWithJSX('Refs', () => (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <TextInput ref={e => (input = e)} />
       <Textarea ref={e => (textArea = e)} />

--- a/stories/greyVest/tabs.stories.js
+++ b/stories/greyVest/tabs.stories.js
@@ -69,7 +69,7 @@ Used in conjunction with TabLabel as an alternative to a combined Tab.
 
 let state = observable({ tab: 'results' })
 
-storiesOf('Components|GreyVest library/Tabs', module)
+storiesOf('Components|GreyVest Library/Tabs', module)
   .add(
     'Docs',
     withInfo({ text: tabDocs, inline: true, source: false, header: false })(

--- a/stories/greyVest/textHighlight.stories.js
+++ b/stories/greyVest/textHighlight.stories.js
@@ -20,6 +20,6 @@ let HighlightDemo = observer(() => {
   )
 })
 
-storiesOf('Components|GreyVest library', module)
+storiesOf('Components|GreyVest Library', module)
   .addDecorator(decorator)
   .addWithJSX('TextHighlight', () => <HighlightDemo />)

--- a/stories/purgatory/checkbutton.stories.js
+++ b/stories/purgatory/checkbutton.stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react'
 import { CheckButton } from '../../src/purgatory'
 import ThemePicker from '../themePicker'
 
-storiesOf('Components|Search components/Other components/Checkbutton', module)
+storiesOf('Components|Search components/Internals/Checkbutton', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('Unchecked', () => (
     <CheckButton>Your refrigerator is running</CheckButton>

--- a/stories/purgatory/checkbutton.stories.js
+++ b/stories/purgatory/checkbutton.stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react'
 import { CheckButton } from '../../src/purgatory'
 import ThemePicker from '../themePicker'
 
-storiesOf('Components|Search components/Internals/Checkbutton', module)
+storiesOf('Components|Search Components/Internals/Checkbutton', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('Unchecked', () => (
     <CheckButton>Your refrigerator is running</CheckButton>

--- a/stories/purgatory/stepsAccordion.stories.js
+++ b/stories/purgatory/stepsAccordion.stories.js
@@ -12,7 +12,7 @@ let makeStepTitle = title => n => (
   </h1>
 )
 
-storiesOf('Components|Search components/Internals', module)
+storiesOf('Components|Search Components/Internals', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('StepsAccordion', () => {
     let isClicked = F.stateLens(React.useState(false))

--- a/stories/purgatory/stepsAccordion.stories.js
+++ b/stories/purgatory/stepsAccordion.stories.js
@@ -12,7 +12,7 @@ let makeStepTitle = title => n => (
   </h1>
 )
 
-storiesOf('Components|Search components/Other components', module)
+storiesOf('Components|Search components/Internals', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('StepsAccordion', () => {
     let isClicked = F.stateLens(React.useState(false))

--- a/stories/purgatory/toggleFiltersButton.stories.js
+++ b/stories/purgatory/toggleFiltersButton.stories.js
@@ -6,7 +6,7 @@ import ThemePicker from '../themePicker'
 
 let click = action('clicked')
 
-storiesOf('Components|Search components/Other components', module)
+storiesOf('Components|Search components/Internals', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('ToggleFiltersButton', () => (
     <ToggleFiltersButton onClick={() => click()} />

--- a/stories/purgatory/toggleFiltersButton.stories.js
+++ b/stories/purgatory/toggleFiltersButton.stories.js
@@ -6,7 +6,7 @@ import ThemePicker from '../themePicker'
 
 let click = action('clicked')
 
-storiesOf('Components|Search components/Internals', module)
+storiesOf('Components|Search Components/Internals', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('ToggleFiltersButton', () => (
     <ToggleFiltersButton onClick={() => click()} />

--- a/stories/purgatory/treePauseButton.stories.js
+++ b/stories/purgatory/treePauseButton.stories.js
@@ -18,7 +18,7 @@ let tree = {
   isPausedNested: () => state.paused,
 }
 
-storiesOf('Components|Search components/Internals/TreePauseButton', module)
+storiesOf('Components|Search Components/Internals/TreePauseButton', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('One Tree', () => (
     <TreePauseButton>

--- a/stories/purgatory/treePauseButton.stories.js
+++ b/stories/purgatory/treePauseButton.stories.js
@@ -18,10 +18,7 @@ let tree = {
   isPausedNested: () => state.paused,
 }
 
-storiesOf(
-  'Components|Search components/Other components/TreePauseButton',
-  module
-)
+storiesOf('Components|Search components/Internals/TreePauseButton', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('One Tree', () => (
     <TreePauseButton>

--- a/stories/searchComponents/filterAdder.stories.js
+++ b/stories/searchComponents/filterAdder.stories.js
@@ -12,7 +12,7 @@ let mockTree = {
   getNode: () => true,
 }
 
-storiesOf('Components|Search components/Other components/FilterAdder', module)
+storiesOf('Components|Search components/FilterAdder', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('With ModalPicker', () => (
     <FilterAdder

--- a/stories/searchComponents/filterAdder.stories.js
+++ b/stories/searchComponents/filterAdder.stories.js
@@ -12,7 +12,7 @@ let mockTree = {
   getNode: () => true,
 }
 
-storiesOf('Components|Search components/FilterAdder', module)
+storiesOf('Components|Search Components/FilterAdder', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('With ModalPicker', () => (
     <FilterAdder

--- a/stories/searchComponents/filterList.stories.js
+++ b/stories/searchComponents/filterList.stories.js
@@ -4,7 +4,7 @@ import { FilterList } from '../../src/FilterList'
 import { componentForType } from '../../src'
 import ThemePicker from '../themePicker'
 
-storiesOf('Components|Search components', module)
+storiesOf('Components|Search Components', module)
   .addDecorator(ThemePicker('blueberry'))
   .addWithJSX('FilterList', () => (
     <FilterList

--- a/stories/searchComponents/queryBuilder/examples.stories.js
+++ b/stories/searchComponents/queryBuilder/examples.stories.js
@@ -15,7 +15,7 @@ let Client = ContextureMobx({
 
 let Node = (type, key) => ({ key, type })
 
-storiesOf('Components|Search components/QueryBuilder', module)
+storiesOf('Components|Search Components/QueryBuilder', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('One Filter', () => (
     <QueryBuilder

--- a/stories/searchComponents/queryBuilder/internals/addPreview.js
+++ b/stories/searchComponents/queryBuilder/internals/addPreview.js
@@ -5,7 +5,7 @@ import AddPreview from '../../../../src/queryBuilder/preview/AddPreview'
 
 export default () =>
   storiesOf(
-    'Components|Search components/QueryBuilder/Internals/AddPreview',
+    'Components|Search Components/QueryBuilder/Internals/AddPreview',
     module
   )
     .addWithJSX('and', () => <AddPreview onClick={action('join')} join="and" />)

--- a/stories/searchComponents/queryBuilder/internals/filterContents.js
+++ b/stories/searchComponents/queryBuilder/internals/filterContents.js
@@ -4,7 +4,7 @@ import FilterContents from '../../../../src/queryBuilder/FilterContents'
 
 export default (parent, root) =>
   storiesOf(
-    'Components|Search components/QueryBuilder/Internals',
+    'Components|Search Components/QueryBuilder/Internals',
     module
   ).addWithJSX('FilterContents', () => (
     <FilterContents

--- a/stories/searchComponents/queryBuilder/internals/group.js
+++ b/stories/searchComponents/queryBuilder/internals/group.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react'
 import Group from '../../../../src/queryBuilder/Group'
 
 export default (parent, root, DnDDecorator) =>
-  storiesOf('Components|Search components/QueryBuilder/Internals/Group', module)
+  storiesOf('Components|Search Components/QueryBuilder/Internals/Group', module)
     .addDecorator(DnDDecorator)
     .addWithJSX('One Filter', () => (
       <Group

--- a/stories/searchComponents/queryBuilder/internals/indentable.js
+++ b/stories/searchComponents/queryBuilder/internals/indentable.js
@@ -4,7 +4,7 @@ import Indentable from '../../../../src/queryBuilder/preview/Indentable'
 
 export default () =>
   storiesOf(
-    'Components|Search components/QueryBuilder/Internals/Indentable',
+    'Components|Search Components/QueryBuilder/Internals/Indentable',
     module
   )
     .addWithJSX('and', () => (

--- a/stories/searchComponents/queryBuilder/internals/operator.js
+++ b/stories/searchComponents/queryBuilder/internals/operator.js
@@ -18,7 +18,7 @@ let operatorStory = (join, index, root) => () => (
 )
 export default (parent, root, DnDDecorator) =>
   storiesOf(
-    'Components|Search components/QueryBuilder/Internals/Operator',
+    'Components|Search Components/QueryBuilder/Internals/Operator',
     module
   )
     .addDecorator(DnDDecorator)

--- a/stories/searchComponents/queryBuilder/internals/operatorMenu.js
+++ b/stories/searchComponents/queryBuilder/internals/operatorMenu.js
@@ -4,7 +4,7 @@ import OperatorMenu from '../../../../src/queryBuilder/OperatorMenu'
 
 export default (parent, root) =>
   storiesOf(
-    'Components|Search components/QueryBuilder/Internals',
+    'Components|Search Components/QueryBuilder/Internals',
     module
   ).addWithJSX('OperatorMenu', () => (
     <OperatorMenu {...{ node: { join: 'and' }, parent, root }} />

--- a/stories/searchComponents/queryBuilder/internals/rule.js
+++ b/stories/searchComponents/queryBuilder/internals/rule.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react'
 import Rule from '../../../../src/queryBuilder/Rule'
 
 export default (parent, root, DnDDecorator) =>
-  storiesOf('Components|Search components/QueryBuilder/Internals', module)
+  storiesOf('Components|Search Components/QueryBuilder/Internals', module)
     .addDecorator(DnDDecorator)
     .addWithJSX('Rule', () => (
       <Rule

--- a/stories/searchComponents/queryWizard/examples.stories.js
+++ b/stories/searchComponents/queryWizard/examples.stories.js
@@ -63,7 +63,7 @@ let AccordionStory = () => (
   </StepsAccordion>
 )
 
-storiesOf('Components|Search components/QueryWizard', module)
+storiesOf('Components|Search Components/QueryWizard', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('QueryWizard', WizardStory)
   .addWithJSX('Accordion with FilterButtonList', AccordionStory)

--- a/stories/searchComponents/searchLayout.stories.js
+++ b/stories/searchComponents/searchLayout.stories.js
@@ -4,7 +4,7 @@ import { SearchLayout } from '../../src'
 import { Box } from '../../src/greyVest'
 import ThemePicker from '../themePicker'
 
-storiesOf('Components|Search components/Other components/SearchLayout', module)
+storiesOf('Components|Search components/SearchLayout', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('Basic', () => (
     <SearchLayout mode="basic">

--- a/stories/searchComponents/searchLayout.stories.js
+++ b/stories/searchComponents/searchLayout.stories.js
@@ -4,7 +4,7 @@ import { SearchLayout } from '../../src'
 import { Box } from '../../src/greyVest'
 import ThemePicker from '../themePicker'
 
-storiesOf('Components|Search components/SearchLayout', module)
+storiesOf('Components|Search Components/SearchLayout', module)
   .addDecorator(ThemePicker('greyVest'))
   .addWithJSX('Basic', () => (
     <SearchLayout mode="basic">


### PR DESCRIPTION
1. Promotes the ExampleType stories to their own heading under Components
2. Renames the "Other components" subsection to "Internals" (contains purgatory component stories used for testing purposes, as those components are not exported)
3. Moves the non-purgatory stories that were wilting in there up a level into the "Search Components" section, rescuing them from obscurity

Possibly coming soon: more exampleType stories and more documentation 📖