### PR TITLE
Debounces tag adding (so pasting 100 tags doesn’t run 100 times)

### DIFF
--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -57,12 +57,12 @@ let TagsQuery = ({
           sanitizeTags={sanitizeTags}
           wordsMatchPattern={wordsMatchPattern}
           tags={_.map(tagValueField, node.tags)}
-          addTag={tag => {
+          addTag={_.debounce(tag => {
             tree.mutate(node.path, {
               tags: [...node.tags, { [tagValueField]: tag, distance: 3 }],
             })
             onAddTag(tag)
-          }}
+          })}
           removeTag={tag => {
             tree.mutate(node.path, {
               tags: _.reject({ [tagValueField]: tag }, node.tags),


### PR DESCRIPTION
This might not work in all cases and might cause some tags to get lost. We might want a bulk add method instead 