### PR TITLE
Misc pre-style-guide UI changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.5.1
+* FilterList/SearchFilters: update pause icon styling
+* ExampleTypes: Remove loader from TagsQuery
+* Add `contexturifyWithoutLoader` HOC
+
 # 2.5.0
 * ExampleTypes: Add an expanding/collapsing TagsQuerySearchBar component
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/FilterList.js
+++ b/src/FilterList.js
@@ -6,7 +6,7 @@ import { observer } from 'mobx-react'
 import { Flex, Dynamic } from './greyVest'
 import { fieldsToOptions } from './FilterAdder'
 import { useLens } from './utils/react'
-import { withNode } from './utils/hoc'
+import { contexturifyWithoutLoader } from './utils/hoc'
 import { bdJoin } from './styles/generic'
 import {
   newNodeFromType,
@@ -160,11 +160,10 @@ export let Label = _.flow(
   )
 })
 
+// we can't do this on export because FilterList is used internally
 export let FilterList = _.flow(
   setDisplayName('FilterList'),
-  observer,
-  withNode,
-  withTheme
+  contexturifyWithoutLoader
 )(
   ({
     tree,

--- a/src/FilterList.js
+++ b/src/FilterList.js
@@ -161,7 +161,7 @@ export let Label = _.flow(
 })
 
 // we can't do this on export because FilterList is used internally
-export let FilterList = _.flow(
+let FilterList = _.flow(
   setDisplayName('FilterList'),
   contexturifyWithoutLoader
 )(
@@ -214,3 +214,5 @@ export let FilterList = _.flow(
     </div>
   )
 )
+
+export default FilterList

--- a/src/SearchFilters.js
+++ b/src/SearchFilters.js
@@ -37,10 +37,14 @@ FiltersBox.displayName = 'FiltersBox'
 
 let BasicSearchFilters = ({ setMode, trees, children, BasicFilters }) => (
   <div>
-    <Flex style={{ alignItems: 'center' }}>
-      <h1>Filters</h1>
-      <ToggleFiltersButton onClick={() => setMode('resultsOnly')} />
-      <TreePauseButton children={children} />
+    <Flex alignItems="center" justifyContent="space-between">
+      <Flex alignItems="center">
+        <h1>Filters</h1>
+        <ToggleFiltersButton onClick={() => setMode('resultsOnly')} />
+      </Flex>
+      <div>
+        <TreePauseButton children={children} />
+      </div>
     </Flex>
     <LabelledList list={trees} Component={BasicFilters} />
     <LinkButton onClick={() => setMode('builder')} style={{ marginTop: 15 }}>

--- a/src/exampleTypes/ResultPager.js
+++ b/src/exampleTypes/ResultPager.js
@@ -1,8 +1,6 @@
 import _ from 'lodash/fp'
 import React from 'react'
-import { observer } from 'mobx-react'
-import { withNode } from '../utils/hoc'
-import { withTheme } from '../utils/theme'
+import { contexturifyWithoutLoader } from '../utils/hoc'
 
 let ResultPager = ({
   node,
@@ -81,8 +79,4 @@ let ResultPager = ({
   )
 }
 
-export default _.flow(
-  observer,
-  withNode,
-  withTheme
-)(ResultPager)
+export default contexturifyWithoutLoader(ResultPager)

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import _ from 'lodash/fp'
 import F from 'futil-js'
 import { Grid, GridItem } from '../../greyVest'
-import { contexturify } from '../../utils/hoc'
+import { contexturifyWithoutLoader } from '../../utils/hoc'
 import { useLensObject } from '../../utils/react'
 import { getTagStyle } from './utils'
 import TagActionsMenu from './TagActionsMenu'
@@ -75,4 +75,4 @@ let TagsQuery = ({
   )
 }
 
-export default contexturify(TagsQuery)
+export default contexturifyWithoutLoader(TagsQuery)

--- a/src/greyVest/Icon.js
+++ b/src/greyVest/Icon.js
@@ -25,8 +25,8 @@ let iconMap = {
       <SmallIcon icon="more_vert" />
     </TextButton>
   ),
-  FilterListExpand: toIcon('add'),
-  FilterListCollapse: toIcon('remove'),
+  FilterListExpand: toIcon('keyboard_arrow_down'),
+  FilterListCollapse: toIcon('keyboard_arrow_up'),
   TreePause: toIcon('unfold_less'),
   TreeUnpause: toIcon('unfold_more'),
   PreviousPage: toIcon('chevron_left'),

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ export * from './exampleTypes'
 // generic search layouts
 export QueryBuilder from './queryBuilder/'
 export QueryWizard from './queryWizard'
-export * from './FilterList'
+export FilterList, { FilterActions, Label } from './FilterList'
 export FilterAdder from './FilterAdder'
 export FilterButtonList from './FilterButtonList'
 export SearchFilters, { SearchTree } from './SearchFilters'

--- a/src/queryBuilder/QueryBuilder.js
+++ b/src/queryBuilder/QueryBuilder.js
@@ -1,12 +1,9 @@
 import React from 'react'
 import F from 'futil-js'
-import _ from 'lodash/fp'
-import { observer } from 'mobx-react'
 import DDContext from './DragDrop/DDContext'
 import Group from './Group'
 import styles from '../styles'
-import { withNode } from '../utils/hoc'
-import { withTheme } from '../utils/theme'
+import { contexturifyWithoutLoader } from '../utils/hoc'
 import { useLens } from '../utils/react'
 
 let { background } = styles
@@ -40,11 +37,6 @@ let QueryBuilder = ({
   )
 }
 
-export default DDContext(
-  _.flow(
-    observer,
-    withNode,
-    withTheme
-  )(QueryBuilder),
-  { allowEmptyNode: true }
-)
+export default DDContext(contexturifyWithoutLoader(QueryBuilder), {
+  allowEmptyNode: true,
+})

--- a/src/utils/hoc.js
+++ b/src/utils/hoc.js
@@ -55,6 +55,12 @@ export let contexturify = _.flow(
   withTheme
 )
 
+export let contexturifyWithoutLoader = _.flow(
+  observer,
+  withNode,
+  withTheme
+)
+
 // this is used for the text components
 export let withTreeLens = Component =>
   wrapDisplayName('withTreeLens', Component)(({ prop = 'value', ...props }) => (


### PR DESCRIPTION
- adds `contexturifyWithoutLoader` HOC and uses it in TagsQuery, ResultPager, QueryBuilder and FilterList
- FilterList: changes the pause/collapse icons in to ^/v instead of +/-
- SearchFilters: moves the TreePauseButton to the right of the basic filters header