### PR TITLE
Tags input issues with tags which contain no spaces and are super long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.2.1
+* Fixes the tags with no space breaking the UI
+* Fixes the tag popover where the refresh facet icon was showing over it
+* Fixes the tag popover keyword breaking the UI
+
 # 2.2.0
 * Add 'counts' to the facet hide config in order to hide the facet counts
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/greyVest/Popover.js
+++ b/src/greyVest/Popover.js
@@ -19,6 +19,7 @@ let Popover = ({ isOpen, onClose, children, style }) =>
             textAlign: 'left',
             background: 'white',
             border: '1px solid #ebebeb',
+            zIndex: 2,
             ...style,
           }}
         >

--- a/src/greyVest/Tag.js
+++ b/src/greyVest/Tag.js
@@ -22,6 +22,7 @@ let Tag = ({
       cursor: 'pointer',
       margin: 3,
       borderRadius: '3px',
+      wordBreak: 'break-word',
       ...F.callOrReturn(tagStyle, value),
     }}
     onClick={onClick}

--- a/src/greyVest/Tag.js
+++ b/src/greyVest/Tag.js
@@ -22,7 +22,7 @@ let Tag = ({
       cursor: 'pointer',
       margin: 3,
       borderRadius: '3px',
-      wordBreak: 'break-word',
+      wordBreak: 'break-all',
       ...F.callOrReturn(tagStyle, value),
     }}
     onClick={onClick}

--- a/src/themes/greyVest/Style.js
+++ b/src/themes/greyVest/Style.js
@@ -93,7 +93,7 @@ export default () => (
       .filter-field-label {
         font-size: 16px;
         font-weight: bold;
-        word-break: break-word;
+        word-break: break-all;
       }
       .filter-field-label-icon {
         color: #9b9b9b;

--- a/src/themes/greyVest/Style.js
+++ b/src/themes/greyVest/Style.js
@@ -93,6 +93,7 @@ export default () => (
       .filter-field-label {
         font-size: 16px;
         font-weight: bold;
+        word-break: break-word;
       }
       .filter-field-label-icon {
         color: #9b9b9b;


### PR DESCRIPTION
1. Fixes the tags with no space breaking the UI

![image](https://user-images.githubusercontent.com/910303/66230442-0cc2f980-e699-11e9-8a7c-e419f593e72b.png)

2. Fixes the tag popover issue where the refresh facet icon was showing over it
3. Fixes the tag popover keyword breaking the UI

![image](https://user-images.githubusercontent.com/910303/66230480-1f3d3300-e699-11e9-8ae2-9933e561cb62.png)
