### PR TITLE
Safely check for `node.context.cardinality` in Facet

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.14.1
+* Fix a bug in Facet where it would throw an error if `node.context` was undefined (now safely checks via `_.get`)
+
 ## 2.14.0
 * Add MemoryTable component
 * ExampleTypes: Add emoji-dataset story to Facet

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -11,27 +11,26 @@ export let Cardinality = _.flow(
   setDisplayName('Cardinality'),
   observer
 )(({ node, tree }) => (
-  <Flex
-    className="contexture-facet-cardinality"
-    style={{ justifyContent: 'space-between' }}
-  >
-    {!!node.context.cardinality && (
-      <div>
-        Showing {_.min([node.size || 10, node.context.options.length])} of{' '}
-        {node.context.cardinality}
-      </div>
-    )}
-    {node.context.cardinality > (node.size || 10) && (
-      <div>
-        <a
-          onClick={() =>
-            tree.mutate(node.path, { size: (node.size || 10) + 10 })
-          }
-          style={{ cursor: 'pointer' }}
-        >
-          View More
-        </a>
-      </div>
+  <Flex className="contexture-facet-cardinality" justifyContent="space-between">
+    {!!_.get('context.cardinality', node) && (
+      <>
+        <div>
+          Showing {_.min([node.size || 10, _.size(node.context.options)])} of{' '}
+          {node.context.cardinality}
+        </div>
+        {node.context.cardinality > (node.size || 10) && (
+          <div>
+            <a
+              onClick={() =>
+                tree.mutate(node.path, { size: (node.size || 10) + 10 })
+              }
+              style={{ cursor: 'pointer' }}
+            >
+              View More
+            </a>
+          </div>
+        )}
+      </>
     )}
   </Flex>
 ))

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -10,30 +10,31 @@ import { withTheme } from '../utils/theme'
 export let Cardinality = _.flow(
   setDisplayName('Cardinality'),
   observer
-)(({ node, tree }) => (
-  <Flex className="contexture-facet-cardinality" justifyContent="space-between">
-    {!!_.get('context.cardinality', node) && (
-      <>
+)(({ node, tree }) =>
+  _.get('context.cardinality', node) ? (
+    <Flex
+      className="contexture-facet-cardinality"
+      justifyContent="space-between"
+    >
+      <div>
+        Showing {_.min([node.size || 10, _.size(node.context.options)])} of{' '}
+        {node.context.cardinality}
+      </div>
+      {node.context.cardinality > (node.size || 10) && (
         <div>
-          Showing {_.min([node.size || 10, _.size(node.context.options)])} of{' '}
-          {node.context.cardinality}
+          <a
+            onClick={() =>
+              tree.mutate(node.path, { size: (node.size || 10) + 10 })
+            }
+            style={{ cursor: 'pointer' }}
+          >
+            View More
+          </a>
         </div>
-        {node.context.cardinality > (node.size || 10) && (
-          <div>
-            <a
-              onClick={() =>
-                tree.mutate(node.path, { size: (node.size || 10) + 10 })
-              }
-              style={{ cursor: 'pointer' }}
-            >
-              View More
-            </a>
-          </div>
-        )}
-      </>
-    )}
-  </Flex>
-))
+      )}
+    </Flex>
+  ) : null
+)
 
 let SelectAll = _.flow(
   setDisplayName('SelectAll'),


### PR DESCRIPTION
Previously, if `node.context` was undefined, Facet would throw. Now it does a safe check with `_.get` before trying to render its Cardinality child component.