### PR TITLE
Feature/theme loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.3.0
+* Add theme support to contexturify's `withLoader`: it now uses `theme.Loader` for the Loader component if it exists, and if a Loader component hasn't been passed as a prop
+
 # 2.2.2
 * Fixes facets search box by making it more intuitive to the user when filtering the facet checkboxes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/FilterList.js
+++ b/src/FilterList.js
@@ -6,7 +6,7 @@ import { observer } from 'mobx-react'
 import { Flex, Dynamic } from './greyVest'
 import { fieldsToOptions } from './FilterAdder'
 import { useLens } from './utils/react'
-import { contexturify } from './utils/hoc'
+import { withNode } from './utils/hoc'
 import { bdJoin } from './styles/generic'
 import {
   newNodeFromType,
@@ -162,7 +162,9 @@ export let Label = _.flow(
 
 export let FilterList = _.flow(
   setDisplayName('FilterList'),
-  contexturify
+  observer,
+  withNode,
+  withTheme
 )(
   ({
     tree,

--- a/src/exampleTypes/ResultPager.js
+++ b/src/exampleTypes/ResultPager.js
@@ -1,6 +1,8 @@
 import _ from 'lodash/fp'
 import React from 'react'
-import { contexturify } from '../utils/hoc'
+import { observer } from 'mobx-react'
+import { withNode } from '../utils/hoc'
+import { withTheme } from '../utils/theme'
 
 let ResultPager = ({
   node,
@@ -79,4 +81,8 @@ let ResultPager = ({
   )
 }
 
-export default contexturify(ResultPager)
+export default _.flow(
+  observer,
+  withNode,
+  withTheme
+)(ResultPager)

--- a/src/greyVest/Popover.js
+++ b/src/greyVest/Popover.js
@@ -19,7 +19,7 @@ let Popover = ({ isOpen, onClose, children, style }) =>
             textAlign: 'left',
             background: 'white',
             border: '1px solid #ebebeb',
-            zIndex: 2,
+            zIndex: 20,
             ...style,
           }}
         >

--- a/src/queryBuilder/QueryBuilder.js
+++ b/src/queryBuilder/QueryBuilder.js
@@ -1,9 +1,12 @@
 import React from 'react'
 import F from 'futil-js'
+import _ from 'lodash/fp'
+import { observer } from 'mobx-react'
 import DDContext from './DragDrop/DDContext'
 import Group from './Group'
 import styles from '../styles'
-import { contexturify } from '../utils/hoc'
+import { withNode } from '../utils/hoc'
+import { withTheme } from '../utils/theme'
 import { useLens } from '../utils/react'
 
 let { background } = styles
@@ -37,4 +40,11 @@ let QueryBuilder = ({
   )
 }
 
-export default DDContext(contexturify(QueryBuilder), { allowEmptyNode: true })
+export default DDContext(
+  _.flow(
+    observer,
+    withNode,
+    withTheme
+  )(QueryBuilder),
+  { allowEmptyNode: true }
+)

--- a/src/utils/hoc.js
+++ b/src/utils/hoc.js
@@ -20,7 +20,8 @@ export let withLoader = Component =>
   _.flow(
     wrapDisplayName('withLoader', Component),
     observer
-  )(({ Loader, theme = {}, node, ...props }) => {
+  )(({ Loader, ...props }) => {
+    let { theme = {}, node } = props
     Loader = Loader || theme.Loader || StripedLoader
     return (
       <Loader loading={node && node.updating}>
@@ -34,17 +35,24 @@ export let withInlineLoader = Component =>
   _.flow(
     wrapDisplayName('withInlineLoader', Component),
     observer
-  )(({ Loader = StripedLoader, node, ...props }) => (
-    <Loader loading={node && node.updating} style={{ display: 'inline-block' }}>
-      <Component node={node} {...props} />
-    </Loader>
-  ))
+  )(({ Loader, ...props }) => {
+    let { theme = {}, node } = props
+    Loader = Loader || theme.Loader || StripedLoader
+    return (
+      <Loader
+        loading={node && node.updating}
+        style={{ display: 'inline-block' }}
+      >
+        <Component {...props} />
+      </Loader>
+    )
+  })
 
 export let contexturify = _.flow(
   observer,
   withNode,
-  withTheme,
-  withLoader
+  withLoader,
+  withTheme
 )
 
 // this is used for the text components

--- a/src/utils/hoc.js
+++ b/src/utils/hoc.js
@@ -50,8 +50,8 @@ export let withInlineLoader = Component =>
 
 export let contexturify = _.flow(
   observer,
-  withNode,
   withLoader,
+  withNode,
   withTheme
 )
 

--- a/src/utils/hoc.js
+++ b/src/utils/hoc.js
@@ -20,11 +20,14 @@ export let withLoader = Component =>
   _.flow(
     wrapDisplayName('withLoader', Component),
     observer
-  )(({ Loader = StripedLoader, node, ...props }) => (
-    <Loader loading={node && node.updating}>
-      <Component node={node} {...props} />
-    </Loader>
-  ))
+  )(({ Loader, theme = {}, node, ...props }) => {
+    Loader = Loader || theme.Loader || StripedLoader
+    return (
+      <Loader loading={node && node.updating}>
+        <Component node={node} {...props} />
+      </Loader>
+    )
+  })
 
 // I am a band-aid, please rip me off as quickly as possible
 export let withInlineLoader = Component =>
@@ -40,8 +43,8 @@ export let withInlineLoader = Component =>
 export let contexturify = _.flow(
   observer,
   withNode,
-  withLoader,
-  withTheme
+  withTheme,
+  withLoader
 )
 
 // this is used for the text components


### PR DESCRIPTION
Makes the `withLoader` HOC (used in contexturify, formerly injectTreeNode, etc) look in theme for a Loader component if one isn't explicitly passed in.

Also fixes a really dumb bug where `withNode` and `withLoader` were in the wrong order, so `withLoader` couldn't see the updating status of nodes that were fetched in `withNode`, which was causing a bunch of loaders not to render. 

This included some loaders we *don't* want -- ResultPager, FilterList, and QueryBuilder all had their loaders reappear after the fix. The loaders on these top-level components were always unnecessary and were waiting on 2.0 to be removed - this PR finally finishes the job 🙂