### PR TITLE
Add more date  facet rolling options

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.18.0
+* Add Next 60 Days, Next 90 Days, Next 6 Months options to date facet
+
 ### 2.17.0
 * Add capability to add columns to the right side of the clicked column header instead of always adding to the end of the header row
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/Date.js
+++ b/src/exampleTypes/Date.js
@@ -110,6 +110,21 @@ let allRollingOpts = [
   },
   {
     type: 'future',
+    label: 'Next 60 days',
+    range: { from: 'now/d', to: 'now/d+60d' },
+  },
+  {
+    type: 'future',
+    label: 'Next 90 days',
+    range: { from: 'now/d', to: 'now/d+90d' },
+  },
+  {
+    type: 'future',
+    label: 'Next 6 Months',
+    range: { from: 'now/d', to: 'now/d+6M' },
+  },
+  {
+    type: 'future',
     label: 'Next 12 Months',
     range: { from: 'now/d', to: 'now/d+12M' },
   },


### PR DESCRIPTION
In regards to https://github.com/smartprocure/spark/issues/5287. 

Adding more rolling options to the date picker:

- Next 60 Days

- Next 90 Days

- Next 6 Months