### PR TITLE
Changes to CR in regards to 5969

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,5 +1,11 @@
-### 2.23.1
+### 2.24.0
+* Changes to filter icons
+* Advanced Search Builder is now in a popup menu
+* Expand / Collapse all filters is now in a popup menu
+* Toggle Filters Panel is now in a popup menu
+* TreePauseButton changes to support Component and be text based vs Icon
 
+### 2.23.1
 * Change "Select All" to "Select All Visible" on all facets
 
 ### 2.23.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.23.1",
+  "version": "2.24.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/SearchFilters.js
+++ b/src/SearchFilters.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types'
 import F from 'futil'
 import { observer } from 'mobx-react'
 import { Flex, QueryBuilder, FilterAdder, FilterList } from '.'
-import { ToggleFiltersButton, TreePauseButton } from './purgatory'
-import { LinkButton } from './greyVest'
+import { TreePauseButton } from './purgatory'
+import { LinkButton, Icon, Popover } from './greyVest'
 import { withTheme } from './utils/theme'
 
 export let SearchTree = () => {}
@@ -35,29 +35,48 @@ export let FiltersBox = withTheme(({ theme: { Box }, ...props }) => (
 ))
 FiltersBox.displayName = 'FiltersBox'
 
-let BasicSearchFilters = ({ setMode, trees, children, BasicFilters }) => (
+let PopOverItem = ({ children, ...props }) => (
+  <div style={{ margin: 10, cursor: 'pointer' }} {...props}>
+    {children}
+  </div>
+)
+
+let BasicSearchFilters = ({ setMode, trees, children, BasicFilters }) => {
+  let [isOpen, setIsOpen] = React.useState(false)
+  return (
   <div>
     <Flex alignItems="center" justifyContent="space-between">
       <Flex alignItems="center">
         <h1>Filters</h1>
-        <ToggleFiltersButton onClick={() => setMode('resultsOnly')} />
       </Flex>
       <div>
-        <TreePauseButton children={children} />
+        <Popover
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          style={{ width: 180, right: 0, top: 40 }}
+        >
+          <PopOverItem onClick={() => setMode('resultsOnly')}>Toggle Filters</PopOverItem>
+          <TreePauseButton children={children} Component={PopOverItem} />
+          <PopOverItem onClick={() => setMode('builder')}>Advanced Search Builder</PopOverItem>
+        </Popover>
+        <Icon
+          style={{ paddingTop: 15, cursor: 'pointer' }}
+          icon="more_vert"
+          onClick={() => setIsOpen(true)}
+        />
       </div>
     </Flex>
     <LabelledList list={trees} Component={BasicFilters} />
-    <LinkButton onClick={() => setMode('builder')} style={{ marginTop: 15 }}>
-      Switch to Advanced Search Builder
-    </LinkButton>
   </div>
-)
+)}
 
 let BuilderSearchFilters = ({ setMode, trees, BuilderFilters }) => (
   <div>
-    <Flex style={{ alignItems: 'center' }}>
-      <h1>Filters</h1>
-      <LinkButton onClick={() => setMode('basic')}>
+    <Flex justifyContent="space-between" style={{ alignItems: 'center' }}>
+      <Flex alignItems="center">
+        <h1>Filters</h1>
+      </Flex>
+      <LinkButton onClick={() => setMode('basic')} style={{marginRight: 30}}>
         Back to Regular Search
       </LinkButton>
     </Flex>

--- a/src/SearchFilters.js
+++ b/src/SearchFilters.js
@@ -5,7 +5,7 @@ import F from 'futil'
 import { observer } from 'mobx-react'
 import { Flex, QueryBuilder, FilterAdder, FilterList } from '.'
 import { TreePauseButton } from './purgatory'
-import { LinkButton, Icon, Popover } from './greyVest'
+import { LinkButton, Icon, Popover, DropdownItem } from './greyVest'
 import { withTheme } from './utils/theme'
 
 export let SearchTree = () => {}
@@ -35,35 +35,24 @@ export let FiltersBox = withTheme(({ theme: { Box }, ...props }) => (
 ))
 FiltersBox.displayName = 'FiltersBox'
 
-let PopOverItem = ({ children, ...props }) => (
-  <div style={{ margin: 10, cursor: 'pointer' }} {...props}>
-    {children}
-  </div>
-)
-
 let BasicSearchFilters = ({ setMode, trees, children, BasicFilters }) => {
   let [isOpen, setIsOpen] = React.useState(false)
   return (
   <div>
     <Flex alignItems="center" justifyContent="space-between">
-      <Flex alignItems="center">
-        <h1>Filters</h1>
-      </Flex>
+      <h1>Filters</h1>
       <div>
         <Popover
           isOpen={isOpen}
           onClose={() => setIsOpen(false)}
-          style={{ width: 180, right: 0, top: 40 }}
         >
-          <PopOverItem onClick={() => setMode('resultsOnly')}>Toggle Filters</PopOverItem>
-          <TreePauseButton children={children} Component={PopOverItem} />
-          <PopOverItem onClick={() => setMode('builder')}>Advanced Search Builder</PopOverItem>
+          <DropdownItem onClick={() => setMode('resultsOnly')}>Toggle Filters</DropdownItem>
+          <TreePauseButton children={children} Component={DropdownItem} />
+          <DropdownItem onClick={() => setMode('builder')}>Advanced Search Builder</DropdownItem>
         </Popover>
-        <Icon
-          style={{ paddingTop: 15, cursor: 'pointer' }}
-          icon="more_vert"
-          onClick={() => setIsOpen(true)}
-        />
+        <DropdownItem onClick={() => setIsOpen(true)}>
+          <Icon icon="more_vert"/>
+        </DropdownItem>
       </div>
     </Flex>
     <LabelledList list={trees} Component={BasicFilters} />
@@ -72,11 +61,9 @@ let BasicSearchFilters = ({ setMode, trees, children, BasicFilters }) => {
 
 let BuilderSearchFilters = ({ setMode, trees, BuilderFilters }) => (
   <div>
-    <Flex justifyContent="space-between" style={{ alignItems: 'center' }}>
-      <Flex alignItems="center">
-        <h1>Filters</h1>
-      </Flex>
-      <LinkButton onClick={() => setMode('basic')} style={{marginRight: 30}}>
+    <Flex alignItems="center" justifyContent="space-between">
+      <h1>Filters</h1>
+      <LinkButton onClick={() => setMode('basic')}>
         Back to Regular Search
       </LinkButton>
     </Flex>

--- a/src/SearchFilters.js
+++ b/src/SearchFilters.js
@@ -38,26 +38,28 @@ FiltersBox.displayName = 'FiltersBox'
 let BasicSearchFilters = ({ setMode, trees, children, BasicFilters }) => {
   let [isOpen, setIsOpen] = React.useState(false)
   return (
-  <div>
-    <Flex alignItems="center" justifyContent="space-between">
-      <h1>Filters</h1>
-      <div>
-        <Popover
-          isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
-        >
-          <DropdownItem onClick={() => setMode('resultsOnly')}>Toggle Filters</DropdownItem>
-          <TreePauseButton children={children} Component={DropdownItem} />
-          <DropdownItem onClick={() => setMode('builder')}>Advanced Search Builder</DropdownItem>
-        </Popover>
-        <DropdownItem onClick={() => setIsOpen(true)}>
-          <Icon icon="more_vert"/>
-        </DropdownItem>
-      </div>
-    </Flex>
-    <LabelledList list={trees} Component={BasicFilters} />
-  </div>
-)}
+    <div>
+      <Flex alignItems="center" justifyContent="space-between">
+        <h1>Filters</h1>
+        <div>
+          <Popover isOpen={isOpen} onClose={() => setIsOpen(false)}>
+            <DropdownItem onClick={() => setMode('resultsOnly')}>
+              Toggle Filters
+            </DropdownItem>
+            <TreePauseButton children={children} Component={DropdownItem} />
+            <DropdownItem onClick={() => setMode('builder')}>
+              Advanced Search Builder
+            </DropdownItem>
+          </Popover>
+          <DropdownItem onClick={() => setIsOpen(true)}>
+            <Icon icon="more_vert" />
+          </DropdownItem>
+        </div>
+      </Flex>
+      <LabelledList list={trees} Component={BasicFilters} />
+    </div>
+  )
+}
 
 let BuilderSearchFilters = ({ setMode, trees, BuilderFilters }) => (
   <div>

--- a/src/greyVest/Icon.js
+++ b/src/greyVest/Icon.js
@@ -17,7 +17,7 @@ let iconMap = {
   MoveRight: toIcon('chevron_right'),
   RemoveColumn: toIcon('remove'),
   AddColumn: toIcon('add'),
-  FilterExpand: toIcon('filter_list'),
+  FilterExpand: toIcon('filter_alt'),
   FilterCollapse: toIcon('filter_list'),
   FilterAdd: toIcon('filter_list'),
   TableColumnMenu: () => (

--- a/src/purgatory/ToggleFiltersButton.js
+++ b/src/purgatory/ToggleFiltersButton.js
@@ -3,7 +3,7 @@ import { withTheme } from '../utils/theme'
 
 let ToggleFiltersButton = ({ onClick, theme: { AlternateButton, Icon } }) => (
   <AlternateButton title="Toggle Filters" onClick={onClick}>
-    <Icon icon="FilterAdd" />
+    <Icon icon="FilterExpand" />
   </AlternateButton>
 )
 export default withTheme(ToggleFiltersButton)

--- a/src/purgatory/TreePauseButton.js
+++ b/src/purgatory/TreePauseButton.js
@@ -6,7 +6,11 @@ import { withTheme } from '../utils/theme'
 let setPausedNested = (tree, path, value) =>
   tree[`${value ? '' : 'un'}pauseNested`](path)
 
-let TreePauseButton = ({ children, theme: { AlternateButton, Icon } }) => {
+let TreePauseButton = ({
+  children,
+  theme: { AlternateButton },
+  Component=AlternateButton
+}) => {
   let trees = _.flow(
     React.Children.toArray,
     _.map('props')
@@ -14,11 +18,10 @@ let TreePauseButton = ({ children, theme: { AlternateButton, Icon } }) => {
   let allPaused = _.every(({ tree, path }) => tree.isPausedNested(path), trees)
   let flip = () =>
     _.each(({ tree, path }) => setPausedNested(tree, path, !allPaused), trees)
-  let title = `${allPaused ? 'Expand' : 'Collapse'} Filters`
   return (
-    <AlternateButton title={title} onClick={flip}>
-      <Icon icon={allPaused ? 'TreeUnpause' : 'TreePause'} />
-    </AlternateButton>
+    <Component onClick={flip}>
+      {`${allPaused ? 'Expand' : 'Collapse'} Filters`}
+    </Component>
   )
 }
 

--- a/src/themes/material/Icon.js
+++ b/src/themes/material/Icon.js
@@ -8,7 +8,7 @@ let iconMap = {
   MoveRight: 'chevron_right',
   RemoveColumn: 'remove',
   AddColumn: 'add',
-  FilterExpand: 'filter_list',
+  FilterExpand: 'filter_alt',
   FilterCollapse: 'filter_list',
   FilterAdd: 'filter_list',
   TableColumnMenu: 'more_vert',


### PR DESCRIPTION
- Advanced Search Builder is now in a popup menu
-  Expand / Collapse all filters is now in a popup menu
- Toggle Filters Panel is now in a popup menu
- TreePauseButton changes to support Component and be text-based vs Icon

![image](https://user-images.githubusercontent.com/910303/84840370-32f4b380-aff4-11ea-98bf-642082c3a5a3.png)

![image](https://user-images.githubusercontent.com/910303/84840410-499b0a80-aff4-11ea-9044-d6354c8a91bb.png)

![image](https://user-images.githubusercontent.com/910303/84840425-561f6300-aff4-11ea-8f06-7eac56d5a095.png)

in regards to https://github.com/smartprocure/spark/issues/5969