### PR TITLE
feature/389 - invoke display fn for facet values with label argument

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.15.0
+* Implement support for passing the labelData prop on facet values to the display function for a facet instance
+
 ### 2.14.1
 * Fix a bug in Facet where it would throw an error if `node.context` was undefined (now safely checks via `_.get`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.13.1",
+  "version": "2.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -123,7 +123,7 @@ let Facet = ({
     {_.flow(
       _.partition(x => _.includes(x.name, node.values)),
       _.flatten,
-      _.map(({ name, count, labelData }) => {
+      _.map(({ name, label, count }) => {
         let lens = tree.lens(node.path, 'values')
         return (
           <label
@@ -134,11 +134,11 @@ let Facet = ({
               display: 'flex',
               cursor: 'pointer',
             }}
-            title={`${display(name, labelData)} : ${formatCount(count)}`}
+            title={`${display(name, label)} : ${formatCount(count)}`}
           >
             <Checkbox {...F.domLens.checkboxValues(name, lens)} />
             <div style={{ flex: 2, padding: '0 5px' }}>
-              {display(name, labelData) || displayBlank()}
+              {display(name, label) || displayBlank()}
             </div>
             {!hide.counts && <div>{formatCount(count)}</div>}
           </label>

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -134,7 +134,7 @@ let Facet = ({
               display: 'flex',
               cursor: 'pointer',
             }}
-            title={`${invokeDisplayFn(name, label)} : ${formatCount(count)}`}
+            title={`${display(name, label)} : ${formatCount(count)}`}
           >
             <Checkbox {...F.domLens.checkboxValues(name, lens)} />
             <div style={{ flex: 2, padding: '0 5px' }}>

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -134,7 +134,7 @@ let Facet = ({
               display: 'flex',
               cursor: 'pointer',
             }}
-            title={`${display(name)} : ${formatCount(count)}`}
+            title={`${display(name, labelData)} : ${formatCount(count)}`}
           >
             <Checkbox {...F.domLens.checkboxValues(name, lens)} />
             <div style={{ flex: 2, padding: '0 5px' }}>

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -107,7 +107,7 @@ let Facet = ({
     facetFilter: false, // Hide the search box above the facet checkboxes
     counts: false, // Hide the facet counts so only the labels are displayed
   },
-  display = x => x,
+  display = (x, y) => _.isString(y) ? y : x,
   displayBlank = () => <i>Not Specified</i>,
   formatCount = x => x,
   theme: { Checkbox, RadioList },
@@ -125,13 +125,6 @@ let Facet = ({
       _.flatten,
       _.map(({ name, label, count }) => {
         let lens = tree.lens(node.path, 'values')
-        let invokeDisplayFn = (name, label) => {
-          if (_.isString(label)) {
-            return display(label)
-          } else {
-            return display(name, label)
-          }
-        }
         return (
           <label
             key={name}
@@ -145,7 +138,7 @@ let Facet = ({
           >
             <Checkbox {...F.domLens.checkboxValues(name, lens)} />
             <div style={{ flex: 2, padding: '0 5px' }}>
-              {invokeDisplayFn(name, label) || displayBlank()}
+              {display(name, label) || displayBlank()}
             </div>
             {!hide.counts && <div>{formatCount(count)}</div>}
           </label>

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -125,6 +125,13 @@ let Facet = ({
       _.flatten,
       _.map(({ name, label, count }) => {
         let lens = tree.lens(node.path, 'values')
+        let invokeDisplayFn = (name, label) => {
+          if (_.isString(label)) {
+            return display(label)
+          } else {
+            return display(name, label)
+          }
+        }
         return (
           <label
             key={name}
@@ -134,11 +141,11 @@ let Facet = ({
               display: 'flex',
               cursor: 'pointer',
             }}
-            title={`${display(name, label)} : ${formatCount(count)}`}
+            title={`${invokeDisplayFn(name, label)} : ${formatCount(count)}`}
           >
             <Checkbox {...F.domLens.checkboxValues(name, lens)} />
             <div style={{ flex: 2, padding: '0 5px' }}>
-              {display(name, label) || displayBlank()}
+              {invokeDisplayFn(name, label) || displayBlank()}
             </div>
             {!hide.counts && <div>{formatCount(count)}</div>}
           </label>

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -107,7 +107,7 @@ let Facet = ({
     facetFilter: false, // Hide the search box above the facet checkboxes
     counts: false, // Hide the facet counts so only the labels are displayed
   },
-  display = (x, y) => (_.isString(y) ? y : x),
+  display = (name, label) => (_.isString(label) ? label : name),
   displayBlank = () => <i>Not Specified</i>,
   formatCount = x => x,
   theme: { Checkbox, RadioList },

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -123,7 +123,7 @@ let Facet = ({
     {_.flow(
       _.partition(x => _.includes(x.name, node.values)),
       _.flatten,
-      _.map(({ name, count }) => {
+      _.map(({ name, count, labelData }) => {
         let lens = tree.lens(node.path, 'values')
         return (
           <label
@@ -138,7 +138,7 @@ let Facet = ({
           >
             <Checkbox {...F.domLens.checkboxValues(name, lens)} />
             <div style={{ flex: 2, padding: '0 5px' }}>
-              {display(name) || displayBlank()}
+              {display(name, labelData) || displayBlank()}
             </div>
             {!hide.counts && <div>{formatCount(count)}</div>}
           </label>

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -107,7 +107,7 @@ let Facet = ({
     facetFilter: false, // Hide the search box above the facet checkboxes
     counts: false, // Hide the facet counts so only the labels are displayed
   },
-  display = (x, y) => _.isString(y) ? y : x,
+  display = (x, y) => (_.isString(y) ? y : x),
   displayBlank = () => <i>Not Specified</i>,
   formatCount = x => x,
   theme: { Checkbox, RadioList },


### PR DESCRIPTION
Fixes #389 

### Description
* part of a project to get rid of that goofy thing where if you want to display a facet with mongoId values you have load a map of all possible values to reasonable labels into the client separately.
* `contexture-mongo` changes will implement basically a populate stage for facet values where you can pick values off a record from another collection for use in your `display` function on the facet. 