### PR TITLE
[fix] Facet: fix for scroll jump when checking items in a long list

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.46.2
+* Facet: fix for scroll jump when checking items in a long list
+
 ### 2.46.1
 * Updated CI to use node16 and npm7
 * Updated package-lock.json to version 2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.46.1",
+  "version": "2.46.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/utils/facet.js
+++ b/src/utils/facet.js
@@ -118,11 +118,14 @@ export let FacetCheckboxList = contexturifyWithoutLoader(
     _.flow(
       _.partition(x => _.includes(x.name, node.values)),
       _.flatten,
-      _.map(({ name, label, count }) => {
+      F.mapIndexed(({ name, label, count }, i) => {
         let lens = tree.lens(node.path, 'values')
         return (
           <label
-            key={name}
+            // not using unique keys for smart DOM reordering
+            // this causes whole filter section to scroll up
+            // when clicking something at the bottom of a long list
+            key={i}
             style={commonStyle}
             title={`${display(name, label)} : ${formatCount(count)}`}
           >

--- a/src/utils/facet.js
+++ b/src/utils/facet.js
@@ -123,7 +123,7 @@ export let FacetCheckboxList = contexturifyWithoutLoader(
         return (
           <label
             // not using unique keys for smart DOM reordering
-            // this causes whole filter section to scroll up
+            // this causes the whole filter section to scroll up
             // when clicking something at the bottom of a long list
             key={i}
             style={commonStyle}


### PR DESCRIPTION
* [x] Facet: fix for scroll jump when checking items in a long list
* [x] Fixed by not using unique keys for smart DOM reordering this causes the whole filter section to scroll up when clicking something at the bottom of a long list. Reordering item that is being clicked forces the browser to scroll views in order to keep focused (one that is clicked) item visible

![Untitled2](https://user-images.githubusercontent.com/8238076/125182721-6ba69280-e1de-11eb-9973-42c27527678c.gif)