### PR TITLE
Debounce popover onClose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.6.1
+* GreyVest: debounce Popover's `onClose` handler (fixes a bug where toggling a popover's open state just kept the popver open)
+
 # 2.6.0
 * FilterList: remove refresh icon & replace it with an "apply filter" button
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/greyVest/Popover.js
+++ b/src/greyVest/Popover.js
@@ -8,7 +8,7 @@ import { expandProp } from '../utils/react'
 // Simple popover
 let Popover = ({ isOpen, onClose, children, style }) =>
   isOpen && (
-    <OutsideClickHandler onOutsideClick={onClose}>
+    <OutsideClickHandler onOutsideClick={_.debounce(0, onClose)}>
       <div style={{ position: 'relative' }}>
         <div
           className="popover"


### PR DESCRIPTION
This PR fixes an issue where popovers couldn't be toggled off from outside buttons, because the popover's OutsideClickHandler would immediately fire and close it, and then the toggle would simply open it again.

Note that as a side effect of this change, _all_ buttons that open the popover will now "toggle", since the OutsideClickHandler event will still fire first and the debounce will prevent the button's click handler from reopening the popover.

Ideally, we'd want popovers to be able to handle clicks on their trigger component _before_ the internal OutsideClickHandler, to enable both of these use cases: a button that toggles the popover, or a button that can only open it. This would require the popover to be aware of its trigger component, however, which would in turn require an API change.