### PR TITLE
MemoryTable

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,7 +1,11 @@
+## 2.14.0
+* Add MemoryTable component
+* ExampleTypes: Add emoji-dataset story to Facet
+
 ### 2.13.1
 * Date Filter - Css changed to fix the date input size
 
-### 2.13.0
+## 2.13.0
 * Add "Load More" functionality to ResultTableFooter for results nodes with a `skipCount` flag
 
 ### 2.12.2
@@ -10,10 +14,10 @@
 ### 2.12.1
 * Date Filter - Change `now` to `now+1M/M-1d` to cover the entire current month
 
-### 2.12.0
+## 2.12.0
 * SearchFilters: Add ability to override `uniqueFields` with `allowDuplicateFields` passed through `SearchFilters`
 
-### 2.11.0
+## 2.11.0
 * Add new pagination components to PagedResultTable (ResultPageSize, ResultTableCount)
 * Add stories for PagedResultTable
 * Split off pagination functionality from ResultPager into a separate Pager component for GreyVest (API: `value`, `onChange`, `pageCount`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10034,6 +10034,12 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
       }
+    },
+    "emoji-datasource": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-datasource/-/emoji-datasource-5.0.1.tgz",
+      "integrity": "sha512-RXokuCv4o8RFLiigN1skAdZwJuJWqtBvcK3GVKpvAL/7BeH95enmKsli7cG8YZ85RTjyEe3+GAdpJJOV43KLKQ==",
+      "dev": true
     },
     "emoji-regex": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "danger": "^6.1.13",
     "duti": "^0.15.2",
     "elasticsearch-browser": "^14.2.2",
+    "emoji-datasource": "^5.0.1",
     "eslint": "^4.12.1",
     "eslint-config-smartprocure": "^1.1.0",
     "jest": "^24.7.1",

--- a/src/MemoryTable.js
+++ b/src/MemoryTable.js
@@ -18,14 +18,16 @@ export let memoryService = (records, { schema, debug } = {}) =>
 
 let MemoryTable = ({ data, fields, pageSize = 10, debug, ...props }) => {
   let service = memoryService(data, { schema: 'data', debug })
-  let tree = ContextureMobx({ service })({
-    key: 'root',
-    schema: 'data',
-    children: [
-      { key: 'results', type: 'results', pageSize },
-      { key: 'criteria', type: 'group' },
-    ],
-  })
+  let [tree] = React.useState(
+    ContextureMobx({ service })({
+      key: 'root',
+      schema: 'data',
+      children: [
+        { key: 'results', type: 'results', pageSize },
+        { key: 'criteria', type: 'group', children: [] },
+      ],
+    })
+  )
   tree.refresh(['root'])
   return (
     <ResultTable

--- a/src/MemoryTable.js
+++ b/src/MemoryTable.js
@@ -1,6 +1,7 @@
 import Contexture from 'contexture'
 import memory from 'contexture/src/provider-memory'
 import types from 'contexture/src/provider-memory/exampleTypes'
+import _ from 'lodash/fp'
 import { observer } from 'mobx-react'
 import React from 'react'
 import ContextureMobx from './utils/contexture-mobx'
@@ -10,7 +11,14 @@ let MemoryTable = ({ data, fields }) => {
   let tree = {
     key: 'root',
     schema: 'schema',
-    children: [{ key: 'results', type: 'results', pageSize: 5 }],
+    children: [
+      {
+        key: 'results',
+        type: 'results',
+        pageSize: 5,
+        include: _.keys(_.head(data)),
+      },
+    ],
   }
   let service = Contexture({
     debug: true,

--- a/src/MemoryTable.js
+++ b/src/MemoryTable.js
@@ -1,0 +1,27 @@
+import Contexture from 'contexture'
+import memory from 'contexture/src/provider-memory'
+import types from 'contexture/src/provider-memory/exampleTypes'
+import { observer } from 'mobx-react'
+import React from 'react'
+import ContextureMobx from './utils/contexture-mobx'
+import { ResultTable } from './exampleTypes'
+
+let MemoryTable = ({ data, fields }) => {
+  let tree = {
+    key: 'root',
+    schema: 'schema',
+    children: [{ key: 'results', type: 'results', pageSize: 5 }],
+  }
+  let service = Contexture({
+    debug: true,
+    schemas: { schema: { memory: { records: data } } },
+    providers: { memory: { ...memory, types: types() } },
+  })
+  let search = ContextureMobx({ service })(tree)
+  search.refresh(['root'])
+  return (
+    <ResultTable fields={fields} tree={search} path={['root', 'results']} />
+  )
+}
+
+export default observer(MemoryTable)

--- a/src/MemoryTable.js
+++ b/src/MemoryTable.js
@@ -7,7 +7,7 @@ import React from 'react'
 import ContextureMobx from './utils/contexture-mobx'
 import { ResultTable } from './exampleTypes'
 
-let MemoryTable = ({ data, fields }) => {
+let MemoryTable = ({ data, fields, pageSize, ...props }) => {
   let tree = {
     key: 'root',
     schema: 'schema',
@@ -15,7 +15,7 @@ let MemoryTable = ({ data, fields }) => {
       {
         key: 'results',
         type: 'results',
-        pageSize: 5,
+        pageSize,
         include: _.keys(_.head(data)),
       },
     ],
@@ -28,7 +28,12 @@ let MemoryTable = ({ data, fields }) => {
   let search = ContextureMobx({ service })(tree)
   search.refresh(['root'])
   return (
-    <ResultTable fields={fields} tree={search} path={['root', 'results']} />
+    <ResultTable
+      fields={fields}
+      tree={search}
+      path={['root', 'results']}
+      {...props}
+    />
   )
 }
 

--- a/src/MemoryTable.js
+++ b/src/MemoryTable.js
@@ -1,6 +1,7 @@
 import Contexture from 'contexture'
 import memory from 'contexture/src/provider-memory'
 import types from 'contexture/src/provider-memory/exampleTypes'
+import _ from 'lodash/fp'
 import { observer } from 'mobx-react'
 import React from 'react'
 import ContextureMobx from './utils/contexture-mobx'
@@ -16,14 +17,15 @@ export let memoryService = (records, { schema, debug } = {}) =>
     providers: { memory: { ...memory, types: types() } },
   })
 
-let MemoryTable = ({ data, fields, pageSize = 10, debug, ...props }) => {
+let nodeProps = ['pageSize', 'page', 'sortField', 'sortDir', 'include']
+let MemoryTable = ({ data, fields, debug, ...props }) => {
   let service = memoryService(data, { schema: 'data', debug })
   let [tree] = React.useState(
     ContextureMobx({ service })({
       key: 'root',
       schema: 'data',
       children: [
-        { key: 'results', type: 'results', pageSize },
+        { key: 'results', type: 'results', ..._.pick(nodeProps, props) },
         { key: 'criteria', type: 'group', children: [] },
       ],
     })
@@ -34,7 +36,7 @@ let MemoryTable = ({ data, fields, pageSize = 10, debug, ...props }) => {
       path={['root', 'results']}
       criteria={['root', 'criteria']}
       mapNodeToProps={componentForType(TypeMap)}
-      {...{ fields, tree, ...props }}
+      {...{ fields, tree, ..._.omit(nodeProps, props) }}
     />
   )
 }

--- a/src/MemoryTable.js
+++ b/src/MemoryTable.js
@@ -7,19 +7,20 @@ import ContextureMobx from './utils/contexture-mobx'
 import { componentForType } from './utils/schema'
 import { ResultTable, TypeMap } from './exampleTypes'
 
-export let memoryService = (records, { debug } = {}) =>
+export let memoryService = (records, { schema, debug } = {}) =>
   Contexture({
     debug,
     // Hack to effectively set a default schema: if our tree root doesn't have
     // a `schema` property, it will get the schema at key `undefined`.
-    schemas: { undefined: { memory: { records } } },
+    schemas: { [schema]: { memory: { records } } },
     providers: { memory: { ...memory, types: types() } },
   })
 
 let MemoryTable = ({ data, fields, pageSize = 10, debug, ...props }) => {
-  let service = memoryService(data, { debug })
+  let service = memoryService(data, { schema: 'data', debug })
   let tree = ContextureMobx({ service })({
     key: 'root',
+    schema: 'data',
     children: [
       { key: 'results', type: 'results', pageSize },
       { key: 'criteria', type: 'group' },

--- a/src/MemoryTable.js
+++ b/src/MemoryTable.js
@@ -1,7 +1,6 @@
 import Contexture from 'contexture'
 import memory from 'contexture/src/provider-memory'
 import types from 'contexture/src/provider-memory/exampleTypes'
-import _ from 'lodash/fp'
 import { observer } from 'mobx-react'
 import React from 'react'
 import ContextureMobx from './utils/contexture-mobx'
@@ -11,14 +10,7 @@ let MemoryTable = ({ data, fields, pageSize = 10, ...props }) => {
   let tree = {
     key: 'root',
     schema: 'schema',
-    children: [
-      {
-        key: 'results',
-        type: 'results',
-        pageSize,
-        include: _.keys(_.head(data)),
-      },
-    ],
+    children: [{ key: 'results', type: 'results', pageSize }],
   }
   let service = Contexture({
     debug: true,

--- a/src/MemoryTable.js
+++ b/src/MemoryTable.js
@@ -6,7 +6,7 @@ import React from 'react'
 import ContextureMobx from './utils/contexture-mobx'
 import { ResultTable } from './exampleTypes'
 
-export let memoryService = (records, { debug }) =>
+export let memoryService = (records, { debug } = {}) =>
   Contexture({
     debug,
     // Hack to effectively set a default schema: if our tree root doesn't have

--- a/src/MemoryTable.js
+++ b/src/MemoryTable.js
@@ -4,7 +4,8 @@ import types from 'contexture/src/provider-memory/exampleTypes'
 import { observer } from 'mobx-react'
 import React from 'react'
 import ContextureMobx from './utils/contexture-mobx'
-import { ResultTable } from './exampleTypes'
+import { componentForType } from './utils/schema'
+import { ResultTable, TypeMap } from './exampleTypes'
 
 export let memoryService = (records, { debug } = {}) =>
   Contexture({
@@ -19,11 +20,19 @@ let MemoryTable = ({ data, fields, pageSize = 10, debug, ...props }) => {
   let service = memoryService(data, { debug })
   let tree = ContextureMobx({ service })({
     key: 'root',
-    children: [{ key: 'results', type: 'results', pageSize }],
+    children: [
+      { key: 'results', type: 'results', pageSize },
+      { key: 'criteria', type: 'group' },
+    ],
   })
   tree.refresh(['root'])
   return (
-    <ResultTable path={['root', 'results']} {...{ fields, tree, ...props }} />
+    <ResultTable
+      path={['root', 'results']}
+      criteria={['root', 'criteria']}
+      mapNodeToProps={componentForType(TypeMap)}
+      {...{ fields, tree, ...props }}
+    />
   )
 }
 

--- a/src/MemoryTable.js
+++ b/src/MemoryTable.js
@@ -6,15 +6,19 @@ import React from 'react'
 import ContextureMobx from './utils/contexture-mobx'
 import { ResultTable } from './exampleTypes'
 
-let MemoryTable = ({ data, fields, pageSize = 10, ...props }) => {
-  let service = Contexture({
-    debug: true,
-    schemas: { schema: { memory: { records: data } } },
+export let memoryService = (records, { debug }) =>
+  Contexture({
+    debug,
+    // Hack to effectively set a default schema: if our tree root doesn't have
+    // a `schema` property, it will get the schema at key `undefined`.
+    schemas: { undefined: { memory: { records } } },
     providers: { memory: { ...memory, types: types() } },
   })
+
+let MemoryTable = ({ data, fields, pageSize = 10, debug, ...props }) => {
+  let service = memoryService(data, { debug })
   let tree = ContextureMobx({ service })({
     key: 'root',
-    schema: 'schema',
     children: [{ key: 'results', type: 'results', pageSize }],
   })
   tree.refresh(['root'])

--- a/src/MemoryTable.js
+++ b/src/MemoryTable.js
@@ -7,25 +7,19 @@ import ContextureMobx from './utils/contexture-mobx'
 import { ResultTable } from './exampleTypes'
 
 let MemoryTable = ({ data, fields, pageSize = 10, ...props }) => {
-  let tree = {
-    key: 'root',
-    schema: 'schema',
-    children: [{ key: 'results', type: 'results', pageSize }],
-  }
   let service = Contexture({
     debug: true,
     schemas: { schema: { memory: { records: data } } },
     providers: { memory: { ...memory, types: types() } },
   })
-  let search = ContextureMobx({ service })(tree)
-  search.refresh(['root'])
+  let tree = ContextureMobx({ service })({
+    key: 'root',
+    schema: 'schema',
+    children: [{ key: 'results', type: 'results', pageSize }],
+  })
+  tree.refresh(['root'])
   return (
-    <ResultTable
-      fields={fields}
-      tree={search}
-      path={['root', 'results']}
-      {...props}
-    />
+    <ResultTable path={['root', 'results']} {...{ fields, tree, ...props }} />
   )
 }
 

--- a/src/MemoryTable.js
+++ b/src/MemoryTable.js
@@ -7,7 +7,7 @@ import React from 'react'
 import ContextureMobx from './utils/contexture-mobx'
 import { ResultTable } from './exampleTypes'
 
-let MemoryTable = ({ data, fields, pageSize, ...props }) => {
+let MemoryTable = ({ data, fields, pageSize = 10, ...props }) => {
   let tree = {
     key: 'root',
     schema: 'schema',

--- a/src/MemoryTable.js
+++ b/src/MemoryTable.js
@@ -1,7 +1,6 @@
 import Contexture from 'contexture'
 import memory from 'contexture/src/provider-memory'
 import types from 'contexture/src/provider-memory/exampleTypes'
-import _ from 'lodash/fp'
 import { observer } from 'mobx-react'
 import React from 'react'
 import ContextureMobx from './utils/contexture-mobx'
@@ -17,15 +16,14 @@ export let memoryService = (records, { schema, debug } = {}) =>
     providers: { memory: { ...memory, types: types() } },
   })
 
-let nodeProps = ['pageSize', 'page', 'sortField', 'sortDir', 'include']
-let MemoryTable = ({ data, fields, debug, ...props }) => {
+let MemoryTable = ({ data, fields, debug, include, ...props }) => {
   let service = memoryService(data, { schema: 'data', debug })
   let [tree] = React.useState(
     ContextureMobx({ service })({
       key: 'root',
       schema: 'data',
       children: [
-        { key: 'results', type: 'results', ..._.pick(nodeProps, props) },
+        { key: 'results', type: 'results', include },
         { key: 'criteria', type: 'group', children: [] },
       ],
     })
@@ -36,7 +34,7 @@ let MemoryTable = ({ data, fields, debug, ...props }) => {
       path={['root', 'results']}
       criteria={['root', 'criteria']}
       mapNodeToProps={componentForType(TypeMap)}
-      {...{ fields, tree, ..._.omit(nodeProps, props) }}
+      {...{ fields, tree, ...props }}
     />
   )
 }

--- a/src/MemoryTable.stories.js
+++ b/src/MemoryTable.stories.js
@@ -1,0 +1,16 @@
+import _ from 'lodash/fp'
+import React from 'react'
+import ThemePicker from './stories/themePicker'
+import MemoryTable from './MemoryTable'
+
+export default {
+  title: 'MemoryTable',
+  component: MemoryTable,
+  decorators: [ThemePicker('greyVest')],
+}
+
+export let story = () => {
+  let fields = { _id: { label: 'id' }, value: { label: 'val' } }
+  let data = _.times(x => ({ _id: x, value: _.random(0, 20000) }), 221)
+  return <MemoryTable {...{ data, fields }} />
+}

--- a/src/MemoryTable.stories.js
+++ b/src/MemoryTable.stories.js
@@ -20,28 +20,28 @@ However, in place of ResultTable's contexture-relevant \`tree\`/\`node\`/\`path\
   },
 }
 
-export let story = () => {
-  let fields = { id: { label: '#' }, value: { label: 'Count' } }
-  let data = _.times(x => ({ id: x, value: _.random(0, 20000) }), 221)
-  return <MemoryTable {...{ data, fields }} />
-}
+export let story = () => (
+  <MemoryTable
+    data={_.times(x => ({ id: x, value: _.random(0, 20000) }), 221)}
+    fields={{ id: { label: '#' }, value: { label: 'Count' } }}
+  />
+)
 
-export let withInfer = () => {
-  let data = _.times(x => ({ id: x, value: _.random(0, 20000) }), 221)
-  return <MemoryTable infer {...{ data }} />
-}
+export let withInfer = () => (
+  <MemoryTable
+    infer
+    data={_.times(x => ({ id: x, value: _.random(0, 20000) }), 221)}
+  />
+)
 
-export let resultTableProps = () => {
-  let fields = { id: { label: '#' }, value: { label: 'Count' } }
-  let data = _.times(x => ({ id: x, value: _.random(0, 20000) }), 221)
-  return (
-    <MemoryTable
-      {...{ data, fields }}
-      pageSize={12}
-      pageSizeOptions={[12, 24, 48, 96]}
-    />
-  )
-}
+export let resultTableProps = () => (
+  <MemoryTable
+    data={_.times(x => ({ id: x, value: _.random(0, 20000) }), 221)}
+    fields={{ id: { label: '#' }, value: { label: 'Count' } }}
+    pageSize={12}
+    pageSizeOptions={[12, 24, 48, 96]}
+  />
+)
 
 export let emojiDataset = () => (
   <MemoryTable

--- a/src/MemoryTable.stories.js
+++ b/src/MemoryTable.stories.js
@@ -1,8 +1,9 @@
-//import emoji from 'emoji-datasource'
+import F from 'futil'
 import _ from 'lodash/fp'
 import React from 'react'
 import EmojiIcon from './stories/EmojiIcon'
 import ThemePicker from './stories/themePicker'
+import { Select } from './greyVest'
 import MemoryTable from './MemoryTable'
 
 export default {
@@ -41,7 +42,26 @@ export let emojis = () => (
     fields={{
       image: {
         order: 1,
-        display: (x, record) => <EmojiIcon set="facebook" record={record} />,
+        display: (x, record) => <EmojiIcon set={record.set} record={record} />,
+      },
+      test: {
+        order: 2,
+        display: (x, record) => (
+          <>
+            <Select
+              options={F.autoLabelOptions([
+                'twitter',
+                'google',
+                'facebook',
+                'apple',
+              ])}
+              onChange={value => {
+                record.set = value
+              }}
+              value={record.set}
+            />
+          </>
+        ),
       },
     }}
   />

--- a/src/MemoryTable.stories.js
+++ b/src/MemoryTable.stories.js
@@ -34,7 +34,7 @@ export let resultTableProps = () => {
   )
 }
 
-export let emojis = () => (
+export let emojiDataset = () => (
   <MemoryTable
     infer
     data={require('emoji-datasource')}

--- a/src/MemoryTable.stories.js
+++ b/src/MemoryTable.stories.js
@@ -1,9 +1,8 @@
 import _ from 'lodash/fp'
 import React from 'react'
-import EmojiIcon from './stories/EmojiIcon'
 import ThemePicker from './stories/themePicker'
 import MemoryTable from './MemoryTable'
-import { schema } from './exampleTypes/stories/emojiData'
+import emojiData from './exampleTypes/stories/emojiData'
 
 export default {
   title: 'MemoryTable',
@@ -44,15 +43,5 @@ export let resultTableProps = () => (
 )
 
 export let emojiDataset = () => (
-  <MemoryTable
-    infer
-    data={require('emoji-datasource')}
-    fields={{
-      ...schema,
-      image: {
-        order: 1,
-        display: (x, record) => <EmojiIcon set="facebook" record={record} />,
-      },
-    }}
-  />
+  <MemoryTable data={require('emoji-datasource')} fields={emojiData} />
 )

--- a/src/MemoryTable.stories.js
+++ b/src/MemoryTable.stories.js
@@ -12,19 +12,19 @@ export default {
 }
 
 export let story = () => {
-  let fields = { _id: { label: 'id' }, value: { label: 'val' } }
-  let data = _.times(x => ({ _id: x, value: _.random(0, 20000) }), 221)
+  let fields = { id: { label: '#' }, value: { label: 'Count' } }
+  let data = _.times(x => ({ id: x, value: _.random(0, 20000) }), 221)
   return <MemoryTable {...{ data, fields }} />
 }
 
 export let withInfer = () => {
-  let data = _.times(x => ({ _id: x, value: _.random(0, 20000) }), 221)
+  let data = _.times(x => ({ id: x, value: _.random(0, 20000) }), 221)
   return <MemoryTable infer {...{ data }} />
 }
 
 export let resultTableProps = () => {
-  let fields = { _id: { label: 'id' }, value: { label: 'val' } }
-  let data = _.times(x => ({ _id: x, value: _.random(0, 20000) }), 221)
+  let fields = { id: { label: '#' }, value: { label: 'Count' } }
+  let data = _.times(x => ({ id: x, value: _.random(0, 20000) }), 221)
   return (
     <MemoryTable
       {...{ data, fields }}

--- a/src/MemoryTable.stories.js
+++ b/src/MemoryTable.stories.js
@@ -3,19 +3,21 @@ import React from 'react'
 import EmojiIcon from './stories/EmojiIcon'
 import ThemePicker from './stories/themePicker'
 import MemoryTable from './MemoryTable'
+import { schema } from './exampleTypes/stories/emojiData'
 
 export default {
   title: 'MemoryTable',
   component: MemoryTable,
   decorators: [ThemePicker('greyVest')],
   parameters: {
-    componentSubtitle: "A ResultTable from arbitrary data using contexture's memory provider",
+    componentSubtitle:
+      "A ResultTable from arbitrary data using contexture's memory provider",
     info: `
 MemoryTable is built on top of ResultTable and supports several of the same props: most notably \`fields\`, which takes a schema object that specifies which fields from the data are visible in the table and how they are ordered, and \`infer\`, which enables MemoryTable to infer field information from the given data without having to explicitly specify it in \`fields\`.
 
 However, in place of ResultTable's contexture-relevant \`tree\`/\`node\`/\`path\` props, MemoryTable simply accepts a \`data\` prop, which should be an array of obects. This is fed into a contexture instance running on the \`memory\` provider, which allows contexture to work against data in the form of plain Javascript objects (in contrast to, for example, a MongoDB database). The result is a dynamically-generated table with built-in support for sorting and filtering operations on the given data.
-`
-  }
+`,
+  },
 }
 
 export let story = () => {
@@ -46,6 +48,7 @@ export let emojiDataset = () => (
     infer
     data={require('emoji-datasource')}
     fields={{
+      ...schema,
       image: {
         order: 1,
         display: (x, record) => <EmojiIcon set="facebook" record={record} />,

--- a/src/MemoryTable.stories.js
+++ b/src/MemoryTable.stories.js
@@ -1,9 +1,8 @@
-import F from 'futil'
+//import emoji from 'emoji-datasource'
 import _ from 'lodash/fp'
 import React from 'react'
 import EmojiIcon from './stories/EmojiIcon'
 import ThemePicker from './stories/themePicker'
-import { Select } from './greyVest'
 import MemoryTable from './MemoryTable'
 
 export default {
@@ -42,26 +41,7 @@ export let emojis = () => (
     fields={{
       image: {
         order: 1,
-        display: (x, record) => <EmojiIcon set={record.set} record={record} />,
-      },
-      test: {
-        order: 2,
-        display: (x, record) => (
-          <>
-            <Select
-              options={F.autoLabelOptions([
-                'twitter',
-                'google',
-                'facebook',
-                'apple',
-              ])}
-              onChange={value => {
-                record.set = value
-              }}
-              value={record.set}
-            />
-          </>
-        ),
+        display: (x, record) => <EmojiIcon set="facebook" record={record} />,
       },
     }}
   />

--- a/src/MemoryTable.stories.js
+++ b/src/MemoryTable.stories.js
@@ -39,6 +39,9 @@ export let resultTableProps = () => (
     fields={{ id: { label: '#' }, value: { label: 'Count' } }}
     pageSize={12}
     pageSizeOptions={[12, 24, 48, 96]}
+    page={4}
+    sortField="value"
+    sortDir="desc"
   />
 )
 

--- a/src/MemoryTable.stories.js
+++ b/src/MemoryTable.stories.js
@@ -14,3 +14,15 @@ export let story = () => {
   let data = _.times(x => ({ _id: x, value: _.random(0, 20000) }), 221)
   return <MemoryTable {...{ data, fields }} />
 }
+
+export let resultTableProps = () => {
+  let fields = { _id: { label: 'id' }, value: { label: 'val' } }
+  let data = _.times(x => ({ _id: x, value: _.random(0, 20000) }), 221)
+  return (
+    <MemoryTable
+      {...{ data, fields }}
+      pageSize={12}
+      pageSizeOptions={[12, 24, 48, 96]}
+    />
+  )
+}

--- a/src/MemoryTable.stories.js
+++ b/src/MemoryTable.stories.js
@@ -1,4 +1,3 @@
-//import emoji from 'emoji-datasource'
 import _ from 'lodash/fp'
 import React from 'react'
 import EmojiIcon from './stories/EmojiIcon'
@@ -9,6 +8,14 @@ export default {
   title: 'MemoryTable',
   component: MemoryTable,
   decorators: [ThemePicker('greyVest')],
+  parameters: {
+    componentSubtitle: "A ResultTable from arbitrary data using contexture's memory provider",
+    info: `
+MemoryTable is built on top of ResultTable and supports several of the same props: most notably \`fields\`, which takes a schema object that specifies which fields from the data are visible in the table and how they are ordered, and \`infer\`, which enables MemoryTable to infer field information from the given data without having to explicitly specify it in \`fields\`.
+
+However, in place of ResultTable's contexture-relevant \`tree\`/\`node\`/\`path\` props, MemoryTable simply accepts a \`data\` prop, which should be an array of obects. This is fed into a contexture instance running on the \`memory\` provider, which allows contexture to work against data in the form of plain Javascript objects (in contrast to, for example, a MongoDB database). The result is a dynamically-generated table with built-in support for sorting and filtering operations on the given data.
+`
+  }
 }
 
 export let story = () => {

--- a/src/MemoryTable.stories.js
+++ b/src/MemoryTable.stories.js
@@ -2,6 +2,8 @@ import _ from 'lodash/fp'
 import React from 'react'
 import ThemePicker from './stories/themePicker'
 import MemoryTable from './MemoryTable'
+import emoji from 'emoji-datasource'
+import sheet from 'emoji-datasource/img/twitter/sheets/32.png'
 
 export default {
   title: 'MemoryTable',
@@ -14,6 +16,34 @@ export let story = () => {
   let data = _.times(x => ({ _id: x, value: _.random(0, 20000) }), 221)
   return <MemoryTable {...{ data, fields }} />
 }
+
+export let withInfer = () => {
+  let data = _.times(x => ({ _id: x, value: _.random(0, 20000) }), 221)
+  return <MemoryTable infer {...{ data }} />
+}
+
+export let emojis = () => (
+  <MemoryTable
+    infer
+    data={emoji}
+    fields={{
+      image: {
+        order: 1,
+        display: (x, { sheet_x, sheet_y }) => (
+          <div
+            style={{
+              backgroundImage: `url(${sheet})`,
+              backgroundPosition: `-${sheet_x * 34}px -${sheet_y * 34}px`,
+              width: 33,
+              height: 33,
+              transform: 'scale(0.75)',
+            }}
+          />
+        ),
+      },
+    }}
+  />
+)
 
 export let resultTableProps = () => {
   let fields = { _id: { label: 'id' }, value: { label: 'val' } }

--- a/src/MemoryTable.stories.js
+++ b/src/MemoryTable.stories.js
@@ -37,11 +37,7 @@ export let resultTableProps = () => (
   <MemoryTable
     data={_.times(x => ({ id: x, value: _.random(0, 20000) }), 221)}
     fields={{ id: { label: '#' }, value: { label: 'Count' } }}
-    pageSize={12}
     pageSizeOptions={[12, 24, 48, 96]}
-    page={4}
-    sortField="value"
-    sortDir="desc"
   />
 )
 

--- a/src/MemoryTable.stories.js
+++ b/src/MemoryTable.stories.js
@@ -1,9 +1,9 @@
+//import emoji from 'emoji-datasource'
 import _ from 'lodash/fp'
 import React from 'react'
+import EmojiIcon from './stories/EmojiIcon'
 import ThemePicker from './stories/themePicker'
 import MemoryTable from './MemoryTable'
-import emoji from 'emoji-datasource'
-import sheet from 'emoji-datasource/img/twitter/sheets/32.png'
 
 export default {
   title: 'MemoryTable',
@@ -22,29 +22,6 @@ export let withInfer = () => {
   return <MemoryTable infer {...{ data }} />
 }
 
-export let emojis = () => (
-  <MemoryTable
-    infer
-    data={emoji}
-    fields={{
-      image: {
-        order: 1,
-        display: (x, { sheet_x, sheet_y }) => (
-          <div
-            style={{
-              backgroundImage: `url(${sheet})`,
-              backgroundPosition: `-${sheet_x * 34}px -${sheet_y * 34}px`,
-              width: 33,
-              height: 33,
-              transform: 'scale(0.75)',
-            }}
-          />
-        ),
-      },
-    }}
-  />
-)
-
 export let resultTableProps = () => {
   let fields = { _id: { label: 'id' }, value: { label: 'val' } }
   let data = _.times(x => ({ _id: x, value: _.random(0, 20000) }), 221)
@@ -56,3 +33,16 @@ export let resultTableProps = () => {
     />
   )
 }
+
+export let emojis = () => (
+  <MemoryTable
+    infer
+    data={require('emoji-datasource')}
+    fields={{
+      image: {
+        order: 1,
+        display: (x, record) => <EmojiIcon set="facebook" record={record} />,
+      },
+    }}
+  />
+)

--- a/src/docs/theme.stories.mdx
+++ b/src/docs/theme.stories.mdx
@@ -16,10 +16,10 @@ To start using themes, simply wrap your application in contexture-react's `Theme
 
 ```jsx
 import { ThemeProvider } from 'contexture-react'
-import { greyVestTheme } from 'contexture-react' // or use your own!
+import { greyVest } from 'contexture-react' // or use your own!
 
 let App = () => (
-  <ThemeProvider theme={greyVestTheme}>{/* rest of your app */}</ThemeProvider>
+  <ThemeProvider theme={greyVest}>{/* rest of your app */}</ThemeProvider>
 )
 ```
 

--- a/src/exampleTypes/Facet.stories.js
+++ b/src/exampleTypes/Facet.stories.js
@@ -1,10 +1,16 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import TestTree from './stories/testTree'
 import ThemePicker from '../stories/themePicker'
 import { Facet, FacetSelect } from '.'
 
-storiesOf('ExampleTypes|Facet', module)
-  .addDecorator(ThemePicker('greyVest'))
-  .add('Facet', () => <Facet tree={TestTree()} path={['facet']} />)
-  .add('FacetSelect', () => <FacetSelect tree={TestTree()} path={['facet']} />)
+export default {
+  title: 'ExampleTypes | Facet',
+  component: Facet,
+  decorators: [ThemePicker('greyVest')],
+}
+
+export let facet = () => <Facet tree={TestTree()} path={['facet']} />
+
+export let facetSelect = () => (
+  <FacetSelect tree={TestTree()} path={['facet']} />
+)

--- a/src/exampleTypes/Facet.stories.js
+++ b/src/exampleTypes/Facet.stories.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import TestTree from './stories/testTree'
 import ThemePicker from '../stories/themePicker'
-import { Facet, FacetSelect } from '.'
+import { memoryService } from '../MemoryTable'
+import ContextureMobx from '../utils/contexture-mobx'
+import { Grid, Box } from '../greyVest'
+import { Facet, FacetSelect, ResultTable } from '.'
 
 export default {
   title: 'ExampleTypes | Facet',
@@ -14,3 +17,28 @@ export let facet = () => <Facet tree={TestTree()} path={['facet']} />
 export let facetSelect = () => (
   <FacetSelect tree={TestTree()} path={['facet']} />
 )
+
+export let emojiDataset = () => {
+  let data = require('emoji-datasource')
+  let service = memoryService(data)
+  let tree = ContextureMobx({ service })({
+    key: 'root',
+    children: [{ type: 'facet', field: 'category' }, { type: 'results' }],
+  })
+  tree.refresh(['root'])
+  return (
+    <Grid columns="1fr 3fr" gap={8}>
+      <Box>
+        <Facet tree={tree} path={['root', 'category-facet']} />
+      </Box>
+      <Box style={{ overflow: 'auto' }}>
+        <ResultTable
+          infer
+          tree={tree}
+          path={['root', 'results']}
+          fields={{ category: { order: 1 } }}
+        />
+      </Box>
+    </Grid>
+  )
+}

--- a/src/exampleTypes/FacetSelect.js
+++ b/src/exampleTypes/FacetSelect.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import F from 'futil-js'
+import F from 'futil'
 import _ from 'lodash/fp'
 import Async from 'react-select/lib/Async'
 import { components } from 'react-select'

--- a/src/exampleTypes/stories/emojiData.js
+++ b/src/exampleTypes/stories/emojiData.js
@@ -1,0 +1,30 @@
+import _ from 'lodash/fp'
+
+let defaultTypes = {
+  name: 'text',
+  unified: 'text',
+  non_qualified: 'text',
+  docomo: null,
+  au: 'text',
+  softbank: 'text',
+  google: 'text',
+  image: 'text',
+  sheet_x: 'number',
+  sheet_y: 'number',
+  short_name: 'text',
+  short_names: 'text',
+  text: null,
+  texts: null,
+  category: 'facet',
+  sort_order: 'number',
+  added_in: 'text',
+  has_img_apple: 'bool',
+  has_img_google: 'bool',
+  has_img_twitter: 'bool',
+  has_img_facebook: 'bool',
+  skin_variations: 'facet',
+  obsoletes: 'facet',
+  obsoleted_by: 'facet',
+}
+
+export let schema = _.mapValues(defaultType => ({ defaultType }), defaultTypes)

--- a/src/exampleTypes/stories/emojiData.js
+++ b/src/exampleTypes/stories/emojiData.js
@@ -1,4 +1,8 @@
+import React from 'react'
 import _ from 'lodash/fp'
+import F from 'futil'
+import MemoryTable from '../../MemoryTable'
+import EmojiIcon from '../../stories/EmojiIcon'
 
 let typeDefaults = {
   name: 'text',
@@ -17,7 +21,7 @@ let typeDefaults = {
   texts: null,
   category: 'facet',
   sort_order: 'number',
-  added_in: 'text',
+  added_in: 'facet',
   has_img_apple: 'bool',
   has_img_google: 'bool',
   has_img_twitter: 'bool',
@@ -27,4 +31,19 @@ let typeDefaults = {
   obsoleted_by: 'facet',
 }
 
-export let schema = _.mapValues(typeDefault => ({ typeDefault }), typeDefaults)
+let overrides = {
+  skin_variations: {
+    display: x => x && <MemoryTable infer data={F.unkeyBy('foo', x)} />,
+  },
+  image: {
+    order: 1,
+    display: (x, record) => <EmojiIcon set="facebook" record={record} />,
+  },
+}
+
+let schema = _.flow(
+  _.mapValues(typeDefault => ({ typeDefault })),
+  _.merge(overrides)
+)(typeDefaults)
+
+export default schema

--- a/src/exampleTypes/stories/emojiData.js
+++ b/src/exampleTypes/stories/emojiData.js
@@ -1,6 +1,6 @@
 import _ from 'lodash/fp'
 
-let defaultTypes = {
+let typeDefaults = {
   name: 'text',
   unified: 'text',
   non_qualified: 'text',
@@ -27,4 +27,4 @@ let defaultTypes = {
   obsoleted_by: 'facet',
 }
 
-export let schema = _.mapValues(defaultType => ({ defaultType }), defaultTypes)
+export let schema = _.mapValues(typeDefault => ({ typeDefault }), typeDefaults)

--- a/src/exampleTypes/stories/emojiData.js
+++ b/src/exampleTypes/stories/emojiData.js
@@ -4,46 +4,55 @@ import F from 'futil'
 import MemoryTable from '../../MemoryTable'
 import EmojiIcon from '../../stories/EmojiIcon'
 
-let typeDefaults = {
-  name: 'text',
-  unified: 'text',
-  non_qualified: 'text',
-  docomo: null,
-  au: 'text',
-  softbank: 'text',
-  google: 'text',
-  image: 'text',
-  sheet_x: 'number',
-  sheet_y: 'number',
-  short_name: 'text',
-  short_names: 'text',
-  text: null,
-  texts: null,
-  category: 'facet',
-  sort_order: 'number',
-  added_in: 'facet',
-  has_img_apple: 'bool',
-  has_img_google: 'bool',
-  has_img_twitter: 'bool',
-  has_img_facebook: 'bool',
-  skin_variations: 'facet',
-  obsoletes: 'facet',
-  obsoleted_by: 'facet',
+// types
+let number = { typeDefault: number }
+let bool = { typeDefault: 'bool', display: x => (x ? 'Yes' : 'No') }
+let codePoint = {
+  typeDefault: 'text',
+  display: F.whenExists(
+    _.flow(
+      _.split('-'),
+      _.map(x => parseInt(x, 16)),
+      _.spread(String.fromCodePoint)
+    )
+  ),
 }
 
-let overrides = {
-  skin_variations: {
-    display: x => x && <MemoryTable infer data={F.unkeyBy('foo', x)} />,
-  },
+let schema = {
   image: {
-    order: 1,
     display: (x, record) => <EmojiIcon set="facebook" record={record} />,
   },
+  name: { typeDefault: 'text' },
+  unified: codePoint,
+  non_qualified: codePoint,
+  sheet_x: { typeDefault: 'number' },
+  sheet_y: { typeDefault: 'number' },
+  short_name: { typeDefault: 'facet' },
+  short_names: { typeDefault: 'facet' },
+  category: { typeDefault: 'facet' },
+  sort_order: { typeDefault: 'number' },
+  added_in: { typeDefault: 'facet' },
+  has_img_apple: bool,
+  has_img_google: bool,
+  has_img_twitter: bool,
+  has_img_facebook: bool,
+  text: { typeDefault: 'facet' },
+  texts: { typeDefault: 'facet' },
+  obsoletes: codePoint,
+  obsoleted_by: codePoint,
 }
-
-let schema = _.flow(
-  _.mapValues(typeDefault => ({ typeDefault })),
-  _.merge(overrides)
-)(typeDefaults)
+schema.skin_variations = {
+  typeDefault: 'facet',
+  display: x =>
+    x && (
+      <MemoryTable
+        data={F.unkeyBy('skin_tone', x)}
+        fields={{
+          skin_tone: codePoint,
+          ..._.pick(['image', 'unified'], schema),
+        }}
+      />
+    ),
+}
 
 export default schema

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,8 @@ export SearchFilters, { SearchTree } from './SearchFilters'
 export SearchLayout from './SearchLayout'
 export ToggleFiltersHeader from './ToggleFiltersHeader'
 
+export MemoryTable from './MemoryTable'
+
 // component library
 export * from './greyVest'
 

--- a/src/stories/EmojiIcon.js
+++ b/src/stories/EmojiIcon.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+let getSheet = set => require(`emoji-datasource/img/${set}/sheets/32.png`)
+
+let EmojiIcon = ({ set = 'twitter', record: { sheet_x, sheet_y } }) => (
+  <div
+    style={{
+      backgroundImage: `url(${getSheet(set)})`,
+      backgroundPosition: `-${sheet_x * 34}px -${sheet_y * 34}px`,
+      width: 33,
+      height: 33,
+      transform: 'scale(0.75)',
+    }}
+  />
+)
+export default EmojiIcon

--- a/src/stories/imdb/searchLayout.js
+++ b/src/stories/imdb/searchLayout.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp'
-import F from 'futil-js'
+import F from 'futil'
 import React from 'react'
 import { observable } from 'mobx'
 import { fromPromise } from 'mobx-utils'


### PR DESCRIPTION
A new component that takes a `data` prop containing an array of objects, feeds the data into contexture-memory, and renders a ResultTable with it. 

**Note on filtering:**

In ResultTable, there is a "filter" option in each column header's menu that checks the `criteria` group for a node whose field matches, and renders a component for that node. Since the tree is internal to MemoryTable in our case, we need to programmatically add a filter for each type when the component is rendered.

ResultTable automatically adds filters for all fields with `typeDefault` set on the schema. MemoryTable lets ResultTable handle it, which means that for fields to be filterable, you _must_ pass the component a `fields` schema with typeDefaults in it.