### PR TITLE
Fix hideMenu and add hideRemoveColumn

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,8 @@
+### 2.19.0
+* `hideMenu` header column config now works as expected and does not show the menu on header click
+* `hideRemoveColumn` option added
+* customizations story updated to demo also these customizations
+
 ### 2.18.0
 * Add Next 60 Days, Next 90 Days, Next 6 Months options to date facet
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.18.0",
+  "version": "2.19.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/ResultTable/Header.js
+++ b/src/exampleTypes/ResultTable/Header.js
@@ -151,13 +151,14 @@ let Header = ({
           <Icon icon="MoveRight" />
           Move Right
         </DropdownItem>
-          {!hideRemoveColumn && <DropdownItem
+        {!hideRemoveColumn && (
+          <DropdownItem
             onClick={() => mutate({ include: _.without([field], includes) })}
           >
             <Icon icon="RemoveColumn" />
             Remove Column
           </DropdownItem>
-        }
+        )}
         {!!addOptions.length && (
           <DropdownItem onClick={F.on(adding)}>
             <Icon icon="AddColumn" />

--- a/src/exampleTypes/ResultTable/Header.js
+++ b/src/exampleTypes/ResultTable/Header.js
@@ -70,6 +70,7 @@ let Header = ({
     field,
     sortField = field,
     label,
+    hideRemoveColumn,
     hideMenu,
     typeDefault,
   } = fieldSchema
@@ -88,10 +89,10 @@ let Header = ({
   let Label = label
   return (
     <HeaderCell
-      style={{ cursor: 'pointer' }}
+      style={{ cursor: hideMenu ? 'default' : 'pointer' }}
       activeFilter={_.get('hasValue', filterNode)}
     >
-      <span onClick={F.flip(popover)}>
+      <span onClick={F.when(!hideMenu, F.flip(popover))}>
         {_.isFunction(label) ? <Label /> : label}{' '}
         {field === node.sortField && (
           <Icon
@@ -150,12 +151,13 @@ let Header = ({
           <Icon icon="MoveRight" />
           Move Right
         </DropdownItem>
-        <DropdownItem
-          onClick={() => mutate({ include: _.without([field], includes) })}
-        >
-          <Icon icon="RemoveColumn" />
-          Remove Column
-        </DropdownItem>
+          {!hideRemoveColumn && <DropdownItem
+            onClick={() => mutate({ include: _.without([field], includes) })}
+          >
+            <Icon icon="RemoveColumn" />
+            Remove Column
+          </DropdownItem>
+        }
         {!!addOptions.length && (
           <DropdownItem onClick={F.on(adding)}>
             <Icon icon="AddColumn" />

--- a/src/exampleTypes/ResultTable/index.stories.js
+++ b/src/exampleTypes/ResultTable/index.stories.js
@@ -46,12 +46,34 @@ export let customizations = () => (
       theme={{ Table: x => <table className="example-table" {...x} /> }}
       infer
       fields={{
-        b: {
-          label: 'Field B',
+        a: {
+          label: 'Colored Header',
           order: -2,
           HeaderCell: ({ style, ...props }) => (
             <th
               style={{ color: 'green', ...style }}
+              {..._.omit('activeFilter', props)}
+            />
+          ),
+        },
+        b: {
+          label: 'Hidden Remove Column',
+          order: -3,
+          hideRemoveColumn: true,
+          HeaderCell: ({ style, ...props }) => (
+            <th
+              style={{ color: 'gray', ...style }}
+              {..._.omit('activeFilter', props)}
+            />
+          ),
+        },
+        c: {
+          label: 'Hidden Menu',
+          order: -4,
+          hideMenu: true,
+          HeaderCell: ({ style, ...props }) => (
+            <th
+              style={{ color: 'gray', ...style }}
               {..._.omit('activeFilter', props)}
             />
           ),


### PR DESCRIPTION
- Fixes the issue with `hideMenu` described in #399
- Adds `hideRemoveColumn` option which is what actually is needed most of the time instead of `hideMenu`
- Adds these to the `customizations` story/demo

Fixes #399
Related to https://github.com/smartprocure/spark/issues/5328