### PR TITLE
feature/464 - fix grey vest table className handling

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.35.1
+* Grey Vest Table: Fix an issue where passing in a className overwrites the gv-table class
+
 ### 2.35.0
 * use GreyVest Table in GreyVest ExpandableTable
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/greyVest/Table.js
+++ b/src/greyVest/Table.js
@@ -1,13 +1,8 @@
 import React from 'react'
 
-let Table = x => (
+let Table = ({ className = '', ...props}) => (
   <div className="gv-table-parent">
-    <table
-      {...{
-        ...x,
-        className: x.className ? `gv-table ${x.className}` : 'gv-table',
-      }}
-    />
+    <table className={`gv-table ${className}`} {...props} />
   </div>
 )
 export default Table

--- a/src/greyVest/Table.js
+++ b/src/greyVest/Table.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 let Table = x => (
   <div className="gv-table-parent">
-    <table className="gv-table" {...x} />
+    <table {...{ ...x, className: x.className ? `gv-table ${x.className}` : 'gv-table' }} />
   </div>
 )
 export default Table

--- a/src/greyVest/Table.js
+++ b/src/greyVest/Table.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-let Table = ({ className = '', ...props}) => (
+let Table = ({ className = '', ...props }) => (
   <div className="gv-table-parent">
     <table className={`gv-table ${className}`} {...props} />
   </div>

--- a/src/greyVest/Table.js
+++ b/src/greyVest/Table.js
@@ -2,7 +2,12 @@ import React from 'react'
 
 let Table = x => (
   <div className="gv-table-parent">
-    <table {...{ ...x, className: x.className ? `gv-table ${x.className}` : 'gv-table' }} />
+    <table
+      {...{
+        ...x,
+        className: x.className ? `gv-table ${x.className}` : 'gv-table',
+      }}
+    />
   </div>
 )
 export default Table


### PR DESCRIPTION
The grey-vest table was wired up to overwrite `gv-table` with whatever classname you pass in. Not the right approach.