### PR TITLE
Fix the NestedPicker overflow issues

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.24.4
+* NestedPicker css changes to allow each section to "overflow: auto"
+
 ### 2.24.3
 * Add new mapping for the dateRangeFacet
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.24.3",
+  "version": "2.24.4",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/greyVest/NestedPicker.js
+++ b/src/greyVest/NestedPicker.js
@@ -45,7 +45,7 @@ let Section = _.flow(
 )(({ options, onClick, selected }) => {
   let { PickerItem } = React.useContext(PickerContext)
   return (
-    <div style={{overflow: 'auto', width: '100%'}}>
+    <div style={{ overflow: 'auto', width: '100%' }}>
       {_.map(
         item => (
           <PickerItem
@@ -85,7 +85,7 @@ let PanelTreePicker = inject((store, { onChange, options }) => {
   observer(({ selectAtLevel, state, nestedOptions }) => (
     <div
       className="panel-tree-picker"
-      style={{ display: 'inline-flex', width: '100%'}}
+      style={{ display: 'inline-flex', width: '100%' }}
     >
       <Section
         options={nestedOptions}

--- a/src/greyVest/NestedPicker.js
+++ b/src/greyVest/NestedPicker.js
@@ -45,7 +45,7 @@ let Section = _.flow(
 )(({ options, onClick, selected }) => {
   let { PickerItem } = React.useContext(PickerContext)
   return (
-    <div>
+    <div style={{overflow: 'auto', width: '100%'}}>
       {_.map(
         item => (
           <PickerItem
@@ -85,7 +85,7 @@ let PanelTreePicker = inject((store, { onChange, options }) => {
   observer(({ selectAtLevel, state, nestedOptions }) => (
     <div
       className="panel-tree-picker"
-      style={{ display: 'inline-flex', width: '100%', overflow: 'auto' }}
+      style={{ display: 'inline-flex', width: '100%'}}
     >
       <Section
         options={nestedOptions}


### PR DESCRIPTION
- Makes it so each section of the NestedPicker has its own `overflow: auto` which fixes the need for `scroll to the top`

![image](https://user-images.githubusercontent.com/910303/86980844-cd4e9f80-c139-11ea-9975-1e4e1e9d7e97.png)

![image](https://user-images.githubusercontent.com/910303/86980999-3fbf7f80-c13a-11ea-982b-55261138ba8e.png)

Fixes https://github.com/smartprocure/spark/issues/5341