### PR TITLE
[fix] FilterList: condition for showing the `Search` button

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.33.2
+* FilterList: condition for showing the `Search` button
+
 ### 2.33.1
 * Popover: updating `reactjs-popup` dependency to v2.0.4
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.33.1",
+  "version": "2.33.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.33.1",
+  "version": "2.33.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/FilterList.js
+++ b/src/FilterList.js
@@ -162,11 +162,7 @@ let FilterList = _.flow(
   }) => {
     let updateRequired =
       tree.disableAutoUpdate &&
-      // find if any nodes in the tree are marked for update (i.e. usually nodes are marked for update because they react to "others" reactor)
-      _.some(
-        treeNode => treeNode !== node && treeNode.markedForUpdate,
-        F.treeToArray(_.get('children'))(node)
-      )
+      tree.getNode(['root', 'results']).markedForUpdate
 
     return (
       <div style={style} className={className}>


### PR DESCRIPTION
Using `tree.getNode(['root', 'results']).markedForUpdate` instead of checking nodes individually 