### PR TITLE
Fix TagsQuery popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.9.3
+* TagsQuery: fix a bug where the actions popover closed itself when clicked on
+
 # 2.9.2
 * Add support for the "searchButtonProps" prop to the SearchBar
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.9.1",
+  "version": "2.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -67,19 +67,19 @@ let TagsQuery = ({
         />
       </GridItem>
       <GridItem place="center">
-        <div onClick={F.flip(popoverState.open)}>
+        <div onClick={F.on(popoverState.open)}>
           <Icon icon="TableColumnMenu" />
-          <Popover open={popoverState.open} style={{ right: 0 }}>
-            <ActionsMenu
-              {...{
-                node,
-                tree,
-                actionWrapper,
-                open: popoverState.open,
-              }}
-            />
-          </Popover>
         </div>
+        <Popover open={popoverState.open} style={{ right: 0 }}>
+          <ActionsMenu
+            {...{
+              node,
+              tree,
+              actionWrapper,
+              open: popoverState.open,
+            }}
+          />
+        </Popover>
       </GridItem>
     </Grid>
   )

--- a/src/utils/schema.js
+++ b/src/utils/schema.js
@@ -6,6 +6,7 @@ export let applyDefaults = F.mapValuesIndexed((val, field) => ({
   field,
   label: F.autoLabel(field),
   order: 0,
+  // `_.get('push') is used instead of `_.isArray` to match mobx4 arrays
   display: x => F.when(_.get('push'), _.join(', '))(x),
   ...val,
 }))


### PR DESCRIPTION
The div containing the popover was flipping the popover state on click - fixed by moving the popover outside.

note that `F.flip` and `F.on` behave the same way for popovers on account of #356 - I just changed it for clarity & efficiency