### PR TITLE
fix Geo component dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.3
+* Fix "within"/"not within" dropdown in Geo component
+
 # 2.0.2
 * Fix order of Text HOCs
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/Geo.js
+++ b/src/exampleTypes/Geo.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import _ from 'lodash/fp'
+import F from 'futil-js'
 import { Flex } from '../greyVest'
 import { contexturify } from '../utils/hoc'
 
@@ -34,13 +35,8 @@ let GeoComponent = ({
       style={elementStyle}
       value={node.operator}
       onChange={e => tree.mutate(node.path, { operator: e.target.value })}
-    >
-      {operatorOptions.map(o => (
-        <option key={o} value={o}>
-          {o}
-        </option>
-      ))}
-    </Select>
+      options={F.autoLabelOptions(operatorOptions)}
+    />
     <div style={elementStyle}>
       <NumberInput
         min="1"


### PR DESCRIPTION
At some point we must've changed it from a generic `select` to a themed `Select` and forgot to update the API
