### PR TITLE
Fix and add IntroComponent to ResultTable

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.16.4
+* Fix for the PagedResultTable and support for IntroComponent
+
 ### 2.16.3
 * Make "NoResults" PagedResultTable aware of markedForUpdate
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.16.3",
+  "version": "2.16.4",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/ResultTable/index.js
+++ b/src/exampleTypes/ResultTable/index.js
@@ -27,6 +27,7 @@ let ResultTable = ({
   node = {},
   tree,
   NoResultsComponent = 'No Results Found',
+  IntroComponent = null, // Initial component to be shown instead of the grid when no data has been loaded
   Row = Tr, // accept a custom Row component so we can do fancy expansion things
   mapNodeToProps = () => ({}),
   pageSizeOptions, // an array of options to set the # of rows per page (default [20, 50, 100, 250])
@@ -96,9 +97,10 @@ let ResultTable = ({
       </>
     )
   }
-  if (!node.markedForUpdate && !hasResults) {
+  if (!node.markedForUpdate && !node.updating && !hasResults) {
     return NoResultsComponent
   }
+  return IntroComponent
 }
 
 export let PagedResultTable = contexturify(ResultTable)


### PR DESCRIPTION
- Fixes the issue where the `No Results` was still showing on initial view of the grid
- Adds support for the IntroComponent