### PR TITLE
Date range change

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,9 @@
+### 2.42.4
+* Date: Fix the issue with range change forcing a tree update
+
+### 2.42.3
+* ResultCount: Support more node result exampleTypes
+
 ### 2.42.2
 * TagsQuery: Format the tags number
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.42.2",
+  "version": "2.42.4",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/Date.js
+++ b/src/exampleTypes/Date.js
@@ -48,7 +48,9 @@ let DateComponent = ({
   excludeRollingRanges = [],
   theme: { DateInput, RadioList, Select },
 }) => {
-  let [range, setRange] = React.useState(node.range !== 'exact' ? 'rolling': 'exact')
+  let [range, setRange] = React.useState(
+    node.range !== 'exact' ? 'rolling' : 'exact'
+  )
 
   // We need the hook to deal with the `clear/reset` case where the node.range is changed but the range remains unchanged
   React.useEffect(() => {

--- a/src/exampleTypes/Date.js
+++ b/src/exampleTypes/Date.js
@@ -48,12 +48,14 @@ let DateComponent = ({
   excludeRollingRanges = [],
   theme: { DateInput, RadioList, Select },
 }) => {
-  let [range, setRange] = React.useState(node.range === 'exact' ? 'exact' : 'rolling')
+  let [range, setRange] = React.useState(
+    node.range === 'exact' ? 'exact' : 'rolling'
+  )
 
   // We need the hook to deal with the `clear/reset` case where the node.range is changed but the range remains unchanged
   React.useEffect(() => {
     if (node.range !== range && node.range === 'exact') setRange('exact')
-  }, [node.range]);
+  }, [node.range])
 
   let rollingOpts = _.reject(
     opt => _.includes(opt.type, excludeRollingRanges),
@@ -72,9 +74,7 @@ let DateComponent = ({
         <Flex style={{ justifyContent: 'space-between', alignItems: 'center' }}>
           <DateInput
             value={node.from}
-            onChange={date =>
-              tree.mutate(node.path, { range, from: date })
-            }
+            onChange={date => tree.mutate(node.path, { range, from: date })}
           />
           <div>-</div>
           <DateInput

--- a/src/exampleTypes/Date.js
+++ b/src/exampleTypes/Date.js
@@ -48,6 +48,13 @@ let DateComponent = ({
   excludeRollingRanges = [],
   theme: { DateInput, RadioList, Select },
 }) => {
+  let [range, setRange] = React.useState(node.range === 'exact' ? 'exact' : 'rolling')
+
+  // We need the hook to deal with the `clear/reset` case where the node.range is changed but the range remains unchanged
+  React.useEffect(() => {
+    if (node.range !== range && node.range === 'exact') setRange('exact')
+  }, [node.range]);
+
   let rollingOpts = _.reject(
     opt => _.includes(opt.type, excludeRollingRanges),
     allRollingOpts
@@ -57,30 +64,23 @@ let DateComponent = ({
     <div>
       <RadioList
         options={F.autoLabelOptions(['exact', 'rolling'])}
-        value={node.range !== 'exact' ? 'rolling' : 'exact'}
+        value={range}
         style={{ marginBottom: 10 }}
-        onChange={value => {
-          tree.mutate(
-            node.path,
-            value === 'exact'
-              ? { range: 'exact', from: null, to: null }
-              : { range: '', from: null, to: null }
-          )
-        }}
+        onChange={value => setRange(value)}
       />
-      {node.range === 'exact' ? (
+      {range === 'exact' ? (
         <Flex style={{ justifyContent: 'space-between', alignItems: 'center' }}>
           <DateInput
             value={node.from}
             onChange={date =>
-              tree.mutate(node.path, { range: 'exact', from: date })
+              tree.mutate(node.path, { range, from: date })
             }
           />
           <div>-</div>
           <DateInput
             value={node.to}
             onChange={date =>
-              tree.mutate(node.path, { range: 'exact', to: endOfDay(date) })
+              tree.mutate(node.path, { range, to: endOfDay(date) })
             }
           />
         </Flex>

--- a/src/exampleTypes/Date.js
+++ b/src/exampleTypes/Date.js
@@ -48,9 +48,7 @@ let DateComponent = ({
   excludeRollingRanges = [],
   theme: { DateInput, RadioList, Select },
 }) => {
-  let [range, setRange] = React.useState(
-    node.range === 'exact' ? 'exact' : 'rolling'
-  )
+  let [range, setRange] = React.useState(node.range !== 'exact' ? 'rolling': 'exact')
 
   // We need the hook to deal with the `clear/reset` case where the node.range is changed but the range remains unchanged
   React.useEffect(() => {

--- a/src/exampleTypes/Date.js
+++ b/src/exampleTypes/Date.js
@@ -48,6 +48,9 @@ let DateComponent = ({
   excludeRollingRanges = [],
   theme: { DateInput, RadioList, Select },
 }) => {
+  let [to, setTo] = React.useState(node.to)
+  let [from, setFrom] = React.useState(node.from)
+  let [dateRange, setDateRange] = React.useState(node.range)
   let [range, setRange] = React.useState(
     node.range !== 'exact' ? 'rolling' : 'exact'
   )
@@ -68,31 +71,45 @@ let DateComponent = ({
         options={F.autoLabelOptions(['exact', 'rolling'])}
         value={range}
         style={{ marginBottom: 10 }}
-        onChange={value => setRange(value)}
+        onChange={value => {
+          // Deal with the reset of the values
+          if (value !== 'exact') {
+            setTo(null)
+            setFrom(null)
+          } else {
+            setDateRange(null)
+          }
+          setRange(value)
+        }}
       />
       {range === 'exact' ? (
         <Flex style={{ justifyContent: 'space-between', alignItems: 'center' }}>
           <DateInput
-            value={node.from}
-            onChange={date => tree.mutate(node.path, { range, from: date })}
+            value={from}
+            onChange={date => {
+              setFrom(date)
+              tree.mutate(node.path, { range, from: date })
+            }}
           />
           <div>-</div>
           <DateInput
-            value={node.to}
-            onChange={date =>
+            value={to}
+            onChange={date => {
+              setTo(date)
               tree.mutate(node.path, { range, to: endOfDay(date) })
-            }
+            }}
           />
         </Flex>
       ) : (
         <Select
-          value={node.range}
-          onChange={e =>
+          value={dateRange}
+          onChange={e => {
+            setDateRange(e.target.value)
             tree.mutate(node.path, {
               range: e.target.value,
               timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
             })
-          }
+          }}
           options={F.map(
             ({ range }) => ({
               label: _.startCase(range),

--- a/src/exampleTypes/ResultTable/Header.js
+++ b/src/exampleTypes/ResultTable/Header.js
@@ -172,8 +172,8 @@ let Header = ({
                   icon={
                     filterNode
                       ? F.view(filtering)
-                        ? 'FilterCollapse'
-                        : 'FilterExpand'
+                        ? 'FilterExpand'
+                        : 'FilterCollapse'
                       : 'FilterAdd'
                   }
                 />


### PR DESCRIPTION
- Remove the node update which forces the filter when in popover to close due to the update of the node/tree.
   There also is no need to update the tree node since we are switching between `exact` and `rolling` without an actual date range change.
- Since we do not update the node anymore we use the `useEffect` hook to set the range in the edge case of the `clear/reset` where the node is updated outside of the component.

Note this is version `2.42.4` and we have another PR with the previous version not merged yet.