### PR TITLE
Facet UI changes to limit number of checked items

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.46.1
+* Facet: UI limit on number of checked values
+
 ### 2.46.0
 * FilterButtonList: adopt FilterList functionality
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.45.2",
+  "version": "2.46.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.46.0",
+  "version": "2.46.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -1,7 +1,9 @@
-import React from 'react'
+import React, { useState } from 'react'
 import F from 'futil'
+import _ from 'lodash/fp'
 import { contexturify } from '../utils/hoc'
 import { toNumber } from '../utils/format'
+import { Box, Expandable } from '../greyVest'
 import {
   displayFn,
   displayBlankFn,
@@ -10,6 +12,11 @@ import {
   FacetCheckboxList,
   FacetOptionsFilter,
 } from '../utils/facet'
+
+// The hard limit to how many checked values we can allow in a facet
+let maxChecked = 500
+// The number of items selected after which we will show the warning message
+let warningCheck = 250
 
 let Facet = ({
   tree,
@@ -24,27 +31,47 @@ let Facet = ({
   displayBlank = displayBlankFn,
   formatCount = toNumber,
   theme: { RadioList },
-}) => (
-  <div className="contexture-facet">
-    {!hide.radioList && (
-      <RadioList
-        value={node.mode || 'include'} // Fix by changing defaults in client example type
-        onChange={mode => tree.mutate(node.path, { mode })}
-        options={F.autoLabelOptions(['include', 'exclude'])}
+}) => {
+  let valuesChecked = _.size(node.values)
+  let [expanded, setExpanded] = useState(false)
+  return (
+    <div className="contexture-facet">
+      {valuesChecked > warningCheck &&
+        <Expandable
+          isOpen={expanded}
+          onClick={() => setExpanded(!expanded)}
+          Label={
+            <a style={{cursor: 'pointer', color: 'red'}}>
+              <b>* Too many items selected</b>
+            </a>
+          }
+        >
+          <Box>
+            You have selected a large number of items for this filter.
+            Please consider using a different <b>filter type</b> or contact support for more search options.
+          </Box>
+        </Expandable>
+      }
+      {!hide.radioList && (
+        <RadioList
+          value={node.mode || 'include'} // Fix by changing defaults in client example type
+          onChange={mode => tree.mutate(node.path, { mode })}
+          options={F.autoLabelOptions(['include', 'exclude'])}
+        />
+      )}
+      {!hide.facetFilter && <FacetOptionsFilter tree={tree} node={node} />}
+      {!hide.selectAll && <SelectAll node={node} tree={tree} maxChecked={maxChecked} />}
+      <FacetCheckboxList
+        tree={tree}
+        node={node}
+        hide={hide}
+        display={display}
+        displayBlank={displayBlank}
+        formatCount={formatCount}
       />
-    )}
-    {!hide.facetFilter && <FacetOptionsFilter tree={tree} node={node} />}
-    {!hide.selectAll && <SelectAll node={node} tree={tree} />}
-    <FacetCheckboxList
-      tree={tree}
-      node={node}
-      hide={hide}
-      display={display}
-      displayBlank={displayBlank}
-      formatCount={formatCount}
-    />
-    <Cardinality {...{ node, tree }} />
-  </div>
-)
+      <Cardinality {...{ node, tree }} />
+    </div>
+  )
+}
 
 export default contexturify(Facet)

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -36,9 +36,10 @@ let Facet = ({
     <div className="contexture-facet">
       {valuesChecked > warningCheck && (
         <span>
-          You have selected more than 250 items for this filter.
-          Please consider using a different <b>filter type</b> or contact support for more search options.
-          You will not be able to select more than 500 items maximum.
+          You have selected more than 250 items for this filter. Please consider
+          using a different <b>filter type</b> or contact support for more
+          search options. You will not be able to select more than 500 items
+          maximum.
         </span>
       )}
       {!hide.radioList && (

--- a/src/exampleTypes/Facet.js
+++ b/src/exampleTypes/Facet.js
@@ -1,9 +1,8 @@
-import React, { useState } from 'react'
+import React from 'react'
 import F from 'futil'
 import _ from 'lodash/fp'
 import { contexturify } from '../utils/hoc'
 import { toNumber } from '../utils/format'
-import { Box, Expandable } from '../greyVest'
 import {
   displayFn,
   displayBlankFn,
@@ -33,25 +32,14 @@ let Facet = ({
   theme: { RadioList },
 }) => {
   let valuesChecked = _.size(node.values)
-  let [expanded, setExpanded] = useState(false)
   return (
     <div className="contexture-facet">
       {valuesChecked > warningCheck && (
-        <Expandable
-          isOpen={expanded}
-          onClick={() => setExpanded(!expanded)}
-          Label={
-            <a style={{ cursor: 'pointer', color: 'red' }}>
-              <b>* Too many items selected</b>
-            </a>
-          }
-        >
-          <Box>
-            You have selected a large number of items for this filter. Please
-            consider using a different <b>filter type</b> or contact support for
-            more search options.
-          </Box>
-        </Expandable>
+        <span>
+          You have selected more than 250 items for this filter.
+          Please consider using a different <b>filter type</b> or contact support for more search options.
+          You will not be able to select more than 500 items maximum.
+        </span>
       )}
       {!hide.radioList && (
         <RadioList

--- a/src/utils/facet.js
+++ b/src/utils/facet.js
@@ -22,7 +22,7 @@ export let Cardinality = _.flow(
   setDisplayName('Cardinality'),
   observer
 )(({ node, tree }) => {
-  let size = _.getOr(10, 'size', node)
+  let size = node.size || 10
   let count = _.get('context.cardinality', node)
   if (count) {
     return (


### PR DESCRIPTION
- Sets a soft limit of 250 checked items at which point we display a note to the user:

<img width="357" alt="CleanShot 2021-07-01 at 22 35 52@2x" src="https://user-images.githubusercontent.com/910303/124216850-bfb5c680-dabc-11eb-9872-1307f92eec02.png">

- `Select All` is hidden if the visible items are more than 500. `Select All` is visible if all the items are checked to allow the user to uncheck all

This currently does not change the old searches values to only send 500. My thought process here was to limit that at the CES if we want to. 