### PR TITLE
Revert changes to Dynamic component

### DIFF
--- a/__tests__/schema.test.js
+++ b/__tests__/schema.test.js
@@ -1,0 +1,22 @@
+import { componentForType } from '../src/utils/schema'
+import { TypeMap, Facet } from '../src/exampleTypes'
+import { UnmappedNodeComponent } from '../src/themes/base'
+
+test('componentForType', () => {
+  let mapNodeToComponent = componentForType(TypeMap)
+  let defaultProps = { component: UnmappedNodeComponent } // for realism
+
+  let node = { type: 'facet' }
+  expect(mapNodeToComponent(node)).toEqual({ component: Facet })
+
+  let unmappedNode = { type: 'little-teapot' }
+  expect(mapNodeToComponent(unmappedNode)).toEqual(undefined)
+
+  // merge test
+  expect({ ...defaultProps, ...mapNodeToComponent(unmappedNode) }).toEqual({
+    component: UnmappedNodeComponent,
+  })
+  expect({ ...defaultProps, ...mapNodeToComponent(node) }).not.toEqual({
+    component: UnmappedNodeComponent,
+  })
+})

--- a/src/FilterButtonList.js
+++ b/src/FilterButtonList.js
@@ -41,13 +41,13 @@ let FilterButtonItem = _.flow(
             )}
             <div className="filter-component">
               <Dynamic
-                defaultProps={{
+                {...{
                   component: UnmappedNodeComponent,
                   tree,
                   node,
                   path: _.toArray(node.path),
+                  ...mappedProps,
                 }}
-                {...mappedProps}
               />
             </div>
             <Button onClick={() => tree.clear(node.path)}>Clear</Button>

--- a/src/FilterList.js
+++ b/src/FilterList.js
@@ -196,13 +196,13 @@ export let FilterList = _.flow(
               {!child.paused && (
                 <div className="filter-list-item-contents">
                   <Dynamic
-                    defaultProps={{
+                    {...{
                       component: UnmappedNodeComponent,
                       tree,
                       node: child,
                       path: _.toArray(child.path),
+                      ...mapNodeToProps(child, fields),
                     }}
-                    {...mapNodeToProps(child, fields)}
                   />
                 </div>
               )}

--- a/src/exampleTypes/ResultTable.js
+++ b/src/exampleTypes/ResultTable.js
@@ -266,12 +266,12 @@ let Header = _.flow(
               </DropdownItem>
               {F.view(filtering) && filterNode && !filterNode.paused && (
                 <Dynamic
-                  defaultProps={{
+                  {...{
                     component: UnmappedNodeComponent,
                     tree,
                     path: _.toArray(filterNode.path),
+                    ...mapNodeToProps(filterNode, fields),
                   }}
-                  {...mapNodeToProps(filterNode, fields)}
                 />
               )}
             </div>

--- a/src/greyVest/Dynamic.js
+++ b/src/greyVest/Dynamic.js
@@ -1,16 +1,5 @@
 import React from 'react'
-import _ from 'lodash/fp'
-import F from 'futil-js'
-import { observer } from 'mobx-react'
+let Dynamic = ({ component: C = null, ...props }) => C && <C {...props} />
+Dynamic.displayName = 'Dynamic'
 
-let Dynamic = ({ component: C = null, defaultProps, ...props }) =>
-  C && (
-    <C
-      {..._.flow(
-        F.compactObject,
-        _.merge(defaultProps)
-      )(props)}
-    />
-  )
-
-export default observer(Dynamic)
+export default Dynamic

--- a/src/queryBuilder/FilterContents.js
+++ b/src/queryBuilder/FilterContents.js
@@ -59,12 +59,12 @@ let FilterContents = ({
           }}
         >
           <Dynamic
-            defaultProps={{
+            {...{
               component: UnmappedNodeComponent,
               tree,
               node,
+              ...mapNodeToProps(node, fields),
             }}
-            {...mapNodeToProps(node, fields)}
           />
         </div>
       )}

--- a/src/utils/schema.js
+++ b/src/utils/schema.js
@@ -31,9 +31,8 @@ export let schemaFieldProps = _.curry((props, { field }, fields) =>
   _.pick(props, fields[field])
 )
 
-export let componentForType = TypeMap => ({ type }) => ({
-  component: TypeMap[type],
-})
+export let componentForType = TypeMap => ({ type }) =>
+  F.whenExists(F.singleObject('component'))(TypeMap[type])
 
 export let fieldsFromSchema = _.curry(
   (schemas, search) => schemas[search.tree.schema].fields


### PR DESCRIPTION
We made these changes to the Dynamic component for 2.0:
- compact the props object before merging it with defaults, such that props with falsy values are no longer merged on top of default props with truthy values
- change the API to take default props as a `defaultProps` prop, instead of just... as props

...this PR reverts both of those. 😄


Instead, `componentForType` no longer returns a `{ component: undefined }` object if the given node's type doesn't exist in the TypeMap, but just `undefined`. This fixes the issue that the above changes were introduced to address in the first place - namely, where the default component prop on our Dynamic components was never rendering, because it was being overridden by `{ component: undefined }`.

As a bonus, there are now tests for `componentForType`!
