### PR TITLE
feature/409 - use https for heremaps requests

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,5 +1,7 @@
-### 2.23.1
+### 2.23.2
+* Use https for HereMaps API calls
 
+### 2.23.1
 * Change "Select All" to "Select All Visible" on all facets
 
 ### 2.23.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -4,8 +4,8 @@ const defaultHereConfig = {
   app_id: 'KzmI0fMwTyOG10rqZacS', // TEMP EMAIL USED - USE/GET YOUR APP_ID
   app_code: 'PykXtnTUeH7DDM-RLlpwyA', // TEMP EMAIL USED - USE/GET YOUR APP_CODE
   country: 'USA',
-  autocomplete: 'http://autocomplete.geocoder.api.here.com/6.2/suggest.json',
-  geoCoding: 'http://geocoder.api.here.com/6.2/geocode.json?gen=9',
+  autocomplete: 'https://autocomplete.geocoder.api.here.com/6.2/suggest.json',
+  geoCoding: 'https://geocoder.api.here.com/6.2/geocode.json?gen=9',
 }
 
 let formatAddress = ({ address, matchLevel }) => {


### PR DESCRIPTION
Fixes #409 

### Description
* uses https for heremaps requests. works in testing and matches all examples in their docs.