### PR TITLE
fixing the null value of endOfDay Error

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.33.2
+* Date type: fixing the null value of endOfDay Error
+
 ### 2.33.1
 * Popover: updating `reactjs-popup` dependency to v2.0.4
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.33.1",
+  "version": "2.33.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/Date.js
+++ b/src/exampleTypes/Date.js
@@ -39,7 +39,7 @@ let allRollingOpts = [
   { type: 'future', range: 'next36Months' },
 ]
 
-let endOfDay = date => moment(date).endOf('day').toDate()
+let endOfDay = date =>  date && moment(date).endOf('day').toDate()
 
 let DateComponent = ({
   tree,

--- a/src/exampleTypes/Date.js
+++ b/src/exampleTypes/Date.js
@@ -39,7 +39,7 @@ let allRollingOpts = [
   { type: 'future', range: 'next36Months' },
 ]
 
-let endOfDay = date =>  date && moment(date).endOf('day').toDate()
+let endOfDay = date => date && moment(date).endOf('day').toDate()
 
 let DateComponent = ({
   tree,


### PR DESCRIPTION
when user input a  null value  moment(date).endOf('day').toDate() will return 'invalid date' instead of Null