### PR TITLE
Add new entry to TypeMap for dateRangeFacet

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.24.3
+* Add new mapping for the dateRangeFacet
+
 ### 2.24.2
 * Format facet values
 * Format table footer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/TypeMap.js
+++ b/src/exampleTypes/TypeMap.js
@@ -11,6 +11,7 @@ import Text from './Text'
 
 export default {
   facet: Facet,
+  dateRangeFacet: Facet,
   query: Query,
   number: Number,
   date: Date,


### PR DESCRIPTION
- Adds a new mapping entry for the `dateRangeFacet`

In regards https://github.com/smartprocure/spark/issues/6298