### PR TITLE
Add classNames to SearchLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.1.1
+* Add `search-layout` and `search-layout-{mode}` classNames to SearchLayout
+
 # 2.1.0
 * Add `BasicFilters` and `BuilderFilters` props to SearchFilters for overriding/customizing filter components in the layout
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/SearchLayout.js
+++ b/src/SearchLayout.js
@@ -11,9 +11,9 @@ let styles = mode => ({
     mode === 'basic' ? 'minmax(250px, 400px) minmax(0, 1fr)' : 'minmax(0, 1fr)',
 })
 
-let SearchLayout = ({ mode, style, ...props }) => (
+let SearchLayout = ({ mode, style, className, ...props }) => (
   <div
-    className={`search-layout search-layout-${mode}`}
+    className={`search-layout search-layout-${mode} ${className}`}
     style={{ ...styles(mode), ...style }}
     {...props}
   />

--- a/src/SearchLayout.js
+++ b/src/SearchLayout.js
@@ -12,7 +12,11 @@ let styles = mode => ({
 })
 
 let SearchLayout = ({ mode, style, ...props }) => (
-  <div style={{ ...styles(mode), ...style }} {...props} />
+  <div
+    className={`search-layout search-layout-${mode}`}
+    style={{ ...styles(mode), ...style }}
+    {...props}
+  />
 )
 
 SearchLayout.propTypes = {


### PR DESCRIPTION
Gives SearchLayout the classNames `search-layout` and `search-layout-${mode}`.

SearchLayout belonged to GreyVest in 1.0 and had a `gv-search-layout-${mode}` className; we inlined the styles when we made it a generic component in 2.0, but I forgot to give it its className back as a generic component. This PR fixes that oversight.