### PR TITLE
[fix] Closing Popover with ActionsMenu, GeoComponent's Portal

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,7 @@
+### 2.31.4
+* Fix TagsQuery: closing Popover using ActionsMenu buttons
+* Fix GeoComponent: Rendering Autocomplete options in a Portal
+
 ### 2.31.3
 * Fix Modal inside of Popover by rolling back to `reactjs-popup@1.5.0`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.31.3",
+  "version": "2.31.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.31.3",
+  "version": "2.31.4",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/Geo.js
+++ b/src/exampleTypes/Geo.js
@@ -58,9 +58,7 @@ let GeoComponent = ({
           menuShouldScrollIntoView={true}
           styles={customStyles}
           loadOptions={loadOptions}
-          onInputChange={newValue =>
-            newValue.replace(/[^a-zA-Z0-9\s]+/g, '')
-          }
+          onInputChange={newValue => newValue.replace(/[^a-zA-Z0-9\s]+/g, '')}
           onChange={async ({ label, value }) => {
             let data = await GeoCodeLocation(value)
             if (data && data.latitude && data.longitude) {

--- a/src/exampleTypes/Geo.js
+++ b/src/exampleTypes/Geo.js
@@ -54,12 +54,13 @@ let GeoComponent = ({
           defaultInputValue={node.location}
           placeholder={placeholder}
           noOptionsMessage={() => ''}
+          menuPortalTarget={document.body}
+          menuShouldScrollIntoView={true}
           styles={customStyles}
           loadOptions={loadOptions}
-          onInputChange={newValue => {
-            const inputValue = newValue.replace(/[^a-zA-Z0-9\s]+/g, '')
-            return inputValue
-          }}
+          onInputChange={newValue =>
+            newValue.replace(/[^a-zA-Z0-9\s]+/g, '')
+          }
           onChange={async ({ label, value }) => {
             let data = await GeoCodeLocation(value)
             if (data && data.latitude && data.longitude) {

--- a/src/exampleTypes/TagsQuery/ActionsMenu.js
+++ b/src/exampleTypes/TagsQuery/ActionsMenu.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import _ from 'lodash/fp'
-import F from 'futil'
 import { observer } from 'mobx-react'
 import TagsJoinPicker from '../TagsJoinPicker'
 import { withTheme } from '../../utils/theme'
@@ -10,7 +9,7 @@ import { copyTags, tagTerm } from './utils'
 let ActionsMenu = ({
   node,
   tree,
-  open,
+  close,
   theme: { Button, Checkbox },
   actionWrapper = _.identity,
 }) => (
@@ -23,13 +22,13 @@ let ActionsMenu = ({
   >
     {!!_.get('tags.length', node) && (
       <>
-        <Button onClick={actionWrapper(() => F.off(open)() || copyTags(node))}>
+        <Button onClick={actionWrapper(() => close() || copyTags(node))}>
           Copy {_.startCase(tagTerm)}s
         </Button>
         <Button
           style={{ margin: '10px 0' }}
           onClick={actionWrapper(
-            () => F.off(open)() || tree.mutate(node.path, { tags: [] })
+            () => close() || tree.mutate(node.path, { tags: [] })
           )}
         >
           Clear {_.startCase(tagTerm)}s

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -67,13 +67,16 @@ let TagsQuery = ({
             </div>
           }
         >
-          <ActionsMenu
-            {...{
-              node,
-              tree,
-              actionWrapper,
-            }}
-          />
+          { close => (
+            <ActionsMenu
+              {...{
+                node,
+                tree,
+                close,
+                actionWrapper,
+              }}
+            />
+          )}
         </Popover>
       </GridItem>
     </Grid>

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -67,7 +67,7 @@ let TagsQuery = ({
             </div>
           }
         >
-          { close => (
+          {close => (
             <ActionsMenu
               {...{
                 node,


### PR DESCRIPTION
* Fixes closing Popover by pressing Buttons in ActionsMenu
* Rendering GeoComponent's Autocomplete options in a Portal, so it's not getting cropped by a scrollable container
