### PR TITLE
Add BasicFilters and BuilderFilters props to SearchFilters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.1.0
+* Add `BasicFilters` and `BuilderFilters` props to SearchFilters for overriding/customizing filter components in the layout
+
 # 2.0.6
 * camelCase `defaultNodeProps` schema util
 * Be explicit about utility function exports in `src/index.js`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/SearchFilters.js
+++ b/src/SearchFilters.js
@@ -35,21 +35,21 @@ export let FiltersBox = withTheme(({ theme: { Box }, ...props }) => (
 ))
 FiltersBox.displayName = 'FiltersBox'
 
-let BasicSearchFilters = ({ setMode, trees, children }) => (
+let BasicSearchFilters = ({ setMode, trees, children, BasicFilters }) => (
   <div>
     <Flex style={{ alignItems: 'center' }}>
       <h1>Filters</h1>
       <TreePauseButton children={children} />
       <ToggleFiltersButton onClick={() => setMode('resultsOnly')} />
     </Flex>
-    <LabelledList list={trees} Component={FiltersBox} />
+    <LabelledList list={trees} Component={BasicFilters} />
     <LinkButton onClick={() => setMode('builder')} style={{ marginTop: 15 }}>
       Switch to Advanced Search Builder
     </LinkButton>
   </div>
 )
 
-let BuilderSearchFilters = ({ setMode, trees }) => (
+let BuilderSearchFilters = ({ setMode, trees, BuilderFilters }) => (
   <div>
     <Flex style={{ alignItems: 'center' }}>
       <h1>Filters</h1>
@@ -57,19 +57,25 @@ let BuilderSearchFilters = ({ setMode, trees }) => (
         Back to Regular Search
       </LinkButton>
     </Flex>
-    <LabelledList list={trees} Component={QueryBuilder} />
+    <LabelledList list={trees} Component={BuilderFilters} />
   </div>
 )
 
-let SearchFilters = ({ mode, setMode, children }) => {
+let SearchFilters = ({
+  mode,
+  setMode,
+  children,
+  BasicFilters = FiltersBox,
+  BuilderFilters = QueryBuilder,
+}) => {
   let trees = _.flow(
     React.Children.toArray,
     _.map('props')
   )(children)
   return mode === 'basic' ? (
-    <BasicSearchFilters {...{ trees, setMode, children }} />
+    <BasicSearchFilters {...{ trees, setMode, children, BasicFilters }} />
   ) : mode === 'builder' ? (
-    <BuilderSearchFilters {...{ trees, setMode }} />
+    <BuilderSearchFilters {...{ trees, setMode, BuilderFilters }} />
   ) : null
 }
 


### PR DESCRIPTION
Restores the `QueryBuilder` and `FiltersBox` props on SearchFilters, just with better names. These allowed the consumer to override the respective components, but were removed in 2.0.

This could also be considered a fix (for the oversight of removing those props in the first place), though I figure marking it as a feature is a little more charitable 🙃