### PR TITLE
Allow '-' character in the tags query tags

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.45.4
+* TagsInput & ExpandableTagsInput: Changes to the sanitize tags regex to allow '-'
+
 ### 2.45.3
 * ExpandableTagsInput: Default `wordsMatchPattern` to alphanumeric characters
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.45.3",
+  "version": "2.45.4",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/greyVest/utils.js
+++ b/src/greyVest/utils.js
@@ -16,7 +16,13 @@ export let sanitizeTagWords = (
   return _.flow(
     string => words(string, wordsMatchPattern),
     _.take(maxWordsPerTag),
-    _.map(_.truncate({ length: maxCharsPerTagWord, omission: '' })),
+    _.map(word => _.flow(
+        _.truncate({ length: maxCharsPerTagWord, omission: '' }),
+        // Remove beginning of line dash and space dash
+        _.replace(/^-| -/g, ' '),
+        _.trim
+      )(word)
+    ),
     _.join(' ')
   )
 }
@@ -31,7 +37,7 @@ export let splitTagOnComma = _.flow(
 )
 
 // RegEx to match words composed of alphanumeric characters.
-// Uses ASCI ranges https://donsnotes.com/tech/charsets/ascii.html
 // From: https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js#L166
+// Uses ASCI ranges https://donsnotes.com/tech/charsets/ascii.html with the exception that it allows '-' which is \x2D
 // eslint-disable-next-line no-control-regex
-export let alphaNumericRegEx = /[^\x00-\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]+/g
+export let alphaNumericRegEx = /[^\x00-\x2C\x2E-\x2F\x3a-\x40\x5b-\x60\x7b-\x7f]+/g

--- a/src/greyVest/utils.js
+++ b/src/greyVest/utils.js
@@ -16,7 +16,8 @@ export let sanitizeTagWords = (
   return _.flow(
     string => words(string, wordsMatchPattern),
     _.take(maxWordsPerTag),
-    _.map(word => _.flow(
+    _.map(word =>
+      _.flow(
         _.truncate({ length: maxCharsPerTagWord, omission: '' }),
         // Remove beginning of line dash and space dash
         _.replace(/^-| -/g, ' '),


### PR DESCRIPTION
- `-` is no longer removed from the tag words on the entry pass
- Space dash and starting a word with dash are now not allowed

Fixes #505