### PR TITLE
Add F.cascade to ResultsCount

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.31.6
+* Fix ResultsCount when used against memory provider context results
+
 ### 2.31.5
 * Fix Phrase options min width size
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.31.5",
+  "version": "2.31.6",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/ResultCount.js
+++ b/src/exampleTypes/ResultCount.js
@@ -1,10 +1,11 @@
 import _ from 'lodash/fp'
+import F from 'futil'
 import { observer } from 'mobx-react'
 import { withNode, withInlineLoader } from '../utils/hoc'
 import { toNumber } from '../utils/format'
 
 let ResultCount = ({ node, display = toNumber }) => {
-  let count = _.get('context.response.results.length', node)
+  let count =  F.cascade(['context.response.results.length', 'context.results.length'], node)
   return count ? display(node.context.response.totalRecords) : 'No Results'
 }
 

--- a/src/exampleTypes/ResultCount.js
+++ b/src/exampleTypes/ResultCount.js
@@ -6,7 +6,8 @@ import { toNumber } from '../utils/format'
 
 let ResultCount = ({ node, display = toNumber }) => {
   let count =  F.cascade(['context.response.results.length', 'context.results.length'], node)
-  return count ? display(node.context.response.totalRecords) : 'No Results'
+  let totalRecords =  count ? F.cascade(['context.response.totalRecords', 'context.totalRecords'], node) : 0
+  return count ? display(totalRecords) : 'No Results'
 }
 
 export default _.flow(observer, withNode, withInlineLoader)(ResultCount)

--- a/src/exampleTypes/ResultCount.js
+++ b/src/exampleTypes/ResultCount.js
@@ -9,7 +9,9 @@ let ResultCount = ({ node, display = toNumber }) => {
     ['context.response.results.length', 'context.results.length'],
     node
   )
-  let totalRecords =  count ? F.cascade(['context.response.totalRecords', 'context.totalRecords'], node) : 0
+  let totalRecords = count
+    ? F.cascade(['context.response.totalRecords', 'context.totalRecords'], node)
+    : 0
   return count ? display(totalRecords) : 'No Results'
 }
 


### PR DESCRIPTION
- With memory provider, the context does not have `response` which breaks the `ResultsCount` component 