### PR TITLE
Fix order of Text example type HOCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.2
+* Fix order of Text HOCs
+
 # 2.0.1
 * Don't export the material theme
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/Text.js
+++ b/src/exampleTypes/Text.js
@@ -1,7 +1,9 @@
 import _ from 'lodash/fp'
 import F from 'futil-js'
 import React from 'react'
-import { contexturify, withTreeLens } from '../utils/hoc'
+import { observer } from 'mobx-react'
+import { withNode, withLoader, withTreeLens } from '../utils/hoc'
+import { withTheme } from '../utils/theme'
 import { setDisplayName } from 'recompose'
 
 let LensInput = ({ lens, theme: { TextInput }, ...props }) => (
@@ -10,8 +12,11 @@ let LensInput = ({ lens, theme: { TextInput }, ...props }) => (
 
 let Text = _.flow(
   setDisplayName('Text'),
+  observer,
   withTreeLens,
-  contexturify
+  withNode,
+  withLoader,
+  withTheme
 )(LensInput)
 
 export default Text

--- a/src/exampleTypes/Text.js
+++ b/src/exampleTypes/Text.js
@@ -10,8 +10,8 @@ let LensInput = ({ lens, theme: { TextInput }, ...props }) => (
 
 let Text = _.flow(
   setDisplayName('Text'),
-  contexturify,
-  withTreeLens
+  withTreeLens,
+  contexturify
 )(LensInput)
 
 export default Text


### PR DESCRIPTION
- `withTreeLens` has to come after `withNode`
- `observer` has to come after `withTreeLens` for the text input to update