### PR TITLE
Feature/460 - compose grey-vest ExpandableTable from grey-vest Table

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.35.0
+* use GreyVest Table in GreyVest ExpandableTable
+
 ### 2.34.0
 * add next18Months rolling date type option
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.33.3",
+  "version": "2.35.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/greyVest/ExpandableTable.js
+++ b/src/greyVest/ExpandableTable.js
@@ -6,6 +6,7 @@ import { observer, inject } from 'mobx-react'
 import { DropdownItem } from './DropdownItem'
 import Popover from './Popover'
 import Icon from './Icon'
+import Table from './Table'
 
 export let Column = _.identity
 Column.displayName = 'Column'
@@ -128,7 +129,7 @@ let ExpandableTable = inject(TableState)(
       columnSort = _.identity,
       ...props
     }) => (
-      <table {...props.tableAttrs}>
+      <Table {...props.tableAttrs}>
         <thead>
           <tr>
             {F.mapIndexed(
@@ -174,7 +175,7 @@ let ExpandableTable = inject(TableState)(
           </tr>
         </thead>
         <TableBody columns={columns} data={data} recordKey={recordKey} />
-      </table>
+      </Table>
     )
   )
 )


### PR DESCRIPTION
Fixes #460 

### Description
* one pretty much always will want the styling on `ExpandableTable` to match the styling on `Table`, but right now you're forced to pass `className: 'gv-table'` into the latter to get that result. Better just to compse `ExpandableTable` from `Table` and then let folks override any styling if they want.