### PR TITLE
Fix greyVest import documentation

### DIFF
--- a/src/docs/theme.stories.mdx
+++ b/src/docs/theme.stories.mdx
@@ -16,10 +16,10 @@ To start using themes, simply wrap your application in contexture-react's `Theme
 
 ```jsx
 import { ThemeProvider } from 'contexture-react'
-import { greyVestTheme } from 'contexture-react' // or use your own!
+import { greyVest } from 'contexture-react' // or use your own!
 
 let App = () => (
-  <ThemeProvider theme={greyVestTheme}>{/* rest of your app */}</ThemeProvider>
+  <ThemeProvider theme={greyVest}>{/* rest of your app */}</ThemeProvider>
 )
 ```
 


### PR DESCRIPTION
The theme story example has an import for `greyVestTheme` instead of `greyVest`, which might be intentional since it is just an example, but it could be a confusing to new users as to what the import is for the grey vest theme.