### PR TITLE
Add min-width:0 to grid children

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.29.2
+* Add min-width:0 to grid children
+
 ### 2.29.1
 * Fix stories
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.29.1",
+  "version": "2.29.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.29.1",
+  "version": "2.29.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/greyVest/Grid.js
+++ b/src/greyVest/Grid.js
@@ -16,9 +16,11 @@ let Grid = ({
   placeItems,
   inline = false,
   style,
+  className,
   ...props
 }) => (
   <Component
+    className={F.compactJoin(['gv-grid', className])}
     style={{
       display: `${inline ? 'inline-' : ''}grid`,
       gridTemplateColumns: repeatNumber(columns),

--- a/src/greyVest/Grid.js
+++ b/src/greyVest/Grid.js
@@ -20,7 +20,7 @@ let Grid = ({
   ...props
 }) => (
   <Component
-    className={F.compactJoin(['gv-grid', className])}
+    className={F.compactJoin(' ', ['gv-grid', className])}
     style={{
       display: `${inline ? 'inline-' : ''}grid`,
       gridTemplateColumns: repeatNumber(columns),

--- a/src/greyVest/Style.js
+++ b/src/greyVest/Style.js
@@ -403,6 +403,9 @@ export default () => (
         padding: 12px;
         border-radius: 5px;
       }
+      .gv-grid > * {
+        min-width: 0;
+      }
 
       .labeled-checkbox {
         display: flex;


### PR DESCRIPTION
Grid sets a `minWidth: auto` on its children by default, which makes it so they never overflow their parent and so it just goes off-bounds.