### PR TITLE
Add bool/exists display prop for customizations

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,7 @@
+### 2.20.0
+* Allow bool & exists types to have customizable options
+* Add stories for bool & exits customizations
+
 ### 2.19.0
 * `hideMenu` header column config now works as expected and does not show the menu on header click
 * `hideRemoveColumn` option added

--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,5 +1,5 @@
 ### 2.20.0
-* Allow bool & exists types to have customizable options
+* Allow bool & exists types to have customizable options via display prop
 * Add stories for bool & exits customizations
 
 ### 2.19.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.16.2",
+  "version": "2.20.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/Bool.js
+++ b/src/exampleTypes/Bool.js
@@ -1,36 +1,4 @@
 import React from 'react'
-import _ from 'lodash/fp'
-import { contexturify } from '../utils/hoc'
+import BooleanType from '../purgatory/BooleanType'
 
-let getValue = (value, either) => _.isBoolean(value)
-  ? value
-  : either ? null : false
-
-let Bool = ({
-  tree,
-  node,
-  display = () => ['Yes', 'No', 'Either'],
-  theme: { RadioList }
-}) => {
-  let [yes, no, either] = display()
-  return (
-    <div className="contexture-bool">
-      <RadioList
-        value={getValue(node.value, either)}
-        onChange={value => {
-          tree.mutate(node.path, {
-            value: getValue(value, either)
-          })
-        }}
-        options={[
-          { label: yes, value: true }, 
-          { label: no, value: false }, 
-          ...(either ? [{ label: either, value: null}] : [])
-        ]}
-      />
-    </div>
-
-  )
-}
-
-export default contexturify(Bool)
+export default ({...props }) => <BooleanType {...props} />

--- a/src/exampleTypes/Bool.js
+++ b/src/exampleTypes/Bool.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import F from 'futil'
 import _ from 'lodash/fp'
 import { contexturify } from '../utils/hoc'
 
@@ -30,6 +29,7 @@ let Bool = ({
         ]}
       />
     </div>
+
   )
 }
 

--- a/src/exampleTypes/Bool.js
+++ b/src/exampleTypes/Bool.js
@@ -1,22 +1,33 @@
 import React from 'react'
 import F from 'futil'
+import _ from 'lodash/fp'
 import { contexturify } from '../utils/hoc'
+
+let getValue = (value, either) => _.isBoolean(value)
+  ? value
+  : either ? null : false
 
 let Bool = ({
   tree,
   node,
-  display = (options=['yes', 'no']) => options,
+  display = () => ['Yes', 'No', 'Either'],
   theme: { RadioList }
 }) => {
-  let options = display()
+  let [yes, no, either] = display()
   return (
     <div className="contexture-bool">
       <RadioList
-        value={node.value ? options[0] : options[1]}
+        value={getValue(node.value, either)}
         onChange={value => {
-          tree.mutate(node.path, { value: value === options[0] })
+          tree.mutate(node.path, {
+            value: getValue(value, either)
+          })
         }}
-        options={F.autoLabelOptions(options)}
+        options={[
+          { label: yes, value: true }, 
+          { label: no, value: false }, 
+          ...(either ? [{ label: either, value: null}] : [])
+        ]}
       />
     </div>
   )

--- a/src/exampleTypes/Bool.js
+++ b/src/exampleTypes/Bool.js
@@ -2,14 +2,14 @@ import React from 'react'
 import F from 'futil'
 import { contexturify } from '../utils/hoc'
 
-let Bool = ({ tree, node, theme: { RadioList } }) => (
+let Bool = ({ tree, node, options = ['yes', 'no'], theme: { RadioList } }) => (
   <div className="contexture-bool">
     <RadioList
-      value={node.value ? 'yes' : 'no'}
+      value={node.value ? options[0] : options[1]}
       onChange={value => {
-        tree.mutate(node.path, { value: value === 'yes' })
+        tree.mutate(node.path, { value: value === options[0] })
       }}
-      options={F.autoLabelOptions(['yes', 'no'])}
+      options={F.autoLabelOptions(options)}
     />
   </div>
 )

--- a/src/exampleTypes/Bool.js
+++ b/src/exampleTypes/Bool.js
@@ -2,16 +2,24 @@ import React from 'react'
 import F from 'futil'
 import { contexturify } from '../utils/hoc'
 
-let Bool = ({ tree, node, options = ['yes', 'no'], theme: { RadioList } }) => (
-  <div className="contexture-bool">
-    <RadioList
-      value={node.value ? options[0] : options[1]}
-      onChange={value => {
-        tree.mutate(node.path, { value: value === options[0] })
-      }}
-      options={F.autoLabelOptions(options)}
-    />
-  </div>
-)
+let Bool = ({
+  tree,
+  node,
+  display = (options=['yes', 'no']) => options,
+  theme: { RadioList }
+}) => {
+  let options = display()
+  return (
+    <div className="contexture-bool">
+      <RadioList
+        value={node.value ? options[0] : options[1]}
+        onChange={value => {
+          tree.mutate(node.path, { value: value === options[0] })
+        }}
+        options={F.autoLabelOptions(options)}
+      />
+    </div>
+  )
+}
 
 export default contexturify(Bool)

--- a/src/exampleTypes/Bool.stories.js
+++ b/src/exampleTypes/Bool.stories.js
@@ -7,3 +7,4 @@ import { Bool } from '.'
 storiesOf('ExampleTypes|Bool', module)
   .addDecorator(ThemePicker('greyVest'))
   .add('Bool', () => <Bool tree={TestTree()} path={['bool']} />)
+  .add('Bool Customized', () => <Bool tree={TestTree()} path={['bool']} options={['Agree', 'Disagree']} />)

--- a/src/exampleTypes/Bool.stories.js
+++ b/src/exampleTypes/Bool.stories.js
@@ -7,6 +7,7 @@ import { Bool } from '.'
 storiesOf('ExampleTypes|Bool', module)
   .addDecorator(ThemePicker('greyVest'))
   .add('Bool', () => <Bool tree={TestTree()} path={['bool']} />)
-  .add('Bool Customized', () => (
-    <Bool tree={TestTree()} path={['bool']} display={() => ['Agree', 'Disagree']} />
+  .add('Bool Custom Options', () => <Bool tree={TestTree()} path={['bool']} display={() => ['Yes', 'No']} />)
+  .add('Bool Custom Labels', () => (
+    <Bool tree={TestTree()} path={['bool']} display={() => ['Agree', 'Disagree', 'Both']} />
   ))

--- a/src/exampleTypes/Bool.stories.js
+++ b/src/exampleTypes/Bool.stories.js
@@ -7,4 +7,6 @@ import { Bool } from '.'
 storiesOf('ExampleTypes|Bool', module)
   .addDecorator(ThemePicker('greyVest'))
   .add('Bool', () => <Bool tree={TestTree()} path={['bool']} />)
-  .add('Bool Customized', () => <Bool tree={TestTree()} path={['bool']} options={['Agree', 'Disagree']} />)
+  .add('Bool Customized', () => (
+    <Bool tree={TestTree()} path={['bool']} options={['Agree', 'Disagree']} />
+  ))

--- a/src/exampleTypes/Bool.stories.js
+++ b/src/exampleTypes/Bool.stories.js
@@ -8,5 +8,5 @@ storiesOf('ExampleTypes|Bool', module)
   .addDecorator(ThemePicker('greyVest'))
   .add('Bool', () => <Bool tree={TestTree()} path={['bool']} />)
   .add('Bool Customized', () => (
-    <Bool tree={TestTree()} path={['bool']} options={['Agree', 'Disagree']} />
+    <Bool tree={TestTree()} path={['bool']} display={() => ['Agree', 'Disagree']} />
   ))

--- a/src/exampleTypes/Bool.stories.js
+++ b/src/exampleTypes/Bool.stories.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import _ from 'lodash/fp'
 import { storiesOf } from '@storybook/react'
 import TestTree from './stories/testTree'
 import ThemePicker from '../stories/themePicker'
@@ -7,7 +8,6 @@ import { Bool } from '.'
 storiesOf('ExampleTypes|Bool', module)
   .addDecorator(ThemePicker('greyVest'))
   .add('Bool', () => <Bool tree={TestTree()} path={['bool']} />)
-  .add('Bool Custom Options', () => <Bool tree={TestTree()} path={['bool']} display={() => ['Yes', 'No']} />)
-  .add('Bool Custom Labels', () => (
-    <Bool tree={TestTree()} path={['bool']} display={() => ['Agree', 'Disagree', 'Both']} />
-  ))
+  .add('Bool Custom Options', () => 
+    <Bool tree={TestTree()} path={['bool']} display={value => _.isNil(value) ? 'Both' : value ? 'Agree' : 'Disagree'} />
+  )

--- a/src/exampleTypes/Exists.js
+++ b/src/exampleTypes/Exists.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import _ from 'lodash/fp'
 import { contexturify } from '../utils/hoc'
 
 let getValue = (value, either) => _.isBoolean(value)

--- a/src/exampleTypes/Exists.js
+++ b/src/exampleTypes/Exists.js
@@ -2,21 +2,31 @@ import React from 'react'
 import F from 'futil'
 import { contexturify } from '../utils/hoc'
 
+let getValue = (value, either) => _.isBoolean(value)
+  ? value
+  : either ? null : false
+
 let Exists = ({
   tree,
   node,
-  display = (options=['exists', 'doesNotExist']) => options,
+  display = () => ['Exists', 'Does Not Exist', 'Either'],
   theme: { RadioList },
 }) => {
-  let options = display()
+  let [exists, doesNotExist, either] = display()
   return (
     <div className="contexture-exists">
       <RadioList
-        value={node.value ? options[0] : options[1]}
+        value={getValue(node.value, either)}
         onChange={value => {
-          tree.mutate(node.path, { value: value === options[0] })
+          tree.mutate(node.path, {
+            value: getValue(value, either)
+          })
         }}
-        options={F.autoLabelOptions(options)}
+        options={[
+          { label: exists, value: true }, 
+          { label: doesNotExist, value: false }, 
+          ...(either ? [{ label: either, value: null}] : [])
+        ]}
       />
     </div>
   )

--- a/src/exampleTypes/Exists.js
+++ b/src/exampleTypes/Exists.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import F from 'futil'
 import { contexturify } from '../utils/hoc'
 
 let getValue = (value, either) => _.isBoolean(value)

--- a/src/exampleTypes/Exists.js
+++ b/src/exampleTypes/Exists.js
@@ -2,14 +2,14 @@ import React from 'react'
 import F from 'futil'
 import { contexturify } from '../utils/hoc'
 
-let Exists = ({ tree, node, theme: { RadioList } }) => (
+let Exists = ({ tree, node, options=['exists', 'doesNotExist'], theme: { RadioList } }) => (
   <div className="contexture-exists">
     <RadioList
-      value={node.value ? 'exists' : 'doesNotExist'}
+      value={node.value ? options[0] : options[1]}
       onChange={value => {
-        tree.mutate(node.path, { value: value === 'exists' })
+        tree.mutate(node.path, { value: value === options[0] })
       }}
-      options={F.autoLabelOptions(['exists', 'doesNotExist'])}
+      options={F.autoLabelOptions(options)}
     />
   </div>
 )

--- a/src/exampleTypes/Exists.js
+++ b/src/exampleTypes/Exists.js
@@ -5,18 +5,21 @@ import { contexturify } from '../utils/hoc'
 let Exists = ({
   tree,
   node,
-  options = ['exists', 'doesNotExist'],
+  display = (options=['exists', 'doesNotExist']) => options,
   theme: { RadioList },
-}) => (
-  <div className="contexture-exists">
-    <RadioList
-      value={node.value ? options[0] : options[1]}
-      onChange={value => {
-        tree.mutate(node.path, { value: value === options[0] })
-      }}
-      options={F.autoLabelOptions(options)}
-    />
-  </div>
-)
+}) => {
+  let options = display()
+  return (
+    <div className="contexture-exists">
+      <RadioList
+        value={node.value ? options[0] : options[1]}
+        onChange={value => {
+          tree.mutate(node.path, { value: value === options[0] })
+        }}
+        options={F.autoLabelOptions(options)}
+      />
+    </div>
+  )
+}
 
 export default contexturify(Exists)

--- a/src/exampleTypes/Exists.js
+++ b/src/exampleTypes/Exists.js
@@ -1,35 +1,8 @@
 import React from 'react'
 import _ from 'lodash/fp'
-import { contexturify } from '../utils/hoc'
+import BooleanType from '../purgatory/BooleanType'
 
-let getValue = (value, either) => _.isBoolean(value)
-  ? value
-  : either ? null : false
-
-let Exists = ({
-  tree,
-  node,
-  display = () => ['Exists', 'Does Not Exist', 'Either'],
-  theme: { RadioList },
-}) => {
-  let [exists, doesNotExist, either] = display()
-  return (
-    <div className="contexture-exists">
-      <RadioList
-        value={getValue(node.value, either)}
-        onChange={value => {
-          tree.mutate(node.path, {
-            value: getValue(value, either)
-          })
-        }}
-        options={[
-          { label: exists, value: true }, 
-          { label: doesNotExist, value: false }, 
-          ...(either ? [{ label: either, value: null}] : [])
-        ]}
-      />
-    </div>
-  )
-}
-
-export default contexturify(Exists)
+export default ({
+  display = value => _.isNil(value) ? 'Either' : value ? 'Exists' : 'Does Not Exist',
+  ...props
+  }) => <BooleanType className='contexture-exists' display={display} {...props} />

--- a/src/exampleTypes/Exists.js
+++ b/src/exampleTypes/Exists.js
@@ -2,7 +2,12 @@ import React from 'react'
 import F from 'futil'
 import { contexturify } from '../utils/hoc'
 
-let Exists = ({ tree, node, options=['exists', 'doesNotExist'], theme: { RadioList } }) => (
+let Exists = ({
+  tree,
+  node,
+  options = ['exists', 'doesNotExist'],
+  theme: { RadioList },
+}) => (
   <div className="contexture-exists">
     <RadioList
       value={node.value ? options[0] : options[1]}

--- a/src/exampleTypes/Exists.stories.js
+++ b/src/exampleTypes/Exists.stories.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import _ from 'lodash/fp'
 import { storiesOf } from '@storybook/react'
 import TestTree from './stories/testTree'
 import ThemePicker from '../stories/themePicker'
@@ -11,6 +12,6 @@ storiesOf('ExampleTypes|Exists', module)
     <Exists
       tree={TestTree()}
       path={['exists']}
-      display={() => ['Foo', 'Boo']}
+      display={value => _.isNil(value) ? 'Both' : value ? 'There' : 'Not there'}
     />
   ))

--- a/src/exampleTypes/Exists.stories.js
+++ b/src/exampleTypes/Exists.stories.js
@@ -7,4 +7,6 @@ import { Exists } from '.'
 storiesOf('ExampleTypes|Exists', module)
   .addDecorator(ThemePicker('greyVest'))
   .add('Exists', () => <Exists tree={TestTree()} path={['exists']} />)
-  .add('Exists Customized', () => <Exists tree={TestTree()} path={['exists']} options={['Foo', 'Boo']} />)
+  .add('Exists Customized', () => (
+    <Exists tree={TestTree()} path={['exists']} options={['Foo', 'Boo']} />
+  ))

--- a/src/exampleTypes/Exists.stories.js
+++ b/src/exampleTypes/Exists.stories.js
@@ -8,5 +8,5 @@ storiesOf('ExampleTypes|Exists', module)
   .addDecorator(ThemePicker('greyVest'))
   .add('Exists', () => <Exists tree={TestTree()} path={['exists']} />)
   .add('Exists Customized', () => (
-    <Exists tree={TestTree()} path={['exists']} options={['Foo', 'Boo']} />
+    <Exists tree={TestTree()} path={['exists']} display={() => ['Foo', 'Boo']} />
   ))

--- a/src/exampleTypes/Exists.stories.js
+++ b/src/exampleTypes/Exists.stories.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import TestTree from './stories/testTree'
+import ThemePicker from '../stories/themePicker'
+import { Exists } from '.'
+
+storiesOf('ExampleTypes|Exists', module)
+  .addDecorator(ThemePicker('greyVest'))
+  .add('Exists', () => <Exists tree={TestTree()} path={['exists']} />)
+  .add('Exists Customized', () => <Exists tree={TestTree()} path={['exists']} options={['Foo', 'Boo']} />)

--- a/src/exampleTypes/stories/testTree.js
+++ b/src/exampleTypes/stories/testTree.js
@@ -55,12 +55,12 @@ export default (f = _.identity) => {
     },
     bool: {
       key: 'bool',
-      value: false,
+      value: null,
       path: ['bool'],
     },
     exists: {
       key: 'exists',
-      value: false,
+      value: null,
       path: ['exists'],
     },
     date: {

--- a/src/exampleTypes/stories/testTree.js
+++ b/src/exampleTypes/stories/testTree.js
@@ -58,6 +58,11 @@ export default (f = _.identity) => {
       value: false,
       path: ['bool'],
     },
+    exists: {
+      key: 'exists',
+      value: false,
+      path: ['exists'],
+    },
     date: {
       key: 'date',
       path: ['date'],

--- a/src/purgatory/BooleanType.js
+++ b/src/purgatory/BooleanType.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import _ from 'lodash/fp'
+import { contexturify } from '../utils/hoc'
+
+let getValue = value => _.isNil(value)  ? null : !!value
+
+let BooleanType = ({
+  tree,
+  node,
+  display = value => _.isNil(value) ? 'Either' : value ? 'Yes' : 'No',
+  className = 'contexture-bool',
+  theme: { RadioList }
+}) => {
+  return (
+    <div className={className}>
+      <RadioList
+        value={getValue(node.value)}
+        onChange={value => {
+          tree.mutate(node.path, {
+            value: getValue(value)
+          })
+        }}
+        options={[
+          { label: display(true), value: true },
+          { label: display(false), value: false },
+          { label: display(null), value: null }
+        ]}
+      />
+    </div>
+  )
+}
+
+export default contexturify(BooleanType)

--- a/src/purgatory/BooleanType.js
+++ b/src/purgatory/BooleanType.js
@@ -10,24 +10,22 @@ let BooleanType = ({
   display = value => _.isNil(value) ? 'Either' : value ? 'Yes' : 'No',
   className = 'contexture-bool',
   theme: { RadioList }
-}) => {
-  return (
-    <div className={className}>
-      <RadioList
-        value={getValue(node.value)}
-        onChange={value => {
-          tree.mutate(node.path, {
-            value: getValue(value)
-          })
-        }}
-        options={[
-          { label: display(true), value: true },
-          { label: display(false), value: false },
-          { label: display(null), value: null }
-        ]}
-      />
-    </div>
-  )
-}
+}) => (
+  <div className={className}>
+    <RadioList
+      value={getValue(node.value)}
+      onChange={value => {
+        tree.mutate(node.path, {
+          value: getValue(value)
+        })
+      }}
+      options={[
+        { label: display(true), value: true },
+        { label: display(false), value: false },
+        { label: display(null), value: null }
+      ]}
+    />
+  </div>
+)
 
 export default contexturify(BooleanType)

--- a/src/purgatory/BooleanType.js
+++ b/src/purgatory/BooleanType.js
@@ -2,27 +2,27 @@ import React from 'react'
 import _ from 'lodash/fp'
 import { contexturify } from '../utils/hoc'
 
-let getValue = value => _.isNil(value)  ? null : !!value
+let getValue = value => (_.isNil(value) ? null : !!value)
 
 let BooleanType = ({
   tree,
   node,
-  display = value => _.isNil(value) ? 'Either' : value ? 'Yes' : 'No',
+  display = value => (_.isNil(value) ? 'Either' : value ? 'Yes' : 'No'),
   className = 'contexture-bool',
-  theme: { RadioList }
+  theme: { RadioList },
 }) => (
   <div className={className}>
     <RadioList
       value={getValue(node.value)}
       onChange={value => {
         tree.mutate(node.path, {
-          value: getValue(value)
+          value: getValue(value),
         })
       }}
       options={[
         { label: display(true), value: true },
         { label: display(false), value: false },
-        { label: display(null), value: null }
+        { label: display(null), value: null },
       ]}
     />
   </div>


### PR DESCRIPTION
- Adds `display`support to the bool and exists types for customizing the labels
- Adds support for the `either` option (which is value `null` and returns all records)
- Adds stories for both types customization options

Related to https://github.com/smartprocure/spark/issues/5469