### PR TITLE
camelCase `defaultNodeProps` & clean up utils exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.2
+* camelCase `defaultNodeProps` schema util
+
 # 2.0.1
 * Don't export the material theme
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.0.6
 * camelCase `defaultNodeProps` schema util
-* Clean up utils exports
+* Be explicit about utility function exports in `src/index.js`
 
 # 2.0.5
 * Ensure components using `openBinding` observe the correct things

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,16 @@
 // utils
-export * from './utils/schema'
-export * from './utils/theme'
+export {
+  fieldsFromSchema,
+  componentForType,
+  schemaFieldProps,
+} from './utils/schema'
+export {
+  ThemeProvider,
+  useTheme,
+  ThemeConsumer,
+  withNamedTheme,
+  withTheme,
+} from './utils/theme'
 
 // exampleTypes
 export * from './exampleTypes'

--- a/src/utils/schema.js
+++ b/src/utils/schema.js
@@ -24,7 +24,7 @@ export let inferSchema = _.flow(
   flattenPlainObject
 )
 
-export let DefaultNodeProps = (field, fields, type) =>
+export let defaultNodeProps = (field, fields, type) =>
   _.get([field, 'defaultNodeProps', type], fields)
 
 export let schemaFieldProps = _.curry((props, { field }, fields) =>

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -1,6 +1,6 @@
 import F from 'futil-js'
 import _ from 'lodash/fp'
-import { DefaultNodeProps as defaultNodeProps } from './schema'
+import { defaultNodeProps } from './schema'
 
 export let oppositeJoin = node =>
   F.getOrReturn('join', node) === 'and' ? 'or' : 'and'


### PR DESCRIPTION
`defaultNodeProps` is just a function and should definitely be camelCase. However, this is technically a breaking change, since `DefaultNodeProps` has been exported as part of `utils/schema` since v1. (I forgot to add it to v2 when I had the chance, and now it's seriously bugging me.)

For what it's worth, none of our apps import this particular function, as far as I can tell. 

Can we sneak it in somehow, or will this one have to wait for 3.0?