### PR TITLE
fix: search bar popup functionality when expanded

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.34.1
+* TagsQuerySearchBar: fix event handling where the child popup events still fire even when the search bar is expanded
+
 ### 2.34.0
 * add next18Months rolling date type option
 

--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,5 +1,6 @@
 ### 2.35.1
 * TagsQuerySearchBar: fix event handling where the child popup events still fire even when the search bar is expanded
+* Box: Use ForwardRef to avoid extra markup
 
 ### 2.35.0
 * use GreyVest Table in GreyVest ExpandableTable

--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,7 @@
+### 2.35.2
+* TagsQuerySearchBar: fix event handling where the child popup events still fire even when the search bar is expanded
+* Box: Use ForwardRef to avoid extra markup
+
 ### 2.35.1
 * Grey Vest Table: Fix an issue where passing in a className overwrites the gv-table class
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.35.1",
+  "version": "2.35.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4128,22 +4128,6 @@
         "symbol.prototype.description": "^1.0.0"
       }
     },
-    "airbnb-prop-types": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
-      "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
-      "requires": {
-        "array.prototype.find": "^2.1.1",
-        "function.prototype.name": "^1.1.2",
-        "is-regex": "^1.1.0",
-        "object-is": "^1.1.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "prop-types-exact": "^1.2.0",
-        "react-is": "^16.13.1"
-      }
-    },
     "ajv": {
       "version": "6.12.3",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
@@ -4391,15 +4375,6 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
-    },
-    "array.prototype.find": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
-      "integrity": "sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==",
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.4"
-      }
     },
     "array.prototype.flat": {
       "version": "1.2.3",
@@ -6655,11 +6630,6 @@
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
-    "consolidated-events": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
-      "integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ=="
-    },
     "constantinople": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
@@ -7315,6 +7285,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -7534,14 +7505,6 @@
       "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
       "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk=",
       "dev": true
-    },
-    "document.contains": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.2.tgz",
-      "integrity": "sha512-YcvYFs15mX8m3AO1QNQy3BlIpSMfNRj3Ujk2BEJxsZG+HZf7/hZ6jr7mDpXrF8q+ff95Vef5yjhiZxm8CGJr6Q==",
-      "requires": {
-        "define-properties": "^1.1.3"
-      }
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -8028,6 +7991,7 @@
       "version": "1.17.6",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
       "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -8075,6 +8039,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -9604,12 +9569,14 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "function.prototype.name": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.2.tgz",
       "integrity": "sha512-C8A+LlHBJjB2AdcRPorc5JvJ5VUoWlXdEHLOJdCI7kjHEtGTpHQUiqMvCIKUwIsGwZX2jZJy761AXsn356bJQg==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1",
@@ -9625,7 +9592,8 @@
     "functions-have-names": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.1.tgz",
-      "integrity": "sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA=="
+      "integrity": "sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA==",
+      "dev": true
     },
     "fuse.js": {
       "version": "3.6.1",
@@ -9982,6 +9950,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -10004,7 +9973,8 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -10812,7 +10782,8 @@
     "is-callable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+      "dev": true
     },
     "is-ci": {
       "version": "2.0.0",
@@ -10846,7 +10817,8 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
     },
     "is-decimal": {
       "version": "1.0.4",
@@ -11049,6 +11021,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
       "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -11095,6 +11068,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -13793,12 +13767,14 @@
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "dev": true
     },
     "object-is": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
       "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -13807,7 +13783,8 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -13822,6 +13799,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -13833,6 +13811,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
       "integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5",
@@ -13884,6 +13863,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
       "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1",
@@ -14846,16 +14826,6 @@
         "react-is": "^16.8.1"
       }
     },
-    "prop-types-exact": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
-      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
-      "requires": {
-        "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "reflect.ownkeys": "^0.2.0"
-      }
-    },
     "property-information": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.5.0.tgz",
@@ -15726,18 +15696,6 @@
         "resize-observer-polyfill": "^1.5.0"
       }
     },
-    "react-outside-click-handler": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.3.0.tgz",
-      "integrity": "sha512-Te/7zFU0oHpAnctl//pP3hEAeobfeHMyygHB8MnjP6sX5OR8KHT1G3jmLsV3U9RnIYo+Yn+peJYWu+D5tUS8qQ==",
-      "requires": {
-        "airbnb-prop-types": "^2.15.0",
-        "consolidated-events": "^1.1.1 || ^2.0.0",
-        "document.contains": "^1.0.1",
-        "object.values": "^1.1.0",
-        "prop-types": "^15.7.2"
-      }
-    },
     "react-popper": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
@@ -16033,11 +15991,6 @@
         "loose-envify": "^1.1.0",
         "symbol-observable": "^1.0.3"
       }
-    },
-    "reflect.ownkeys": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
-      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA="
     },
     "refractor": {
       "version": "2.10.1",
@@ -17532,6 +17485,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
       "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -17541,6 +17495,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
       "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.33.3",
+  "version": "2.34.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.35.1",
+  "version": "2.35.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.34.0",
+  "version": "2.34.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "react-dnd": "^2.5.4",
     "react-dnd-html5-backend": "^2.5.4",
     "react-measure": "^2.3.0",
-    "react-outside-click-handler": "^1.2.3",
     "reactjs-popup": "^2.0.4",
     "recompose": "^0.30.0"
   },

--- a/src/exampleTypes/ExpandableTagsQuery/ExpandArrow.js
+++ b/src/exampleTypes/ExpandableTagsQuery/ExpandArrow.js
@@ -6,9 +6,9 @@ import { Flex } from '../../greyVest'
 import { withTheme } from '../../utils/theme'
 import { tagTerm } from '../TagsQuery/utils'
 
-let ExpandArrow = ({ collapse, tagsLength, style, theme: { Icon } }) =>
-  !!(F.view(collapse) && tagsLength) && (
-    <div className="expand-arrow" onClick={F.off(collapse)} style={style}>
+let ExpandArrow = ({ isOpen, onClick, tagsLength, style, theme: { Icon } }) =>
+  !!(!isOpen && tagsLength) && (
+    <div className="expand-arrow" onClick={onClick} style={style}>
       <div
         style={{
           height: 0,

--- a/src/exampleTypes/ExpandableTagsQuery/ExpandArrow.js
+++ b/src/exampleTypes/ExpandableTagsQuery/ExpandArrow.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import F from 'futil'
 import _ from 'lodash/fp'
 import { observer } from 'mobx-react'
 import { Flex } from '../../greyVest'

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef, useEffect, useState } from 'react'
 import _ from 'lodash/fp'
 import F from 'futil'
 import { withContentRect } from 'react-measure'
@@ -11,17 +11,42 @@ let collapsedStyle = {
   overflowY: 'auto',
 }
 
-let ExpandableTagsQuery = ({ measureRef, contentRect, collapse, ...props }) => (
-  <>
-    <div style={F.view(collapse) ? collapsedStyle : {}}>
+let ExpandableTagsQuery = ({ measureRef, contentRect, isOpen, ...props }) => (
+  // let node = useRef()
+  // let [isOpen, setIsOpen] = useState(false)
+
+  // let handleOutsideClick = e => {
+  //   if (node.current.contains(e.target)) {
+  //     console.log('CLICKED INSIDE')
+  //     return
+  //   }
+  //   console.log('CLICKED OUTSIDE')
+  //   setTimeout(() => setIsOpen(false), 0)
+  // }
+
+  // useEffect(() => {
+  //   document.addEventListener('mousedown', handleOutsideClick)
+
+  //   return () => {
+  //     document.removeEventListener('mousedown', handleOutsideClick)
+  //   }
+  // }, [])
+
+  <div>
+    <div style={isOpen ? {} : collapsedStyle}>
       <div ref={measureRef}>
-        <TagsQuery {...{ ..._.omit('measure', props), collapse }} />
+        <TagsQuery
+          {...{
+            ..._.omit('measure', props),
+            isOpen,
+          }}
+        />
       </div>
     </div>
-    {F.view(collapse) && contentRect.entry.height > innerHeight && (
-      <ExpandArrow collapse={collapse} tagsLength={props.node.tags.length} />
+    {!isOpen && contentRect.entry.height > innerHeight && (
+      <ExpandArrow isOpen={isOpen} tagsLength={props.node.tags.length} />
     )}
-  </>
+  </div>
 )
 
 export default _.flow(contexturify, withContentRect())(ExpandableTagsQuery)

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -1,6 +1,5 @@
-import React, { useRef, useEffect, useState } from 'react'
+import React from 'react'
 import _ from 'lodash/fp'
-import F from 'futil'
 import { withContentRect } from 'react-measure'
 import { contexturify } from '../../utils/hoc'
 import TagsQuery, { innerHeight } from '../TagsQuery'
@@ -11,42 +10,21 @@ let collapsedStyle = {
   overflowY: 'auto',
 }
 
-let ExpandableTagsQuery = ({ measureRef, contentRect, isOpen, ...props }) => (
-  // let node = useRef()
-  // let [isOpen, setIsOpen] = useState(false)
-
-  // let handleOutsideClick = e => {
-  //   if (node.current.contains(e.target)) {
-  //     console.log('CLICKED INSIDE')
-  //     return
-  //   }
-  //   console.log('CLICKED OUTSIDE')
-  //   setTimeout(() => setIsOpen(false), 0)
-  // }
-
-  // useEffect(() => {
-  //   document.addEventListener('mousedown', handleOutsideClick)
-
-  //   return () => {
-  //     document.removeEventListener('mousedown', handleOutsideClick)
-  //   }
-  // }, [])
-
-  <div>
-    <div style={isOpen ? {} : collapsedStyle}>
-      <div ref={measureRef}>
-        <TagsQuery
-          {...{
-            ..._.omit('measure', props),
-            isOpen,
-          }}
-        />
+let ExpandableTagsQuery = ({ measureRef, contentRect, isOpen,...props }) => (<>
+      <div style={isOpen ? {} : collapsedStyle}>
+        <div ref={measureRef}>
+          <TagsQuery
+            {...{
+              ..._.omit('measure', props),
+              isOpen,
+            }}
+          />
+        </div>
       </div>
-    </div>
-    {!isOpen && contentRect.entry.height > innerHeight && (
-      <ExpandArrow isOpen={isOpen} tagsLength={props.node.tags.length} />
-    )}
-  </div>
-)
+      {!isOpen && contentRect.entry.height > innerHeight && (
+        <ExpandArrow isOpen={isOpen} tagsLength={props.node.tags.length} />
+      )}
+    </>
+  )
 
 export default _.flow(contexturify, withContentRect())(ExpandableTagsQuery)

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -10,21 +10,22 @@ let collapsedStyle = {
   overflowY: 'auto',
 }
 
-let ExpandableTagsQuery = ({ measureRef, contentRect, isOpen,...props }) => (<>
-      <div style={isOpen ? {} : collapsedStyle}>
-        <div ref={measureRef}>
-          <TagsQuery
-            {...{
-              ..._.omit('measure', props),
-              isOpen,
-            }}
-          />
-        </div>
+let ExpandableTagsQuery = ({ measureRef, contentRect, isOpen, ...props }) => (
+  <>
+    <div style={isOpen ? {} : collapsedStyle}>
+      <div ref={measureRef}>
+        <TagsQuery
+          {...{
+            ..._.omit('measure', props),
+            isOpen,
+          }}
+        />
       </div>
-      {!isOpen && contentRect.entry.height > innerHeight && (
-        <ExpandArrow isOpen={isOpen} tagsLength={props.node.tags.length} />
-      )}
-    </>
-  )
+    </div>
+    {!isOpen && contentRect.entry.height > innerHeight && (
+      <ExpandArrow isOpen={isOpen} tagsLength={props.node.tags.length} />
+    )}
+  </>
+)
 
 export default _.flow(contexturify, withContentRect())(ExpandableTagsQuery)

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -15,7 +15,7 @@ let ExpandableTagsQuery = ({ measureRef, contentRect, collapse, ...props }) => (
   <>
     <div style={F.view(collapse) ? collapsedStyle : {}}>
       <div ref={measureRef}>
-        <TagsQuery {..._.omit('measure', props)} />
+        <TagsQuery {...{ ..._.omit('measure', props), collapse }} />
       </div>
     </div>
     {F.view(collapse) && contentRect.entry.height > innerHeight && (

--- a/src/exampleTypes/TagsQuery/ActionsMenu.js
+++ b/src/exampleTypes/TagsQuery/ActionsMenu.js
@@ -9,7 +9,7 @@ import { copyTags, tagTerm } from './utils'
 let ActionsMenu = ({
   node,
   tree,
-  close,
+  close = _.noop,
   theme: { Button, Checkbox },
   actionWrapper = _.identity,
 }) => (
@@ -40,7 +40,10 @@ let ActionsMenu = ({
       <Checkbox
         htmlId="stemming"
         checked={!node.exact}
-        onChange={e => tree.mutate(node.path, { exact: !e.target.checked })}
+        onChange={actionWrapper(e => {
+          tree.mutate(node.path, { exact: !e.target.checked })
+          close()
+        })}
       />
       <span>Include word variations</span>
     </label>

--- a/src/exampleTypes/TagsQuerySearchBar.js
+++ b/src/exampleTypes/TagsQuerySearchBar.js
@@ -79,18 +79,16 @@ let SearchBar = ({
 
   return (
     <ButtonGroup style={searchBarStyle}>
-      <Box style={searchBarBoxStyle}>
-        <div onClick={() => setIsOpen(true)} ref={ref}>
-          <ExpandableTagsQuery
-            {...{ tree, node, actionWrapper, isOpen }}
-            Loader={({ children }) => <div>{children}</div>}
-            style={inputStyle}
-            theme={{ TagsInput: ExpandableTagsInput }}
-            onAddTag={() => setIsOpen(true)}
-            autoFocus
-            {...tagsQueryProps}
-          />
-        </div>
+      <Box onClick={() => setIsOpen(true)} ref={ref} style={searchBarBoxStyle}>
+        <ExpandableTagsQuery
+          {...{ tree, node, actionWrapper, isOpen }}
+          Loader={({ children }) => <div>{children}</div>}
+          style={inputStyle}
+          theme={{ TagsInput: ExpandableTagsInput }}
+          onAddTag={() => setIsOpen(true)}
+          autoFocus
+          {...tagsQueryProps}
+        />
       </Box>
       {tree.disableAutoUpdate && (
         <SearchButton

--- a/src/exampleTypes/TagsQuerySearchBar.js
+++ b/src/exampleTypes/TagsQuerySearchBar.js
@@ -1,11 +1,11 @@
-import React from 'react'
-import F from 'futil'
+import React, { useRef, useEffect, useState } from 'react'
+// import F from 'futil'
 import _ from 'lodash/fp'
 import { observer } from 'mobx-react'
-import OutsideClickHandler from 'react-outside-click-handler'
+// import OutsideClickHandler from 'react-outside-click-handler'
 import { withNode } from '../utils/hoc'
 import { Box, ButtonGroup, Button } from '../greyVest'
-import ExpandableTagsInput, { Tags } from '../greyVest/ExpandableTagsInput'
+import ExpandableTagsInput from '../greyVest/ExpandableTagsInput'
 import ExpandableTagsQuery from './ExpandableTagsQuery'
 
 let searchBarStyle = {
@@ -62,36 +62,48 @@ let SearchBar = ({
   searchButtonProps,
   tagsQueryProps,
 }) => {
-  let collapse = React.useState(true)
+  let ref = useRef(null)
+  let [isOpen, setIsOpen] = useState(false)
+
+  let handleOutsideClick = e => {
+    if (ref.current.contains(e.target)) {
+      console.log('CLICKED INSIDE')
+      return
+    }
+    console.log('CLICKED OUTSIDE')
+    setTimeout(() => setIsOpen(false), 0)
+  }
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleOutsideClick)
+
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick)
+    }
+  }, [])
+
   return (
-    <OutsideClickHandler
-      onOutsideClick={() => {
-        F.on(collapse)()
-      }}
-    >
-      <ButtonGroup style={searchBarStyle}>
-        <Box style={searchBarBoxStyle} onClick={F.off(collapse)}>
-          <ExpandableTagsQuery
-            {...{ tree, node, collapse, actionWrapper }}
-            onAddTag={F.off(collapse)}
-            Loader={({ children }) => <div>{children}</div>}
-            style={inputStyle}
-            theme={{
-              TagsInput: ExpandableTagsInput,
-            }}
-            autoFocus
-            {...tagsQueryProps}
-          />
-        </Box>
-        {tree.disableAutoUpdate && (
-          <SearchButton
-            tree={tree}
-            resultsPath={resultsPath}
-            searchButtonProps={searchButtonProps}
-          />
-        )}
-      </ButtonGroup>
-    </OutsideClickHandler>
+    <ButtonGroup style={searchBarStyle}>
+      <Box onClick={() => setIsOpen(true)} ref={ref} style={searchBarBoxStyle}>
+        <ExpandableTagsQuery
+          {...{ tree, node, actionWrapper }}
+          Loader={({ children }) => <div>{children}</div>}
+          style={inputStyle}
+          theme={{ TagsInput: ExpandableTagsInput }}
+          onAddTag={() => setIsOpen(true)}
+          autoFocus
+          isOpen
+          {...tagsQueryProps}
+        />
+      </Box>
+      {tree.disableAutoUpdate && (
+        <SearchButton
+          tree={tree}
+          resultsPath={resultsPath}
+          searchButtonProps={searchButtonProps}
+        />
+      )}
+    </ButtonGroup>
   )
 }
 

--- a/src/exampleTypes/TagsQuerySearchBar.js
+++ b/src/exampleTypes/TagsQuerySearchBar.js
@@ -77,10 +77,7 @@ let SearchBar = ({
             Loader={({ children }) => <div>{children}</div>}
             style={inputStyle}
             theme={{
-              TagsInput:
-                F.view(collapse) && !_.isEmpty(node.tags)
-                  ? Tags
-                  : ExpandableTagsInput,
+              TagsInput: ExpandableTagsInput,
             }}
             autoFocus
             {...tagsQueryProps}

--- a/src/exampleTypes/TagsQuerySearchBar.js
+++ b/src/exampleTypes/TagsQuerySearchBar.js
@@ -66,35 +66,33 @@ let SearchBar = ({
   let [isOpen, setIsOpen] = useState(false)
 
   let handleOutsideClick = e => {
-    if (ref.current.contains(e.target)) {
-      console.log('CLICKED INSIDE')
-      return
+    if (!ref.current.contains(e.target)) {
+      setTimeout(() => setIsOpen(false), 0)
     }
-    console.log('CLICKED OUTSIDE')
-    setTimeout(() => setIsOpen(false), 0)
   }
 
   useEffect(() => {
-    document.addEventListener('mousedown', handleOutsideClick)
+    document.addEventListener('mouseup', handleOutsideClick)
 
     return () => {
-      document.removeEventListener('mousedown', handleOutsideClick)
+      document.removeEventListener('mouseup', handleOutsideClick)
     }
   }, [])
 
   return (
     <ButtonGroup style={searchBarStyle}>
-      <Box onClick={() => setIsOpen(true)} ref={ref} style={searchBarBoxStyle}>
-        <ExpandableTagsQuery
-          {...{ tree, node, actionWrapper }}
-          Loader={({ children }) => <div>{children}</div>}
-          style={inputStyle}
-          theme={{ TagsInput: ExpandableTagsInput }}
-          onAddTag={() => setIsOpen(true)}
-          autoFocus
-          isOpen
-          {...tagsQueryProps}
-        />
+      <Box style={searchBarBoxStyle}>
+        <div onClick={() => setIsOpen(true)} ref={ref}>
+          <ExpandableTagsQuery
+            {...{ tree, node, actionWrapper, isOpen }}
+            Loader={({ children }) => <div>{children}</div>}
+            style={inputStyle}
+            theme={{ TagsInput: ExpandableTagsInput }}
+            onAddTag={() => setIsOpen(true)}
+            autoFocus
+            {...tagsQueryProps}
+          />
+        </div>
       </Box>
       {tree.disableAutoUpdate && (
         <SearchButton

--- a/src/exampleTypes/TagsQuerySearchBar.js
+++ b/src/exampleTypes/TagsQuerySearchBar.js
@@ -1,8 +1,6 @@
 import React, { useRef, useEffect, useState } from 'react'
-// import F from 'futil'
 import _ from 'lodash/fp'
 import { observer } from 'mobx-react'
-// import OutsideClickHandler from 'react-outside-click-handler'
 import { withNode } from '../utils/hoc'
 import { Box, ButtonGroup, Button } from '../greyVest'
 import ExpandableTagsInput from '../greyVest/ExpandableTagsInput'

--- a/src/greyVest/Box.js
+++ b/src/greyVest/Box.js
@@ -1,8 +1,12 @@
 import React from 'react'
 import F from 'futil'
 
-let Box = ({ className = '', ...props }) => (
-  <div className={F.compactJoin(' ', ['gv-box', className])} {...props} />
-)
+let Box = React.forwardRef(({ className = '', ...props }, ref) => (
+  <div
+    ref={ref}
+    className={F.compactJoin(' ', ['gv-box', className])}
+    {...props}
+  />
+))
 
 export default Box

--- a/src/greyVest/ExpandableTagsInput.js
+++ b/src/greyVest/ExpandableTagsInput.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import _ from 'lodash/fp'
-import F from 'futil'
 import { observer } from 'mobx-react'
 import { Tag as DefaultTag, Flex } from '.'
 

--- a/src/greyVest/ExpandableTagsInput.js
+++ b/src/greyVest/ExpandableTagsInput.js
@@ -49,7 +49,7 @@ let ExpandableTagsInput = ({
   onInputChange = _.noop,
   onTagClick = _.noop,
   Tag = DefaultTag,
-  collapse = [],
+  isOpen = false,
   ...props
 }) => {
   addTag = splitCommas
@@ -66,7 +66,7 @@ let ExpandableTagsInput = ({
   return (
     <div style={style}>
       <span className="tags-input-container" columns="1fr auto" gap="8px 4px">
-        {(!F.view(collapse) || _.isEmpty(tags)) && (
+        {(isOpen || _.isEmpty(tags)) && (
           <input
             style={{ flex: 1, border: 0 }}
             onChange={e => {

--- a/src/greyVest/ExpandableTagsInput.js
+++ b/src/greyVest/ExpandableTagsInput.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import _ from 'lodash/fp'
+import F from 'futil'
 import { observer } from 'mobx-react'
 import { Tag as DefaultTag, Flex } from '.'
 
@@ -48,6 +49,7 @@ let ExpandableTagsInput = ({
   onInputChange = _.noop,
   onTagClick = _.noop,
   Tag = DefaultTag,
+  collapse = [],
   ...props
 }) => {
   addTag = splitCommas
@@ -64,41 +66,43 @@ let ExpandableTagsInput = ({
   return (
     <div style={style}>
       <span className="tags-input-container" columns="1fr auto" gap="8px 4px">
-        <input
-          style={{ flex: 1, border: 0 }}
-          onChange={e => {
-            setCurrentInput(e.target.value)
-            onInputChange()
-          }}
-          onBlur={() => {
-            if (isValidInput(currentInput, tags)) {
-              addTag(currentInput)
-              setCurrentInput('')
-              onBlur()
-            }
-          }}
-          onKeyDown={e => {
-            if (e.key === 'Enter' && !currentInput) submit()
-            if (
-              (_.includes(e.key, ['Enter', 'Tab']) ||
-                (splitCommas && e.key === ',')) &&
-              isValidInput(currentInput, tags)
-            ) {
-              addTag(currentInput)
-              setCurrentInput('')
-              e.preventDefault()
-            }
-            if (e.key === 'Backspace' && !currentInput && tags.length) {
-              let last = _.last(tags)
-              removeTag(last)
-              setCurrentInput(last)
-              e.preventDefault()
-            }
-          }}
-          value={currentInput}
-          placeholder={placeholder}
-          {...props}
-        />
+        {(!F.view(collapse) || _.isEmpty(tags)) && (
+          <input
+            style={{ flex: 1, border: 0 }}
+            onChange={e => {
+              setCurrentInput(e.target.value)
+              onInputChange()
+            }}
+            onBlur={() => {
+              if (isValidInput(currentInput, tags)) {
+                addTag(currentInput)
+                setCurrentInput('')
+                onBlur()
+              }
+            }}
+            onKeyDown={e => {
+              if (e.key === 'Enter' && !currentInput) submit()
+              if (
+                (_.includes(e.key, ['Enter', 'Tab']) ||
+                  (splitCommas && e.key === ',')) &&
+                isValidInput(currentInput, tags)
+              ) {
+                addTag(currentInput)
+                setCurrentInput('')
+                e.preventDefault()
+              }
+              if (e.key === 'Backspace' && !currentInput && tags.length) {
+                let last = _.last(tags)
+                removeTag(last)
+                setCurrentInput(last)
+                e.preventDefault()
+              }
+            }}
+            value={currentInput}
+            placeholder={placeholder}
+            {...props}
+          />
+        )}
         <Tags reverse {...{ tags, removeTag, tagStyle, onTagClick, Tag }} />
       </span>
     </div>


### PR DESCRIPTION
Fixes #463 

- Remove outside click library and hand roll one instead
- Pass the close function from the popover to the change listener in the `ActionsMenu`
- Favor useState with separate props to observe instead of using lenses
- Allow `ExpandableTagsInput` to determine it's "expanded" display based on props
- Forward the ref inside `Box` so there isn't unnecessary extra markup

From react-outside-click-handler docs:
<img width="875" alt="Screen Shot 2020-12-18 at 10 26 05 AM" src="https://user-images.githubusercontent.com/15692477/102637349-7b179e80-411b-11eb-842d-de89da88be5e.png">
