### PR TITLE
ExpandableTagsInput change

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.45.3
+* ExpandableTagsInput: Default `wordsMatchPattern` to alphanumeric characters
+
 ### 2.45.2
 * TagsInput: Default `wordsMatchPattern` to alphanumeric characters
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.45.2",
+  "version": "2.45.3",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/greyVest/ExpandableTagsInput.js
+++ b/src/greyVest/ExpandableTagsInput.js
@@ -2,7 +2,7 @@ import React from 'react'
 import _ from 'lodash/fp'
 import { observer } from 'mobx-react'
 import { Tag as DefaultTag, Flex } from '.'
-import { sanitizeTagWords, splitTagOnComma } from './utils'
+import { sanitizeTagWords, splitTagOnComma, alphaNumericRegEx } from './utils'
 
 export let Tags = ({
   reverse = false,
@@ -49,7 +49,7 @@ let ExpandableTagsInput = ({
   onInputChange = _.noop,
   maxWordsPerTag = 100,
   maxCharsPerTagWord = 100,
-  wordsMatchPattern,
+  wordsMatchPattern = alphaNumericRegEx,
   onTagClick = _.noop,
   sanitizeTags = true,
   Tag = DefaultTag,

--- a/src/greyVest/TagsInput.js
+++ b/src/greyVest/TagsInput.js
@@ -4,7 +4,7 @@ import { observable } from 'mobx'
 import { observer, inject, useLocalStore } from 'mobx-react'
 import Flex from './Flex'
 import DefaultTag from './Tag'
-import { sanitizeTagWords, splitTagOnComma } from './utils'
+import { sanitizeTagWords, splitTagOnComma, alphaNumericRegEx } from './utils'
 
 let isValidInput = (tag, tags) => !_.isEmpty(tag) && !_.includes(tag, tags)
 
@@ -24,10 +24,7 @@ let TagsInput = forwardRef(
       onTagClick = _.noop,
       maxWordsPerTag = 100,
       maxCharsPerTagWord = 100,
-      // Used to match words composed of alphanumeric characters.
-      // https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js#L166
-      // eslint-disable-next-line no-control-regex
-      wordsMatchPattern = /[^\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]+/g,
+      wordsMatchPattern = alphaNumericRegEx,
       sanitizeTags = true,
       Tag = DefaultTag,
       ...props

--- a/src/greyVest/utils.js
+++ b/src/greyVest/utils.js
@@ -29,3 +29,9 @@ export let splitTagOnComma = _.flow(
   _.compact,
   _.uniq
 )
+
+// RegEx to match words composed of alphanumeric characters.
+// Uses ASCI ranges https://donsnotes.com/tech/charsets/ascii.html
+// From: https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js#L166
+// eslint-disable-next-line no-control-regex
+export let alphaNumericRegEx = /[^\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]+/g


### PR DESCRIPTION
- Add the `wordsMatchPattern` default to the  `ExpandableTagsInput` as well
- Refactor so both components use the same regEx