### PR TITLE
Don't export material theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.1
+* Don't export the material theme
+
 # 2.0.0
 
 ## Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {
@@ -55,7 +55,9 @@
     "testURL": "http://localhost/",
     "rootDir": "src",
     "collectCoverage": false,
-    "collectCoverageFrom": ["<rootDir>"]
+    "collectCoverageFrom": [
+      "<rootDir>"
+    ]
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/src/themes/index.js
+++ b/src/themes/index.js
@@ -1,4 +1,3 @@
 export base from './base'
 export blueberry from './blueberry'
 export greyVest from './greyVest'
-export material from './material'


### PR DESCRIPTION
The material theme uses a bunch of dev dependencies (material-ui, date stuff), which we'd have to set as optional dependencies if we were going to export it. Since it's meant as a demo thing anyway, the easiest solution is just not to export the theme 🙂