### PR TITLE
futil import fixes

### DIFF
--- a/src/exampleTypes/FacetSelect.js
+++ b/src/exampleTypes/FacetSelect.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import F from 'futil-js'
+import F from 'futil'
 import _ from 'lodash/fp'
 import Async from 'react-select/lib/Async'
 import { components } from 'react-select'

--- a/src/stories/imdb/searchLayout.js
+++ b/src/stories/imdb/searchLayout.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import F from 'futil-js'
+import F from 'futil'
 import React from 'react'
 import { observable } from 'mobx'
 import { fromPromise } from 'mobx-utils'


### PR DESCRIPTION
From the 2.7.1 update [here](https://github.com/smartprocure/contexture-react/blob/ddf47ad6fc476fcea05bb77dffc7d8f3b197b12f/CHANGELOG.mdx#271) and [the commits](https://github.com/smartprocure/contexture-react/commit/c8c8b2d9464bc09697e64e9dcb0a809f090111db), it looks like these were missed when making the transition from `futil-js` to `futil`. 