### PR TITLE
Remove rule conflicting with zebra stripe styled tables

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.32.2
+* Remove css rule when nested table is expanded
+
 ### 2.32.1
 * Fix Popover width and placement for TagsJoinPicker
 * Add Story for TagsText

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.32.1",
+  "version": "2.32.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/greyVest/Style.js
+++ b/src/greyVest/Style.js
@@ -125,11 +125,6 @@ export default () => (
         align-items: center;
       }
 
-      /* Nested Table */
-      .gv-table .expanded, .gv-table .expanded + tr {
-        background: rgba(237, 237, 237, 0.5)
-      }
-
       .gv-box {
         border-radius: 4px;
         background-color: #fff;


### PR DESCRIPTION
This removes a CSS rule that changes the background color of
a nested table when it is expanded. The rule conflicts with zebra
striped tables, making differentiation of one row to the next obscured.