### PR TITLE
Pass new params to TagsQuery/TagsInput

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,7 @@
+### 2.44.4
+* TagsInput: Allow for new parameters to govern the words match pattern and if we want to sanitize the tags
+* TagsQuery: Pass the new parameters to TagsInput
+
 ### 2.44.3
 * TagsInput: Limit the number of words per tag and the number of characters per word
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.44.3",
+  "version": "2.44.4",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -21,6 +21,8 @@ let TagsQuery = ({
   popoverOffsetY,
   theme: { Icon, TagsInput, Tag, Popover },
   joinOptions,
+  wordsMatchPattern,
+  sanitizeTags = true,
   ...props
 }) => {
   let TagWithPopover = observer(props => {
@@ -52,6 +54,8 @@ let TagsQuery = ({
       <GridItem height={2} place="center stretch">
         <TagsInput
           splitCommas
+          sanitizeTags={sanitizeTags}
+          wordsMatchPattern={wordsMatchPattern}
           tags={_.map(tagValueField, node.tags)}
           addTag={tag => {
             tree.mutate(node.path, {

--- a/src/greyVest/TagsInput.js
+++ b/src/greyVest/TagsInput.js
@@ -33,7 +33,7 @@ let TagsInput = forwardRef(
     let containerRef = React.useRef()
     let state = useLocalStore(() => ({ currentInput: '' }))
 
-    let words = _.words.convert({ fixed: false, cap: false })
+    let words = _.words.convert({ fixed: false })
     // Convert string to words, take the first maxWordsPerTag, truncate them and convert back to string
     let sanitizeWords = _.flow(
       string => words(string, wordsMatchPattern),

--- a/src/greyVest/TagsInput.js
+++ b/src/greyVest/TagsInput.js
@@ -23,6 +23,8 @@ let TagsInput = forwardRef(
       onTagClick = _.noop,
       maxWordsPerTag = 100,
       maxCharsPerTagWord = 100,
+      wordsMatchPattern,
+      sanitizeTags = true,
       Tag = DefaultTag,
       ...props
     },
@@ -31,9 +33,10 @@ let TagsInput = forwardRef(
     let containerRef = React.useRef()
     let state = useLocalStore(() => ({ currentInput: '' }))
 
+    let words = _.words.convert({ fixed: false, cap: false })
     // Convert string to words, take the first maxWordsPerTag, truncate them and convert back to string
     let sanitizeWords = _.flow(
-      _.words,
+      string => words(string, wordsMatchPattern),
       _.take(maxWordsPerTag),
       _.map(_.truncate({ length: maxCharsPerTagWord, omission: '' })),
       _.join(' ')
@@ -45,7 +48,7 @@ let TagsInput = forwardRef(
           _.invokeMap('trim'),
           _.compact,
           _.uniq,
-          _.map(sanitizeWords),
+          tags => sanitizeTags ? _.map(sanitizeWords, tags) : tags,
           _.difference(_, tags),
           _.map(addTag)
         )

--- a/src/greyVest/TagsInput.js
+++ b/src/greyVest/TagsInput.js
@@ -48,7 +48,7 @@ let TagsInput = forwardRef(
           _.invokeMap('trim'),
           _.compact,
           _.uniq,
-          tags => sanitizeTags ? _.map(sanitizeWords, tags) : tags,
+          tags => (sanitizeTags ? _.map(sanitizeWords, tags) : tags),
           _.difference(_, tags),
           _.map(addTag)
         )


### PR DESCRIPTION
- Allow for passing to TagsQuery/TagsInput `sanitizeTags` to enable/disable the words/tags sanitization
- Allow for passing to TagsQuery/TagsInput `wordsMatchPattern` so that we can customize the words match pattern in cases where we are too greedy removing characters.

This allows us to now specify per filter if we want to sanitize and if we want to with what match pattern. This should resolve issues where we can not input email addresses etc.