### PR TITLE
[fix] ResultTable: transparency for blank results

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.39.1
+* ResultTable: fixing transparency for blank results with nested components
+
 ### 2.39.0
 * ResultTable: extending theme to utilize base table components such as Tr, Th, Td
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.39.0",
+  "version": "2.39.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.39.0",
+  "version": "2.39.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -44,7 +44,11 @@ let toBlankText = (display, data, record) => {
 }
 
 export let blankResult = display => (data, record) => (
-  <span style={{ opacity: 0.2, fontFamily: 'monospace' }}>
+  <span style={{
+    fontFamily: 'monospace',
+    display: 'inline-block',
+    opacity: 0.2,
+  }}>
     {toBlankText(display, data, record)}
   </span>
 )

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -44,11 +44,13 @@ let toBlankText = (display, data, record) => {
 }
 
 export let blankResult = display => (data, record) => (
-  <span style={{
-    fontFamily: 'monospace',
-    display: 'inline-block',
-    opacity: 0.2,
-  }}>
+  <span
+    style={{
+      fontFamily: 'monospace',
+      display: 'inline-block',
+      opacity: 0.2,
+    }}
+  >
     {toBlankText(display, data, record)}
   </span>
 )


### PR DESCRIPTION
* [x] ResultTable With limited results: making sure opacity propagates to inner children