### PR TITLE
Feature/no results component

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.16.2
+* Make "NoResults" PagedResultTable aware of markedForUpdate
+
 ### 2.16.1
 * Fix PagedResultTable "NoResultsComponent"
 

--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.16.0
+* Added support for a "No Results" component being passed via props on the PagedResultTable
+
 ### 2.15.0
 * Implement support for passing the labelData prop on facet values to the display function for a facet instance
 

--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.16.1
+* Fix PagedResultTable "NoResultsComponent"
+
 ### 2.16.0
 * Added support for a "No Results" component being passed via props on the PagedResultTable
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.16.2",
+  "version": "2.16.3",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/ResultTable/index.js
+++ b/src/exampleTypes/ResultTable/index.js
@@ -24,7 +24,7 @@ let ResultTable = ({
   infer,
   path,
   criteria,
-  node,
+  node = {},
   tree,
   NoResultsComponent = 'No Results Found',
   Row = Tr, // accept a custom Row component so we can do fancy expansion things
@@ -63,7 +63,7 @@ let ResultTable = ({
     mutate,
     criteria,
   }
-  if (hasResults) {
+  if (!node.updating && hasResults) {
     return (
       <>
         <Table>
@@ -92,7 +92,8 @@ let ResultTable = ({
         <ResultTableFooter {...{ tree, node, path, pageSizeOptions }} />
       </>
     )
-  } else {
+  } 
+  if (!node.markedForUpdate && !hasResults) {
     return NoResultsComponent
   }
 }

--- a/src/exampleTypes/ResultTable/index.js
+++ b/src/exampleTypes/ResultTable/index.js
@@ -34,7 +34,8 @@ let ResultTable = ({
 }) => {
   // From Theme/Components
   let mutate = tree.mutate(path)
-  let hasResults = !!_.get('context.response.totalRecords', node)
+  // Account for all providers here (memory provider has results with no response parent)
+  let hasResults = !!_.get('context.response.results.length', node) || !!_.get('context.results.length', node)
   // NOTE infer + add columns does not work together (except for anything explicitly passed in)
   //   When removing a field, it's not longer on the record, so infer can't pick it up since it runs per render
   let schema = _.flow(

--- a/src/exampleTypes/ResultTable/index.js
+++ b/src/exampleTypes/ResultTable/index.js
@@ -18,7 +18,6 @@ let Tr = props => (
     {..._.omit(['record', 'fields', 'visibleFields', 'hiddenFields'], props)}
   />
 )
-let DefaultNoResultsComponent = () => 'No Results Found'
 
 let ResultTable = ({
   fields,
@@ -27,7 +26,7 @@ let ResultTable = ({
   criteria,
   node,
   tree,
-  NoResultsComponent = DefaultNoResultsComponent,
+  NoResultsComponent = 'No Results Found',
   Row = Tr, // accept a custom Row component so we can do fancy expansion things
   mapNodeToProps = () => ({}),
   pageSizeOptions, // an array of options to set the # of rows per page (default [20, 50, 100, 250])
@@ -64,7 +63,6 @@ let ResultTable = ({
     mutate,
     criteria,
   }
-
   if (hasResults) {
     return (
       <>
@@ -95,7 +93,7 @@ let ResultTable = ({
       </>
     )
   } else {
-    return <NoResultsComponent />
+    return NoResultsComponent
   }
 }
 

--- a/src/exampleTypes/ResultTable/index.js
+++ b/src/exampleTypes/ResultTable/index.js
@@ -18,6 +18,7 @@ let Tr = props => (
     {..._.omit(['record', 'fields', 'visibleFields', 'hiddenFields'], props)}
   />
 )
+let DefaultNoResultsComponent = () => 'No Results Found'
 
 let ResultTable = ({
   fields,
@@ -26,6 +27,7 @@ let ResultTable = ({
   criteria,
   node,
   tree,
+  NoResultsComponent = DefaultNoResultsComponent,
   Row = Tr, // accept a custom Row component so we can do fancy expansion things
   mapNodeToProps = () => ({}),
   pageSizeOptions, // an array of options to set the # of rows per page (default [20, 50, 100, 250])
@@ -33,6 +35,7 @@ let ResultTable = ({
 }) => {
   // From Theme/Components
   let mutate = tree.mutate(path)
+  let hasResults = !!_.get('context.response.totalRecords', node)
   // NOTE infer + add columns does not work together (except for anything explicitly passed in)
   //   When removing a field, it's not longer on the record, so infer can't pick it up since it runs per render
   let schema = _.flow(
@@ -62,34 +65,38 @@ let ResultTable = ({
     criteria,
   }
 
-  return (
-    <>
-      <Table>
-        <thead>
-          <tr>
-            {F.mapIndexed(
-              x => (
-                <Header key={x.field} field={x} {...headerProps} />
-              ),
-              visibleFields
-            )}
-            <HighlightedColumnHeader node={node} />
-          </tr>
-        </thead>
-        <TableBody
-          {...{
-            node,
-            fields,
-            visibleFields,
-            hiddenFields,
-            schema,
-            Row,
-          }}
-        />
-      </Table>
-      <ResultTableFooter {...{ tree, node, path, pageSizeOptions }} />
-    </>
-  )
+  if (hasResults) {
+    return (
+      <>
+        <Table>
+          <thead>
+            <tr>
+              {F.mapIndexed(
+                x => (
+                  <Header key={x.field} field={x} {...headerProps} />
+                ),
+                visibleFields
+              )}
+              <HighlightedColumnHeader node={node} />
+            </tr>
+          </thead>
+          <TableBody
+            {...{
+              node,
+              fields,
+              visibleFields,
+              hiddenFields,
+              schema,
+              Row,
+            }}
+          />
+        </Table>
+        <ResultTableFooter {...{ tree, node, path, pageSizeOptions }} />
+      </>
+    )
+  } else {
+    return <NoResultsComponent />
+  }
 }
 
 export let PagedResultTable = contexturify(ResultTable)

--- a/src/exampleTypes/ResultTable/index.js
+++ b/src/exampleTypes/ResultTable/index.js
@@ -35,7 +35,9 @@ let ResultTable = ({
   // From Theme/Components
   let mutate = tree.mutate(path)
   // Account for all providers here (memory provider has results with no response parent)
-  let hasResults = !!_.get('context.response.results.length', node) || !!_.get('context.results.length', node)
+  let hasResults =
+    !!_.get('context.response.results.length', node) ||
+    !!_.get('context.results.length', node)
   // NOTE infer + add columns does not work together (except for anything explicitly passed in)
   //   When removing a field, it's not longer on the record, so infer can't pick it up since it runs per render
   let schema = _.flow(


### PR DESCRIPTION
- Use the `markedForUpdate` to not show the "No Results" component initially and only when there are no results found.
- Account for the different providers in the `hasResults` check