### PR TITLE
feat: allow ability to filter out joinOptions in the TagsJoinPicker and TagsQuerySearchBar

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.39.3
+* TagsQuerySearchBar: Add the ability to specify specific tag query join options
+
 ### 2.39.2
 * Icon: Use `withTheme` so that Icon can be replaced at the consumer level
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.39.1",
+  "version": "2.39.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.39.2",
+  "version": "2.39.3",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/TagsJoinPicker.js
+++ b/src/exampleTypes/TagsJoinPicker.js
@@ -19,7 +19,12 @@ let getJoinOptions = _.intersectionWith(
   ]
 )
 
-let TagsJoinPicker = ({ node, tree, theme: { Select }, joinOptions = [] }) => (
+let TagsJoinPicker = ({
+  node,
+  tree,
+  theme: { Select },
+  joinOptions = ['any', 'all', 'none'],
+}) => (
   <Select
     value={node.join}
     onChange={e => tree.mutate(node.path, { join: e.target.value })}

--- a/src/exampleTypes/TagsJoinPicker.js
+++ b/src/exampleTypes/TagsJoinPicker.js
@@ -10,19 +10,14 @@ export let tagToGroupJoin = (x = 'any') =>
     none: 'not',
   }[x])
 
-let defaultJoinOptions = [
-  { value: 'any', label: 'Match any of these keywords' },
-  { value: 'all', label: 'Match all of these keywords' },
-  { value: 'none', label: 'Match none of these keywords' },
-]
-
-let getJoinOptions = options =>
-  _.size(options)
-    ? _.filter(
-        option => _.includes(_.get('value', option), options),
-        defaultJoinOptions
-      )
-    : defaultJoinOptions
+let getJoinOptions = _.intersectionWith(
+  (defaultOption, option) => defaultOption.value === option,
+  [
+    { value: 'any', label: 'Match any of these keywords' },
+    { value: 'all', label: 'Match all of these keywords' },
+    { value: 'none', label: 'Match none of these keywords' },
+  ]
+)
 
 let TagsJoinPicker = ({ node, tree, theme: { Select }, joinOptions = [] }) => (
   <Select

--- a/src/exampleTypes/TagsJoinPicker.js
+++ b/src/exampleTypes/TagsJoinPicker.js
@@ -10,17 +10,25 @@ export let tagToGroupJoin = (x = 'any') =>
     none: 'not',
   }[x])
 
-let joinOptions = [
+let defaultJoinOptions = [
   { value: 'any', label: 'Match any of these keywords' },
   { value: 'all', label: 'Match all of these keywords' },
   { value: 'none', label: 'Match none of these keywords' },
 ]
 
-let TagsJoinPicker = ({ node, tree, theme: { Select } }) => (
+let getJoinOptions = options =>
+  _.size(options)
+    ? _.filter(
+        option => _.includes(_.get('value', option), options),
+        defaultJoinOptions
+      )
+    : defaultJoinOptions
+
+let TagsJoinPicker = ({ node, tree, theme: { Select }, joinOptions = [] }) => (
   <Select
     value={node.join}
     onChange={e => tree.mutate(node.path, { join: e.target.value })}
-    options={joinOptions}
+    options={getJoinOptions(joinOptions)}
     placeholder={false}
   />
 )

--- a/src/exampleTypes/TagsQuery/ActionsMenu.js
+++ b/src/exampleTypes/TagsQuery/ActionsMenu.js
@@ -12,6 +12,7 @@ let ActionsMenu = ({
   close,
   theme: { Button, Checkbox },
   actionWrapper = _.identity,
+  ...props
 }) => (
   <Flex
     style={{ minWidth: 240, padding: 10 }}
@@ -45,7 +46,7 @@ let ActionsMenu = ({
       <span>Include word variations</span>
     </label>
     <div>
-      <TagsJoinPicker node={node} tree={tree} />
+      <TagsJoinPicker node={node} tree={tree} joinOptions={props.joinOptions} />
     </div>
   </Flex>
 )

--- a/src/exampleTypes/TagsQuery/ActionsMenu.js
+++ b/src/exampleTypes/TagsQuery/ActionsMenu.js
@@ -12,7 +12,7 @@ let ActionsMenu = ({
   close,
   theme: { Button, Checkbox },
   actionWrapper = _.identity,
-  ...props
+  joinOptions,
 }) => (
   <Flex
     style={{ minWidth: 240, padding: 10 }}
@@ -46,7 +46,7 @@ let ActionsMenu = ({
       <span>Include word variations</span>
     </label>
     <div>
-      <TagsJoinPicker node={node} tree={tree} joinOptions={props.joinOptions} />
+      <TagsJoinPicker {...{ node, tree, joinOptions }} />
     </div>
   </Flex>
 )

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -18,6 +18,7 @@ let TagsQuery = ({
   popoverArrow,
   popoverOffsetY,
   theme: { Icon, TagsInput, Tag, Popover },
+  joinOptions,
   ...props
 }) => {
   let TagWithPopover = props => (
@@ -79,7 +80,7 @@ let TagsQuery = ({
                 tree,
                 close,
                 actionWrapper,
-                joinOptions: props.joinOptions,
+                joinOptions,
               }}
             />
           )}

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -79,6 +79,7 @@ let TagsQuery = ({
                 tree,
                 close,
                 actionWrapper,
+                joinOptions: props.joinOptions,
               }}
             />
           )}


### PR DESCRIPTION
You can now filter down the ['none', 'all', 'any'] options TagsJoinPicker by passing an explicit array of options.  

EX: `joinOptions: ['all', 'any']`
Or in TagsQuerySearchBar it would be `tagsQueryProps={{ joinOptions: ['any', 'all'] }}`