### PR TITLE
Introduce addTags

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,6 +1,6 @@
 ### 2.44.5
-* TagsQuery: Introduce `onTagsAdded`
-* TagsInput: Use `onTagsAdded` so we mutate the tree only at the point where all tags have been objectified
+* TagsQuery: Refactoring to use `addTags`
+* TagsInput: Use `addTags` so we mutate the tree only at the point where all tags have been objectified
 
 ### 2.44.4
 * TagsInput: Allow for new parameters to govern the words match pattern and if we want to sanitize the tags

--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,7 @@
+### 2.44.5
+* TagsQuery: Introduce `onTagsAdded`
+* TagsInput: Use `onTagsAdded` so we mutate the tree only at the point where all tags have been objectified
+
 ### 2.44.4
 * TagsInput: Allow for new parameters to govern the words match pattern and if we want to sanitize the tags
 * TagsQuery: Pass the new parameters to TagsInput

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.44.4",
+  "version": "2.44.5",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -63,7 +63,7 @@ let TagsQuery = ({
             onAddTag(tagObject)
             return tagObject
           }}
-          // onTagsAdded: Called when the all the tags are sanitized and converted to objects with their distance etc.
+          // onTagsAdded: Called when all the tags are sanitized and converted to objects with their distance etc.
           onTagsAdded={tags => tree.mutate(node.path, { tags: [ ...node.tags,...tags ] })}
           removeTag={tag => {
             tree.mutate(node.path, {

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -58,16 +58,11 @@ let TagsQuery = ({
           sanitizeTags={sanitizeTags}
           wordsMatchPattern={wordsMatchPattern}
           tags={_.map(tagValueField, node.tags)}
-          // addTag: Called on every tag being added via the input. Use to decorate the tag into object form
-          addTag={tag => {
-            let tagObject = { [tagValueField]: tag, distance: 3 }
-            onAddTag(tagObject)
-            return tagObject
+          addTags={tags => {
+            let tagObjects = _.map(tag => ({ [tagValueField]: tag, distance: 3 }), tags)
+            tree.mutate(node.path, { tags: [...node.tags, ...tagObjects] })
+            onAddTag(tags)
           }}
-          // onTagsAdded: Called when all the tags are sanitized and converted to objects with their distance etc.
-          onTagsAdded={tags =>
-            tree.mutate(node.path, { tags: [...node.tags, ...tags] })
-          }
           removeTag={tag => {
             tree.mutate(node.path, {
               tags: _.reject({ [tagValueField]: tag }, node.tags),

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -57,12 +57,14 @@ let TagsQuery = ({
           sanitizeTags={sanitizeTags}
           wordsMatchPattern={wordsMatchPattern}
           tags={_.map(tagValueField, node.tags)}
+          // addTag: Called on every tag being added via the input. Use to decorate the tag into object form
           addTag={tag => {
-            tree.mutate(node.path, {
-              tags: [...node.tags, { [tagValueField]: tag, distance: 3 }],
-            })
-            onAddTag(tag)
+            let tagObject = { [tagValueField]: tag, distance: 3 }
+            onAddTag(tagObject)
+            return tagObject
           }}
+          // onTagsAdded: Called when the all the tags are sanitized and converted to objects with their distance etc.
+          onTagsAdded={tags => tree.mutate(node.path, { tags: [ ...node.tags,...tags ] })}
           removeTag={tag => {
             tree.mutate(node.path, {
               tags: _.reject({ [tagValueField]: tag }, node.tags),

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -23,6 +23,7 @@ let TagsQuery = ({
   joinOptions,
   wordsMatchPattern,
   sanitizeTags = true,
+  splitCommas = true,
   ...props
 }) => {
   let TagWithPopover = observer(props => {
@@ -53,7 +54,7 @@ let TagsQuery = ({
     >
       <GridItem height={2} place="center stretch">
         <TagsInput
-          splitCommas
+          splitCommas={splitCommas}
           sanitizeTags={sanitizeTags}
           wordsMatchPattern={wordsMatchPattern}
           tags={_.map(tagValueField, node.tags)}

--- a/src/greyVest/TagsInput.js
+++ b/src/greyVest/TagsInput.js
@@ -11,7 +11,7 @@ let TagsInput = forwardRef(
   (
     {
       tags,
-      addTag,
+      addTags,
       removeTag,
       submit = _.noop,
       tagStyle,
@@ -21,7 +21,6 @@ let TagsInput = forwardRef(
       onBlur = _.noop,
       onInputChange = _.noop,
       onTagClick = _.noop,
-      onTagsAdded = _.noop,
       maxWordsPerTag = 100,
       maxCharsPerTagWord = 100,
       wordsMatchPattern,
@@ -43,7 +42,7 @@ let TagsInput = forwardRef(
       _.join(' ')
     )
 
-    addTag = splitCommas
+    addTags = splitCommas
       ? _.flow(
           _.split(','),
           _.invokeMap('trim'),
@@ -51,10 +50,9 @@ let TagsInput = forwardRef(
           _.uniq,
           tags => (sanitizeTags ? _.map(sanitizeWords, tags) : tags),
           _.difference(_, tags),
-          _.map(addTag),
-          onTagsAdded
+          addTags
         )
-      : _.flow(_.trim, addTag, _.castArray, onTagsAdded)
+      : _.flow(_.trim, _.castArray, addTags)
     return (
       <div className={'tags-input'} ref={containerRef} style={{ ...style }}>
         <Flex
@@ -92,7 +90,7 @@ let TagsInput = forwardRef(
             }}
             onBlur={() => {
               if (isValidInput(state.currentInput, tags)) {
-                addTag(state.currentInput)
+                addTags(state.currentInput)
                 state.currentInput = ''
                 onBlur()
               }
@@ -104,7 +102,7 @@ let TagsInput = forwardRef(
                   (splitCommas && e.key === ',')) &&
                 isValidInput(state.currentInput, tags)
               ) {
-                addTag(state.currentInput)
+                addTags(state.currentInput)
                 state.currentInput = ''
                 e.preventDefault()
               }
@@ -130,7 +128,7 @@ export let MockTagsInput = inject(() => {
   let tags = observable([])
   return {
     tags,
-    addTag(tag) {
+    addTags(tag) {
       tags.push(tag)
     },
     removeTag(tag) {

--- a/src/greyVest/TagsInput.js
+++ b/src/greyVest/TagsInput.js
@@ -54,7 +54,7 @@ let TagsInput = forwardRef(
           _.map(addTag),
           onTagsAdded
         )
-      : _.flow(_.trim, addTag)
+      : _.flow(_.trim, addTag, _.castArray, onTagsAdded)
     return (
       <div className={'tags-input'} ref={containerRef} style={{ ...style }}>
         <Flex

--- a/src/greyVest/TagsInput.js
+++ b/src/greyVest/TagsInput.js
@@ -21,6 +21,7 @@ let TagsInput = forwardRef(
       onBlur = _.noop,
       onInputChange = _.noop,
       onTagClick = _.noop,
+      onTagsAdded = _.noop,
       maxWordsPerTag = 100,
       maxCharsPerTagWord = 100,
       wordsMatchPattern,
@@ -50,7 +51,8 @@ let TagsInput = forwardRef(
           _.uniq,
           tags => (sanitizeTags ? _.map(sanitizeWords, tags) : tags),
           _.difference(_, tags),
-          _.map(addTag)
+          _.map(addTag),
+          onTagsAdded
         )
       : _.flow(_.trim, addTag)
     return (

--- a/src/greyVest/utils.js
+++ b/src/greyVest/utils.js
@@ -1,6 +1,27 @@
+import _ from 'lodash/fp'
 import F from 'futil'
 
 export let openBinding = (...lens) => ({
   isOpen: F.view(...lens),
   onClose: F.off(...lens),
 })
+
+// Convert string to words, take the first maxWordsPerTag, truncate them and convert back to string
+export let sanitizeTagWords = (wordsMatchPattern, maxWordsPerTag, maxCharsPerTagWord) => {
+  let words = _.words.convert({ fixed: false })
+  return _.flow(
+    string => words(string, wordsMatchPattern),
+    _.take(maxWordsPerTag),
+    _.map(_.truncate({ length: maxCharsPerTagWord, omission: '' })),
+    _.join(' ')
+  )
+}
+
+// Split a tag on comma into unique words
+export let splitTagOnComma = _.flow(
+  _.trim,
+  _.split(','),
+  _.invokeMap('trim'),
+  _.compact,
+  _.uniq,
+)


### PR DESCRIPTION
The issue identified by @daedalus28 recently is that we call the `tree.mutate` on every single tag when someone does copy/paste of 100K tags. We limit to only 100 now ... but we still call `tree.mutate` 100 times. 

- Fix the `splitCommas` not being properly passed down from `TagsQuery` to `TagsInput`
- Refactor the logic so that we now have `addTags` method which adds array
- Refactor the common logic into `utils` so that the ExpandableTagsInput also uses it