### PR TITLE
Fix: memory table default criteria

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.43.2
+* MemoryTable: default criteria nodes to an empty array so casting works as expected
+
 ### 2.43.1
 * useMemoryTree: pageSize 50 by default
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.43.1",
+  "version": "2.43.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.43.1",
+  "version": "2.43.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/MemoryTable.js
+++ b/src/MemoryTable.js
@@ -11,7 +11,7 @@ export let useMemoryTree = ({
   records,
   debug,
   resultsNode,
-  criteriaNodes,
+  criteriaNodes = [],
 } = {}) => {
   let makeTree = () =>
     ContextureMobx({


### PR DESCRIPTION
_.castArray on `undefined` will just wrap `undefined` in an array instead of creating an empty array, which can cause havoc.  So we will just return an empty array if the criteria is undefined.