### PR TITLE
Add GridItem component and Grid 'row' prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.0
+* GreyVest: Add GridItem component
+* GreyVest: Add `row` prop to Grid
+
 # 2.1.1
 * Add `search-layout` and `search-layout-{mode}` classNames to SearchLayout
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/greyVest/Grid.js
+++ b/src/greyVest/Grid.js
@@ -1,12 +1,16 @@
 import React from 'react'
 
-let Grid = ({ style, columns, gap, ...props }) => (
+let Grid = ({ style, columns, rows, gap, ...props }) => (
   <div
     style={{
       display: 'grid',
       ...(columns && {
         gridTemplateColumns: columns,
         msGridTemplateColumns: columns,
+      }),
+      ...(rows && {
+        gridTemplateRows: rows,
+        msGridTemplateRows: rows,
       }),
       ...(gap && { gridGap: gap }),
       ...style,

--- a/src/greyVest/GridItem.js
+++ b/src/greyVest/GridItem.js
@@ -1,0 +1,30 @@
+import React from 'react'
+
+let GridItem = ({
+  column,
+  colStart,
+  colEnd,
+  colSpan,
+  row,
+  rowStart,
+  rowSpan,
+  rowEnd,
+  children,
+  style,
+}) => (
+  <div
+    style={{
+      gridColumn: column,
+      gridColumnStart: colStart,
+      gridColumnEnd: colEnd || (!!colSpan && `span ${colSpan}`),
+      gridRow: row,
+      gridRowStart: rowStart,
+      gridRowEnd: rowEnd || (!!rowSpan && `span ${rowSpan}`),
+      ...style,
+    }}
+  >
+    {children}
+  </div>
+)
+
+export default GridItem


### PR DESCRIPTION
GridItem is a div with props for most of the basic grid-positioning-related things you'd want to do with a grid item.

@daedalus28, @stellarhoof - what are your thoughts on `colX` vs `columnX` (eg `colSpan`/`columnSpan`) in the prop API for this one? I like the brevity of `col`, but our Grid component uses `column`, so we might want to stick with it out of consistency. Either way, we probably want to weigh the options on this one before merging.