### PR TITLE
Remove `display: block` from input css

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.12.3
+* Date Filter - Css changed to fix the date input size
+
 ### 2.12.2
 * Date Filter - Change added Last 15 months and Last 18 months to the dropdown
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.12.2",
+  "version": "2.12.3",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/greyVest/Style.js
+++ b/src/greyVest/Style.js
@@ -122,7 +122,6 @@ export default () => (
         border: solid 2px #EDEDED;
         background: #fff;
 
-        display: block;
         width: 100%;
         min-width: 0;
 

--- a/src/themes/blueberry/Style.js
+++ b/src/themes/blueberry/Style.js
@@ -43,7 +43,6 @@ export default () => (
         border: solid 2px #EDEDED;
         background: #fff;
         
-        display: block;
         width: 100%;
         
         box-sizing: border-box;

--- a/src/themes/blueberry/Style.js
+++ b/src/themes/blueberry/Style.js
@@ -44,7 +44,7 @@ export default () => (
         background: #fff;
         
         width: 100%;
-        
+        display: block;
         box-sizing: border-box;
         height: 40px;
       }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/910303/75300018-7e881500-57eb-11ea-9c8d-5cef0c032b59.png)


Fixes the issue where the date input height becomes very large due to the inputs inside each being displayed as `block`