### PR TITLE
Feature/430 - update signature of loadHereOptions to support passing country as second arg, backwards compatible

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.29.0
+* Geo: support passing country as second argument to `loadHereOptions`
+
 ### 2.28.4
 * GreyVest: add className `gv-table-parent` to table parent `div`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.28.4",
+  "version": "2.29.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.28.4",
+  "version": "2.29.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/utils/geo.js
+++ b/src/utils/geo.js
@@ -35,9 +35,15 @@ let formatAddress = ({ address, matchLevel }) => {
 }
 export let loadHereOptions = async (
   inputValue,
+  countryCode = 'USA',
   hereConfig = defaultHereConfig
 ) => {
   if (inputValue.length <= 2) return []
+  if (typeof countryCode === 'object') {
+    hereConfig = countryCode
+    countryCode = 'USA'
+  }
+  hereConfig.country = countryCode
   let { autocomplete: url, app_id, app_code, country } = hereConfig
   let apiUrl = `${url}?app_id=${app_id}&app_code=${app_code}&country=${country}&query=${inputValue}`
 


### PR DESCRIPTION
Fixes #430 

### Description
* lets you re-bias HereMaps address completion options to another country.
* behavior unchanged for existing code that passes only 1 or 2 arguments