### PR TITLE
Rolling back `reactjs-popup` version

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.31.3
+* Fix Modal inside of Popover by rolling back to `reactjs-popup@1.5.0`
+
 ### 2.31.2
 * Fix Modal inside of Popover in ResultTable Header
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.31.2",
+  "version": "2.31.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15869,9 +15869,9 @@
       }
     },
     "reactjs-popup": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/reactjs-popup/-/reactjs-popup-2.0.4.tgz",
-      "integrity": "sha512-G5jTXL2JkClKAYAdqedf+K9QvbNsFWvdbrXW1/vWiyanuCU/d7DtQzQux+uKOz2HeNVRsFQHvs7abs0Z7VLAhg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/reactjs-popup/-/reactjs-popup-1.5.0.tgz",
+      "integrity": "sha512-9uoxUAcUomnNoBtdYXBmgsF4w46llsogE3tOvLb5IkR5MMrD6UZJK20ip9kDKXCYubSxNkdfQKqSb/c95rf/qA=="
     },
     "read-pkg": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.31.2",
+  "version": "2.31.3",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "react-dnd-html5-backend": "^2.5.4",
     "react-measure": "^2.3.0",
     "react-outside-click-handler": "^1.2.3",
-    "reactjs-popup": "^2.0.4",
+    "reactjs-popup": "^1.5.0",
     "recompose": "^0.30.0"
   },
   "readme": "README.mdx"

--- a/src/exampleTypes/ResultTable/Header.js
+++ b/src/exampleTypes/ResultTable/Header.js
@@ -103,7 +103,6 @@ let Header = ({
           trigger={hideMenu ? null : <Icon icon="TableColumnMenu" />}
           position="bottom right"
           closeOnPopoverClick={false}
-          closeOnDocumentClick={!F.view(adding)}
           style={popoverStyle}
         >
           {!disableSort && (

--- a/src/greyVest/Popover.js
+++ b/src/greyVest/Popover.js
@@ -38,15 +38,17 @@ let Popover = ({
     position={position || 'bottom left'}
     closeOnDocumentClick={closeOnDocumentClick}
     arrowStyle={{
-      filter: 'drop-shadow(0 -3px 3px rgba(39, 44, 65, 0.1)',
+      // matching arrow style with the popover body
+      margin: '-6px',
+      borderRight: '1px solid rgb(235, 235, 235)',
+      borderBottom: '1px solid rgb(235, 235, 235)',
+      boxShadow: 'rgba(39, 44, 65, 0.05) 2px 2px 3px',
       ...arrowStyle,
     }}
     contentStyle={{
-      background: '#FFF',
       borderRadius: 3,
       border: '1px solid rgb(235, 235, 235)',
       boxShadow: '0 2px 10px 0 rgba(39, 44, 65, 0.1)',
-      padding: 5,
       ...contentStyle,
       ...style,
     }}


### PR DESCRIPTION
* Setting `reactjs-popup` version back to `1.5.0`. Clicking on a nested `Modal` was closing popup because the backdrop from `2.0.4` was capturing click despite having lower `z-index`
* Matching arrow style to the popup body style
