### PR TITLE
Default regex for TagsInput / wordsMatchPattern

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.45.2
+* TagsInput: Default `wordsMatchPattern` to alphanumeric characters
+
 ### 2.45.1
 * TagsQuery: Fix the `maxTags` handling of extra tags
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.45.0",
+  "version": "2.45.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.45.1",
+  "version": "2.45.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/greyVest/TagsInput.js
+++ b/src/greyVest/TagsInput.js
@@ -24,7 +24,10 @@ let TagsInput = forwardRef(
       onTagClick = _.noop,
       maxWordsPerTag = 100,
       maxCharsPerTagWord = 100,
-      wordsMatchPattern,
+      // Used to match words composed of alphanumeric characters.
+      // https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js#L166
+      // eslint-disable-next-line no-control-regex
+      wordsMatchPattern = /[^\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]+/g,
       sanitizeTags = true,
       Tag = DefaultTag,
       ...props


### PR DESCRIPTION
- Default the TagsInput / wordsMatchPattern to alphanumeric characters