### PR TITLE
Add support for NoResultsComponent

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.16.0
+* Added support for a "No Results" component being passed via props on the PagedResultTable
+
 ### 2.15.0
 * Implement support for passing the labelData prop on facet values to the display function for a facet instance
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/ResultTable/index.js
+++ b/src/exampleTypes/ResultTable/index.js
@@ -18,6 +18,7 @@ let Tr = props => (
     {..._.omit(['record', 'fields', 'visibleFields', 'hiddenFields'], props)}
   />
 )
+let DefaultNoResultsComponent = () => 'No Results Found'
 
 let ResultTable = ({
   fields,
@@ -26,6 +27,7 @@ let ResultTable = ({
   criteria,
   node,
   tree,
+  NoResultsComponent = DefaultNoResultsComponent,
   Row = Tr, // accept a custom Row component so we can do fancy expansion things
   mapNodeToProps = () => ({}),
   pageSizeOptions, // an array of options to set the # of rows per page (default [20, 50, 100, 250])
@@ -33,6 +35,7 @@ let ResultTable = ({
 }) => {
   // From Theme/Components
   let mutate = tree.mutate(path)
+  let hasResults = !!_.get('context.response.totalRecords', node)
   // NOTE infer + add columns does not work together (except for anything explicitly passed in)
   //   When removing a field, it's not longer on the record, so infer can't pick it up since it runs per render
   let schema = _.flow(
@@ -62,34 +65,38 @@ let ResultTable = ({
     criteria,
   }
 
-  return (
-    <>
-      <Table>
-        <thead>
-          <tr>
-            {F.mapIndexed(
-              x => (
-                <Header key={x.field} field={x} {...headerProps} />
-              ),
-              visibleFields
-            )}
-            <HighlightedColumnHeader node={node} />
-          </tr>
-        </thead>
-        <TableBody
-          {...{
-            node,
-            fields,
-            visibleFields,
-            hiddenFields,
-            schema,
-            Row,
-          }}
-        />
-      </Table>
-      <ResultTableFooter {...{ tree, node, path, pageSizeOptions }} />
-    </>
-  )
+  if (hasResults) {
+    return (
+      <>
+        <Table>
+          <thead>
+            <tr>
+              {F.mapIndexed(
+                x => (
+                  <Header key={x.field} field={x} {...headerProps} />
+                ),
+                visibleFields
+              )}
+              <HighlightedColumnHeader node={node} />
+            </tr>
+          </thead>
+          <TableBody
+            {...{
+              node,
+              fields,
+              visibleFields,
+              hiddenFields,
+              schema,
+              Row,
+            }}
+          />
+        </Table>
+        <ResultTableFooter {...{ tree, node, path, pageSizeOptions }} />
+      </>
+    )
+  } else {
+    return <NoResultsComponent />
+  }
 }
 
 export let PagedResultTable = contexturify(ResultTable)


### PR DESCRIPTION
Related to https://github.com/smartprocure/bid-search/pull/4944

- Adds support for the custom no results component being passed to the PagedResultTable.

The idea is to achieve something like this eventually when the UI component is passed to the grid:

![image](https://user-images.githubusercontent.com/910303/77686824-bf925700-6f5a-11ea-9182-14b0ea004065.png)
