### PR TITLE
Header changes for adding column to either side

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.17.0
+* Add capability to add columns to either side (left/right) on the clicked column header instead of always adding to the end
+
 ### 2.16.4
 * Fix for the PagedResultTable and support for IntroComponent
 

--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,5 +1,5 @@
 ### 2.17.0
-* Add capability to add columns to either side (left/right) on the clicked column header instead of always adding to the end
+* Add capability to add columns to the right side of the clicked column header instead of always adding to the end of the header row
 
 ### 2.16.4
 * Fix for the PagedResultTable and support for IntroComponent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.16.4",
+  "version": "2.17.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/ResultTable/Header.js
+++ b/src/exampleTypes/ResultTable/Header.js
@@ -27,20 +27,6 @@ const moveColumn = (
   })
 }
 
-const addColumn = (
-  mutate,
-  computeSideIndex,
-  includes,
-  triggerField,
-  field
-) => {
-  let index = includes.indexOf(triggerField)
-  if (index >= 0) {
-    includes.splice(computeSideIndex(index), 0, field)
-    mutate({ include: includes })
-  }
-}
-
 let popoverStyle = {
   userSelect: 'none',
 }
@@ -77,7 +63,6 @@ let Header = ({
 }) => {
   let popover = React.useState(false)
   let adding = React.useState(false)
-  let [addColumnTriggerField, setAddColumnTriggerField] = React.useState(null)
   let filtering = React.useState(false)
   let {
     disableFilter,
@@ -172,12 +157,7 @@ let Header = ({
           Remove Column
         </DropdownItem>
         {!!addOptions.length && (
-          <DropdownItem
-            onClick={() => {
-              setAddColumnTriggerField(field)
-              F.on(adding)()
-            }}
-          >
+          <DropdownItem onClick={F.on(adding)}>
             <Icon icon="AddColumn" />
             Add Column
           </DropdownItem>
@@ -211,14 +191,12 @@ let Header = ({
         <Modal open={adding}>
           <NestedPicker
             options={addOptions}
-            onChange={field => {
-              addColumn(
-                mutate,
-                i => i + 1, // Add to the right of the clicked column
-                includes,
-                addColumnTriggerField,
-                field
-              )
+            onChange={triggerField => {
+              let index = includes.indexOf(field)
+              if (index >= 0) {
+                includes.splice(index+1, 0, triggerField)
+                mutate({ include: includes })
+              }
               F.off(adding)()
             }}
           />

--- a/src/exampleTypes/ResultTable/Header.js
+++ b/src/exampleTypes/ResultTable/Header.js
@@ -77,7 +77,7 @@ let Header = ({
 }) => {
   let popover = React.useState(false)
   let adding = React.useState(false)
-  let [addColumnField, setAddColumnField] = React.useState(null)
+  let [addColumnTriggerField, setAddColumnTriggerField] = React.useState(null)
   let filtering = React.useState(false)
   let {
     disableFilter,
@@ -173,7 +173,7 @@ let Header = ({
         </DropdownItem>
         {!!addOptions.length && (
           <DropdownItem onClick={() => {
-            setAddColumnField(field)
+            setAddColumnTriggerField(field)
             F.on(adding)()
           }}>
             <Icon icon="AddColumn" />
@@ -214,7 +214,7 @@ let Header = ({
                 mutate,
                 i => i + 1, // Add to the right of the clicked column
                 includes,
-                addColumnField,
+                addColumnTriggerField,
                 field
               )
               F.off(adding)()

--- a/src/exampleTypes/ResultTable/Header.js
+++ b/src/exampleTypes/ResultTable/Header.js
@@ -31,10 +31,10 @@ const addColumn = (
   mutate,
   computeSideIndex,
   includes,
-  addColumnField,
+  triggerField,
   field
 ) => {
-  let index = includes.indexOf(addColumnField)
+  let index = includes.indexOf(triggerField)
   if (index >= 0) {
     includes.splice(computeSideIndex(index), 0, field)
     mutate({ include: includes })

--- a/src/exampleTypes/ResultTable/Header.js
+++ b/src/exampleTypes/ResultTable/Header.js
@@ -194,7 +194,7 @@ let Header = ({
             onChange={triggerField => {
               let index = includes.indexOf(field)
               if (index >= 0) {
-                includes.splice(index+1, 0, triggerField)
+                includes.splice(index + 1, 0, triggerField)
                 mutate({ include: includes })
               }
               F.off(adding)()

--- a/src/exampleTypes/ResultTable/Header.js
+++ b/src/exampleTypes/ResultTable/Header.js
@@ -27,6 +27,20 @@ const moveColumn = (
   })
 }
 
+const addColumn = (
+  mutate,
+  computeSideIndex,
+  includes,
+  addColumnField,
+  field,
+) => {
+  let index = includes.indexOf(addColumnField)
+  if (index >= 0) {
+    includes.splice(computeSideIndex(index), 0, field)
+    mutate({ include: includes })
+  }
+}
+
 let popoverStyle = {
   userSelect: 'none',
 }
@@ -63,6 +77,7 @@ let Header = ({
 }) => {
   let popover = React.useState(false)
   let adding = React.useState(false)
+  let [addColumnField, setAddColumnField] = React.useState(null)
   let filtering = React.useState(false)
   let {
     disableFilter,
@@ -157,7 +172,10 @@ let Header = ({
           Remove Column
         </DropdownItem>
         {!!addOptions.length && (
-          <DropdownItem onClick={F.on(adding)}>
+          <DropdownItem onClick={() => {
+            setAddColumnField(field)
+            F.on(adding)()
+          }}>
             <Icon icon="AddColumn" />
             Add Column
           </DropdownItem>
@@ -192,8 +210,13 @@ let Header = ({
           <NestedPicker
             options={addOptions}
             onChange={field => {
-              if (!_.contains(field, includes))
-                mutate({ include: [...includes, field] })
+              addColumn(
+                mutate,
+                i => i + 1, // Add to the right of the clicked column
+                includes,
+                addColumnField,
+                field
+              )
               F.off(adding)()
             }}
           />


### PR DESCRIPTION
- Adds the capability to add the requested by the end-user column to either left or the right side of the column clicked by the user. By default now `AddColumn` would add to the right side.

In regards to https://github.com/smartprocure/spark/issues/5144