### PR TITLE
[feature] TagsQuery: making TagsQuery based on ExpandableTagsQuery

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.47.0
+* TagsQuery: making TagsQuery based on ExpandableTagsQuery
+
 ### 2.46.3
 * Facet: Add warning when more than 250 values are selected
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.46.3",
+  "version": "2.47.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -2,166 +2,147 @@ import React from 'react'
 import _ from 'lodash/fp'
 import F from 'futil'
 import { withContentRect } from 'react-measure'
-import { observer } from 'mobx-react'
-import OutsideClickHandler from 'react-outside-click-handler'
 import { contexturify } from '../../utils/hoc'
-import { toNumber } from '../../utils/format'
 import ExpandArrow from './ExpandArrow'
+import { observer } from 'mobx-react'
+import { toNumber } from '../../utils/format'
 import TagActionsMenu from '../TagsQuery/TagActionsMenu'
 import { Grid, GridItem } from '../../greyVest'
 import { getTagStyle, tagValueField } from '../TagsQuery/utils'
 import ActionsMenu from '../TagsQuery/ActionsMenu'
-import ExpandableTagsInput, { Tags } from '../../greyVest/ExpandableTagsInput'
-import { withTheme } from '../../utils/theme'
 
 let innerHeightLimit = 40
 
-let ExpandableTagsQuery = ({ measureRef, contentRect, ...props }) => {
-  let collapse = React.useState(true)
-  let isCollapsed = F.view(collapse) && !_.isEmpty(props.node.tags)
-  return (
-    <OutsideClickHandler
-      onOutsideClick={() => {
-        F.on(collapse)()
+let ExpandableTagsQuery = ({ measureRef, contentRect, collapse, ...props }) => (
+  <>
+    <div
+      style={{
+        overflow: 'hidden',
+        maxHeight: F.view(collapse) ? innerHeightLimit : '',
       }}
-      useCapture={false}
     >
-      <div
-        onClick={F.off(collapse)}
-        style={{
-          overflow: 'hidden',
-          maxHeight: F.view(collapse) ? innerHeightLimit : '',
-        }}
-      >
-        <div ref={measureRef}>
-          <TagsWrapper
-            {..._.omit('measure', props)}
-            onAddTag={F.off(collapse)}
-            theme={{ TagsInput: isCollapsed ? Tags : ExpandableTagsInput }}
+      <div ref={measureRef}>
+        <Tags {..._.omit('measure', props)} />
+      </div>
+    </div>
+    {F.view(collapse) &&
+      contentRect.entry.height > innerHeightLimit &&
+      !!props.node.tags.length && (
+        <div style={{ minHeight: 10 }}>
+          <ExpandArrow
+            collapse={collapse}
+            tagsLength={props.node.tags.length}
           />
         </div>
-      </div>
-      {F.view(collapse) &&
-        contentRect.entry.height > innerHeightLimit &&
-        !!props.node.tags.length && (
-          <div style={{ minHeight: 10 }}>
-            <ExpandArrow
-              collapse={collapse}
-              tagsLength={props.node.tags.length}
+      )}
+  </>
+)
+
+let Tags = ({
+  tree,
+  node,
+  style,
+  actionWrapper,
+  onAddTag = _.noop,
+  onTagsDropped = _.noop,
+  popoverPosition = 'bottom right',
+  popoverArrow,
+  popoverOffsetY,
+  theme: { Icon, TagsInput, Tag, Popover },
+  joinOptions,
+  wordsMatchPattern,
+  sanitizeTags = true,
+  splitCommas = true,
+  maxTags = 1000,
+  ...props
+}) => {
+  let TagWithPopover = observer(props => {
+    let result = _.get(['context', 'results', props.value], node)
+    let tagProps = {
+      ...props,
+      ...(!_.isNil(result)
+        ? { label: `${props.value} (${toNumber(result)})` }
+        : {}),
+    }
+    return (
+      <Popover
+        position="right top"
+        closeOnPopoverClick={false}
+        trigger={<Tag {...tagProps} />}
+      >
+        <TagActionsMenu tag={props.value} {...{ node, tree }} />
+      </Popover>
+    )
+  })
+
+  return (
+    <Grid
+      rows={`${innerHeightLimit}px minmax(0, auto)`}
+      columns="1fr auto"
+      style={style}
+    >
+      <GridItem height={2} place="center stretch">
+        <TagsInput
+          splitCommas={splitCommas}
+          sanitizeTags={sanitizeTags}
+          maxTags={maxTags}
+          wordsMatchPattern={wordsMatchPattern}
+          tags={_.map(tagValueField, node.tags)}
+          onTagsDropped={onTagsDropped}
+          addTags={addedTags => {
+            let addedTagObjects = _.map(
+              tag => ({ [tagValueField]: tag, distance: 3 }),
+              addedTags
+            )
+            let tags = [...node.tags, ...addedTagObjects]
+            // Limit the number of tags to maxTags
+            if (_.size(tags) > maxTags) {
+              tags = _.take(maxTags, tags)
+              onTagsDropped(maxTags, tags)
+            }
+            tree.mutate(node.path, { tags })
+            onAddTag(tags)
+          }}
+          removeTag={tag => {
+            tree.mutate(node.path, {
+              tags: _.reject({ [tagValueField]: tag }, node.tags),
+            })
+          }}
+          tagStyle={getTagStyle(node, tagValueField)}
+          submit={tree.triggerUpdate}
+          Tag={TagWithPopover}
+          style={{ flex: 1, border: 0 }}
+          {...props}
+        />
+      </GridItem>
+      <GridItem place="center">
+        <Popover
+          style={{ width: 'auto' }}
+          position={popoverPosition}
+          arrow={popoverArrow}
+          offsetY={popoverOffsetY}
+          closeOnPopoverClick={false}
+          trigger={
+            <div>
+              <Icon icon="TableColumnMenu" />
+            </div>
+          }
+        >
+          {close => (
+            <ActionsMenu
+              {...{
+                node,
+                tree,
+                close,
+                actionWrapper,
+                joinOptions,
+              }}
             />
-          </div>
-        )}
-    </OutsideClickHandler>
+          )}
+        </Popover>
+      </GridItem>
+    </Grid>
   )
 }
-
-let TagsWrapper = withTheme(
-  ({
-    tree,
-    node,
-    style,
-    actionWrapper,
-    onAddTag = _.noop,
-    onTagsDropped = _.noop,
-    popoverPosition = 'bottom right',
-    popoverArrow,
-    popoverOffsetY,
-    theme: { Icon, TagsInput, Tag, Popover },
-    joinOptions,
-    wordsMatchPattern,
-    sanitizeTags = true,
-    splitCommas = true,
-    maxTags = 1000,
-    ...props
-  }) => {
-    let TagWithPopover = observer(props => {
-      let result = _.get(['context', 'results', props.value], node)
-      let tagProps = {
-        ...props,
-        ...(!_.isNil(result)
-          ? { label: `${props.value} (${toNumber(result)})` }
-          : {}),
-      }
-      return (
-        <Popover
-          position="right top"
-          closeOnPopoverClick={false}
-          trigger={<Tag {...tagProps} />}
-        >
-          <TagActionsMenu tag={props.value} {...{ node, tree }} />
-        </Popover>
-      )
-    })
-
-    return (
-      <Grid
-        rows={`${innerHeightLimit}px minmax(0, auto)`}
-        columns="1fr auto"
-        style={style}
-      >
-        <GridItem height={2} place="center stretch">
-          <TagsInput
-            splitCommas={splitCommas}
-            sanitizeTags={sanitizeTags}
-            maxTags={maxTags}
-            wordsMatchPattern={wordsMatchPattern}
-            tags={_.map(tagValueField, node.tags)}
-            onTagsDropped={onTagsDropped}
-            addTags={addedTags => {
-              let addedTagObjects = _.map(
-                tag => ({ [tagValueField]: tag, distance: 3 }),
-                addedTags
-              )
-              let tags = [...node.tags, ...addedTagObjects]
-              // Limit the number of tags to maxTags
-              if (_.size(tags) > maxTags) {
-                tags = _.take(maxTags, tags)
-                onTagsDropped(maxTags, tags)
-              }
-              tree.mutate(node.path, { tags })
-              onAddTag(tags)
-            }}
-            removeTag={tag => {
-              tree.mutate(node.path, {
-                tags: _.reject({ [tagValueField]: tag }, node.tags),
-              })
-            }}
-            tagStyle={getTagStyle(node, tagValueField)}
-            submit={tree.triggerUpdate}
-            Tag={TagWithPopover}
-            style={{ flex: 1, border: 0 }}
-            {...props}
-          />
-        </GridItem>
-        <GridItem place="center">
-          <Popover
-            style={{ width: 'auto' }}
-            position={popoverPosition}
-            arrow={popoverArrow}
-            offsetY={popoverOffsetY}
-            closeOnPopoverClick={false}
-            trigger={
-              <div>
-                <Icon icon="TableColumnMenu" />
-              </div>
-            }
-          >
-            {close => (
-              <ActionsMenu
-                {...{
-                  node,
-                  tree,
-                  close,
-                  actionWrapper,
-                  joinOptions,
-                }}
-              />
-            )}
-          </Popover>
-        </GridItem>
-      </Grid>
-    )
-  }
-)
 
 export default _.flow(contexturify, withContentRect())(ExpandableTagsQuery)

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -11,30 +11,32 @@ import { Grid, GridItem } from '../../greyVest'
 import { getTagStyle, tagValueField } from '../TagsQuery/utils'
 import ActionsMenu from '../TagsQuery/ActionsMenu'
 
-let collapsedStyle = {
-  maxHeight: innerHeight,
-  overflowY: 'auto',
-}
+let innerHeightLimit = 40
 
-export let innerHeight = 40
-
-let ExpandableTagsQuery = ({ measureRef, contentRect, collapse, ...props }) => (
+let ExpandableTagsQuery = ({
+  measureRef,
+  contentRect,
+  collapse,
+  ...props
+}) => (
   <>
-    <div style={F.view(collapse) ? collapsedStyle : {}}>
+    <div style={{
+      overflow: 'hidden',
+      maxHeight: F.view(collapse) ? innerHeightLimit : '',
+    }}>
       <div ref={measureRef}>
-        <Tags {..._.omit('measure', props)} />
+        <Tags
+          {..._.omit('measure', props)}
+        />
       </div>
     </div>
-    {F.view(collapse) &&
-      contentRect.entry.height > innerHeight &&
-      !!props.node.tags.length && (
-        <div style={{ minHeight: 20 }}>
-          <ExpandArrow
-            collapse={collapse}
-            tagsLength={props.node.tags.length}
-          />
-        </div>
-      )}
+    {F.view(collapse)
+    && contentRect.entry.height > innerHeightLimit
+    && !!props.node.tags.length && (
+      <div style={{ minHeight: 20 }}>
+        <ExpandArrow collapse={collapse} tagsLength={props.node.tags.length} />
+      </div>
+    )}
   </>
 )
 
@@ -77,8 +79,7 @@ let Tags = ({
 
   return (
     <Grid
-      className="tags-query"
-      rows={`${innerHeight}px minmax(0, auto)`}
+      rows={`${innerHeightLimit}px minmax(0, auto)`}
       columns="1fr auto"
       style={style}
     >

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -13,30 +13,28 @@ import ActionsMenu from '../TagsQuery/ActionsMenu'
 
 let innerHeightLimit = 40
 
-let ExpandableTagsQuery = ({
-  measureRef,
-  contentRect,
-  collapse,
-  ...props
-}) => (
+let ExpandableTagsQuery = ({ measureRef, contentRect, collapse, ...props }) => (
   <>
-    <div style={{
-      overflow: 'hidden',
-      maxHeight: F.view(collapse) ? innerHeightLimit : '',
-    }}>
+    <div
+      style={{
+        overflow: 'hidden',
+        maxHeight: F.view(collapse) ? innerHeightLimit : '',
+      }}
+    >
       <div ref={measureRef}>
-        <Tags
-          {..._.omit('measure', props)}
-        />
+        <Tags {..._.omit('measure', props)} />
       </div>
     </div>
-    {F.view(collapse)
-    && contentRect.entry.height > innerHeightLimit
-    && !!props.node.tags.length && (
-      <div style={{ minHeight: 10 }}>
-        <ExpandArrow collapse={collapse} tagsLength={props.node.tags.length} />
-      </div>
-    )}
+    {F.view(collapse) &&
+      contentRect.entry.height > innerHeightLimit &&
+      !!props.node.tags.length && (
+        <div style={{ minHeight: 10 }}>
+          <ExpandArrow
+            collapse={collapse}
+            tagsLength={props.node.tags.length}
+          />
+        </div>
+      )}
   </>
 )
 

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -3,25 +3,144 @@ import _ from 'lodash/fp'
 import F from 'futil'
 import { withContentRect } from 'react-measure'
 import { contexturify } from '../../utils/hoc'
-import TagsQuery, { innerHeight } from '../TagsQuery'
 import ExpandArrow from './ExpandArrow'
+import { observer } from 'mobx-react'
+import { toNumber } from '../../utils/format'
+import TagActionsMenu from '../TagsQuery/TagActionsMenu'
+import { Grid, GridItem } from '../../greyVest'
+import { getTagStyle, tagValueField } from '../TagsQuery/utils'
+import ActionsMenu from '../TagsQuery/ActionsMenu'
 
 let collapsedStyle = {
   maxHeight: innerHeight,
   overflowY: 'auto',
 }
 
+export let innerHeight = 40
+
 let ExpandableTagsQuery = ({ measureRef, contentRect, collapse, ...props }) => (
   <>
     <div style={F.view(collapse) ? collapsedStyle : {}}>
       <div ref={measureRef}>
-        <TagsQuery {..._.omit('measure', props)} />
+        <Tags {..._.omit('measure', props)} />
       </div>
     </div>
-    {F.view(collapse) && contentRect.entry.height > innerHeight && (
-      <ExpandArrow collapse={collapse} tagsLength={props.node.tags.length} />
+    {F.view(collapse)
+    && contentRect.entry.height > innerHeight
+    && !!props.node.tags.length && (
+      <div style={{ minHeight: 20 }}>
+        <ExpandArrow collapse={collapse} tagsLength={props.node.tags.length} />
+      </div>
     )}
   </>
 )
+
+let Tags = ({
+  tree,
+  node,
+  style,
+  actionWrapper,
+  onAddTag = _.noop,
+  onTagsDropped = _.noop,
+  popoverPosition = 'bottom right',
+  popoverArrow,
+  popoverOffsetY,
+  theme: { Icon, TagsInput, Tag, Popover },
+  joinOptions,
+  wordsMatchPattern,
+  sanitizeTags = true,
+  splitCommas = true,
+  maxTags = 1000,
+  ...props
+}) => {
+  let TagWithPopover = observer(props => {
+    let result = _.get(['context', 'results', props.value], node)
+    let tagProps = {
+      ...props,
+      ...(!_.isNil(result)
+        ? { label: `${props.value} (${toNumber(result)})` }
+        : {}),
+    }
+    return (
+      <Popover
+        position="right top"
+        closeOnPopoverClick={false}
+        trigger={<Tag {...tagProps} />}
+      >
+        <TagActionsMenu tag={props.value} {...{ node, tree }} />
+      </Popover>
+    )
+  })
+
+  return (
+    <Grid
+      className="tags-query"
+      rows={`${innerHeight}px minmax(0, auto)`}
+      columns="1fr auto"
+      style={style}
+    >
+      <GridItem height={2} place="center stretch">
+        <TagsInput
+          splitCommas={splitCommas}
+          sanitizeTags={sanitizeTags}
+          maxTags={maxTags}
+          wordsMatchPattern={wordsMatchPattern}
+          tags={_.map(tagValueField, node.tags)}
+          onTagsDropped={onTagsDropped}
+          addTags={addedTags => {
+            let addedTagObjects = _.map(
+              tag => ({ [tagValueField]: tag, distance: 3 }),
+              addedTags
+            )
+            let tags = [...node.tags, ...addedTagObjects]
+            // Limit the number of tags to maxTags
+            if (_.size(tags) > maxTags) {
+              tags = _.take(maxTags, tags)
+              onTagsDropped(maxTags, tags)
+            }
+            tree.mutate(node.path, { tags })
+            onAddTag(tags)
+          }}
+          removeTag={tag => {
+            tree.mutate(node.path, {
+              tags: _.reject({ [tagValueField]: tag }, node.tags),
+            })
+          }}
+          tagStyle={getTagStyle(node, tagValueField)}
+          submit={tree.triggerUpdate}
+          Tag={TagWithPopover}
+          style={{ flex: 1, border: 0 }}
+          {...props}
+        />
+      </GridItem>
+      <GridItem place="center">
+        <Popover
+          style={{ width: 'auto' }}
+          position={popoverPosition}
+          arrow={popoverArrow}
+          offsetY={popoverOffsetY}
+          closeOnPopoverClick={false}
+          trigger={
+            <div>
+              <Icon icon="TableColumnMenu" />
+            </div>
+          }
+        >
+          {close => (
+            <ActionsMenu
+              {...{
+                node,
+                tree,
+                close,
+                actionWrapper,
+                joinOptions,
+              }}
+            />
+          )}
+        </Popover>
+      </GridItem>
+    </Grid>
+  )
+}
 
 export default _.flow(contexturify, withContentRect())(ExpandableTagsQuery)

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -13,30 +13,28 @@ import ActionsMenu from '../TagsQuery/ActionsMenu'
 
 let innerHeightLimit = 40
 
-let ExpandableTagsQuery = ({
-  measureRef,
-  contentRect,
-  collapse,
-  ...props
-}) => (
+let ExpandableTagsQuery = ({ measureRef, contentRect, collapse, ...props }) => (
   <>
-    <div style={{
-      overflow: 'hidden',
-      maxHeight: F.view(collapse) ? innerHeightLimit : '',
-    }}>
+    <div
+      style={{
+        overflow: 'hidden',
+        maxHeight: F.view(collapse) ? innerHeightLimit : '',
+      }}
+    >
       <div ref={measureRef}>
-        <Tags
-          {..._.omit('measure', props)}
-        />
+        <Tags {..._.omit('measure', props)} />
       </div>
     </div>
-    {F.view(collapse)
-    && contentRect.entry.height > innerHeightLimit
-    && !!props.node.tags.length && (
-      <div style={{ minHeight: 20 }}>
-        <ExpandArrow collapse={collapse} tagsLength={props.node.tags.length} />
-      </div>
-    )}
+    {F.view(collapse) &&
+      contentRect.entry.height > innerHeightLimit &&
+      !!props.node.tags.length && (
+        <div style={{ minHeight: 20 }}>
+          <ExpandArrow
+            collapse={collapse}
+            tagsLength={props.node.tags.length}
+          />
+        </div>
+      )}
   </>
 )
 

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -37,129 +37,131 @@ let ExpandableTagsQuery = ({ measureRef, contentRect, ...props }) => {
           <TagsWrapper
             {..._.omit('measure', props)}
             onAddTag={F.off(collapse)}
-            theme={{TagsInput: isCollapsed ? Tags : ExpandableTagsInput}}
+            theme={{ TagsInput: isCollapsed ? Tags : ExpandableTagsInput }}
           />
         </div>
       </div>
       {F.view(collapse) &&
-      contentRect.entry.height > innerHeightLimit &&
-      !!props.node.tags.length && (
-        <div style={{ minHeight: 10 }}>
-          <ExpandArrow
-            collapse={collapse}
-            tagsLength={props.node.tags.length}
-          />
-        </div>
-      )}
+        contentRect.entry.height > innerHeightLimit &&
+        !!props.node.tags.length && (
+          <div style={{ minHeight: 10 }}>
+            <ExpandArrow
+              collapse={collapse}
+              tagsLength={props.node.tags.length}
+            />
+          </div>
+        )}
     </OutsideClickHandler>
   )
 }
 
-let TagsWrapper = withTheme(({
-  tree,
-  node,
-  style,
-  actionWrapper,
-  onAddTag = _.noop,
-  onTagsDropped = _.noop,
-  popoverPosition = 'bottom right',
-  popoverArrow,
-  popoverOffsetY,
-  theme: { Icon, TagsInput, Tag, Popover },
-  joinOptions,
-  wordsMatchPattern,
-  sanitizeTags = true,
-  splitCommas = true,
-  maxTags = 1000,
-  ...props
-}) => {
-  let TagWithPopover = observer(props => {
-    let result = _.get(['context', 'results', props.value], node)
-    let tagProps = {
-      ...props,
-      ...(!_.isNil(result)
-        ? { label: `${props.value} (${toNumber(result)})` }
-        : {}),
-    }
-    return (
-      <Popover
-        position="right top"
-        closeOnPopoverClick={false}
-        trigger={<Tag {...tagProps} />}
-      >
-        <TagActionsMenu tag={props.value} {...{ node, tree }} />
-      </Popover>
-    )
-  })
-
-  return (
-    <Grid
-      rows={`${innerHeightLimit}px minmax(0, auto)`}
-      columns="1fr auto"
-      style={style}
-    >
-      <GridItem height={2} place="center stretch">
-        <TagsInput
-          splitCommas={splitCommas}
-          sanitizeTags={sanitizeTags}
-          maxTags={maxTags}
-          wordsMatchPattern={wordsMatchPattern}
-          tags={_.map(tagValueField, node.tags)}
-          onTagsDropped={onTagsDropped}
-          addTags={addedTags => {
-            let addedTagObjects = _.map(
-              tag => ({ [tagValueField]: tag, distance: 3 }),
-              addedTags
-            )
-            let tags = [...node.tags, ...addedTagObjects]
-            // Limit the number of tags to maxTags
-            if (_.size(tags) > maxTags) {
-              tags = _.take(maxTags, tags)
-              onTagsDropped(maxTags, tags)
-            }
-            tree.mutate(node.path, { tags })
-            onAddTag(tags)
-          }}
-          removeTag={tag => {
-            tree.mutate(node.path, {
-              tags: _.reject({ [tagValueField]: tag }, node.tags),
-            })
-          }}
-          tagStyle={getTagStyle(node, tagValueField)}
-          submit={tree.triggerUpdate}
-          Tag={TagWithPopover}
-          style={{ flex: 1, border: 0 }}
-          {...props}
-        />
-      </GridItem>
-      <GridItem place="center">
+let TagsWrapper = withTheme(
+  ({
+    tree,
+    node,
+    style,
+    actionWrapper,
+    onAddTag = _.noop,
+    onTagsDropped = _.noop,
+    popoverPosition = 'bottom right',
+    popoverArrow,
+    popoverOffsetY,
+    theme: { Icon, TagsInput, Tag, Popover },
+    joinOptions,
+    wordsMatchPattern,
+    sanitizeTags = true,
+    splitCommas = true,
+    maxTags = 1000,
+    ...props
+  }) => {
+    let TagWithPopover = observer(props => {
+      let result = _.get(['context', 'results', props.value], node)
+      let tagProps = {
+        ...props,
+        ...(!_.isNil(result)
+          ? { label: `${props.value} (${toNumber(result)})` }
+          : {}),
+      }
+      return (
         <Popover
-          style={{ width: 'auto' }}
-          position={popoverPosition}
-          arrow={popoverArrow}
-          offsetY={popoverOffsetY}
+          position="right top"
           closeOnPopoverClick={false}
-          trigger={
-            <div>
-              <Icon icon="TableColumnMenu" />
-            </div>
-          }
+          trigger={<Tag {...tagProps} />}
         >
-          {close => (
-            <ActionsMenu
-              {...{
-                node,
-                tree,
-                close,
-                actionWrapper,
-                joinOptions,
-              }}
-            />
-          )}
+          <TagActionsMenu tag={props.value} {...{ node, tree }} />
         </Popover>
-      </GridItem>
-    </Grid>
-  )
-})
+      )
+    })
+
+    return (
+      <Grid
+        rows={`${innerHeightLimit}px minmax(0, auto)`}
+        columns="1fr auto"
+        style={style}
+      >
+        <GridItem height={2} place="center stretch">
+          <TagsInput
+            splitCommas={splitCommas}
+            sanitizeTags={sanitizeTags}
+            maxTags={maxTags}
+            wordsMatchPattern={wordsMatchPattern}
+            tags={_.map(tagValueField, node.tags)}
+            onTagsDropped={onTagsDropped}
+            addTags={addedTags => {
+              let addedTagObjects = _.map(
+                tag => ({ [tagValueField]: tag, distance: 3 }),
+                addedTags
+              )
+              let tags = [...node.tags, ...addedTagObjects]
+              // Limit the number of tags to maxTags
+              if (_.size(tags) > maxTags) {
+                tags = _.take(maxTags, tags)
+                onTagsDropped(maxTags, tags)
+              }
+              tree.mutate(node.path, { tags })
+              onAddTag(tags)
+            }}
+            removeTag={tag => {
+              tree.mutate(node.path, {
+                tags: _.reject({ [tagValueField]: tag }, node.tags),
+              })
+            }}
+            tagStyle={getTagStyle(node, tagValueField)}
+            submit={tree.triggerUpdate}
+            Tag={TagWithPopover}
+            style={{ flex: 1, border: 0 }}
+            {...props}
+          />
+        </GridItem>
+        <GridItem place="center">
+          <Popover
+            style={{ width: 'auto' }}
+            position={popoverPosition}
+            arrow={popoverArrow}
+            offsetY={popoverOffsetY}
+            closeOnPopoverClick={false}
+            trigger={
+              <div>
+                <Icon icon="TableColumnMenu" />
+              </div>
+            }
+          >
+            {close => (
+              <ActionsMenu
+                {...{
+                  node,
+                  tree,
+                  close,
+                  actionWrapper,
+                  joinOptions,
+                }}
+              />
+            )}
+          </Popover>
+        </GridItem>
+      </Grid>
+    )
+  }
+)
 
 export default _.flow(contexturify, withContentRect())(ExpandableTagsQuery)

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -13,28 +13,30 @@ import ActionsMenu from '../TagsQuery/ActionsMenu'
 
 let innerHeightLimit = 40
 
-let ExpandableTagsQuery = ({ measureRef, contentRect, collapse, ...props }) => (
+let ExpandableTagsQuery = ({
+  measureRef,
+  contentRect,
+  collapse,
+  ...props
+}) => (
   <>
-    <div
-      style={{
-        overflow: 'hidden',
-        maxHeight: F.view(collapse) ? innerHeightLimit : '',
-      }}
-    >
+    <div style={{
+      overflow: 'hidden',
+      maxHeight: F.view(collapse) ? innerHeightLimit : '',
+    }}>
       <div ref={measureRef}>
-        <Tags {..._.omit('measure', props)} />
+        <Tags
+          {..._.omit('measure', props)}
+        />
       </div>
     </div>
-    {F.view(collapse) &&
-      contentRect.entry.height > innerHeightLimit &&
-      !!props.node.tags.length && (
-        <div style={{ minHeight: 20 }}>
-          <ExpandArrow
-            collapse={collapse}
-            tagsLength={props.node.tags.length}
-          />
-        </div>
-      )}
+    {F.view(collapse)
+    && contentRect.entry.height > innerHeightLimit
+    && !!props.node.tags.length && (
+      <div style={{ minHeight: 10 }}>
+        <ExpandArrow collapse={collapse} tagsLength={props.node.tags.length} />
+      </div>
+    )}
   </>
 )
 

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -22,7 +22,7 @@ let ExpandableTagsQuery = ({ measureRef, contentRect, collapse, ...props }) => (
       }}
     >
       <div ref={measureRef}>
-        <Tags {..._.omit('measure', props)} />
+        <TagsWrapper {..._.omit('measure', props)} />
       </div>
     </div>
     {F.view(collapse) &&
@@ -38,7 +38,7 @@ let ExpandableTagsQuery = ({ measureRef, contentRect, collapse, ...props }) => (
   </>
 )
 
-let Tags = ({
+let TagsWrapper = ({
   tree,
   node,
   style,

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -2,30 +2,46 @@ import React from 'react'
 import _ from 'lodash/fp'
 import F from 'futil'
 import { withContentRect } from 'react-measure'
-import { contexturify } from '../../utils/hoc'
-import ExpandArrow from './ExpandArrow'
 import { observer } from 'mobx-react'
+import OutsideClickHandler from 'react-outside-click-handler'
+import { contexturify } from '../../utils/hoc'
 import { toNumber } from '../../utils/format'
+import ExpandArrow from './ExpandArrow'
 import TagActionsMenu from '../TagsQuery/TagActionsMenu'
 import { Grid, GridItem } from '../../greyVest'
 import { getTagStyle, tagValueField } from '../TagsQuery/utils'
 import ActionsMenu from '../TagsQuery/ActionsMenu'
+import ExpandableTagsInput, { Tags } from '../../greyVest/ExpandableTagsInput'
+import { withTheme } from '../../utils/theme'
 
 let innerHeightLimit = 40
 
-let ExpandableTagsQuery = ({ measureRef, contentRect, collapse, ...props }) => (
-  <>
-    <div
-      style={{
-        overflow: 'hidden',
-        maxHeight: F.view(collapse) ? innerHeightLimit : '',
+let ExpandableTagsQuery = ({ measureRef, contentRect, ...props }) => {
+  let collapse = React.useState(true)
+  let isCollapsed = F.view(collapse) && !_.isEmpty(props.node.tags)
+  return (
+    <OutsideClickHandler
+      onOutsideClick={() => {
+        F.on(collapse)()
       }}
+      useCapture={false}
     >
-      <div ref={measureRef}>
-        <Tags {..._.omit('measure', props)} />
+      <div
+        onClick={F.off(collapse)}
+        style={{
+          overflow: 'hidden',
+          maxHeight: F.view(collapse) ? innerHeightLimit : '',
+        }}
+      >
+        <div ref={measureRef}>
+          <TagsWrapper
+            {..._.omit('measure', props)}
+            onAddTag={F.off(collapse)}
+            theme={{TagsInput: isCollapsed ? Tags : ExpandableTagsInput}}
+          />
+        </div>
       </div>
-    </div>
-    {F.view(collapse) &&
+      {F.view(collapse) &&
       contentRect.entry.height > innerHeightLimit &&
       !!props.node.tags.length && (
         <div style={{ minHeight: 10 }}>
@@ -35,10 +51,11 @@ let ExpandableTagsQuery = ({ measureRef, contentRect, collapse, ...props }) => (
           />
         </div>
       )}
-  </>
-)
+    </OutsideClickHandler>
+  )
+}
 
-let Tags = ({
+let TagsWrapper = withTheme(({
   tree,
   node,
   style,
@@ -143,6 +160,6 @@ let Tags = ({
       </GridItem>
     </Grid>
   )
-}
+})
 
 export default _.flow(contexturify, withContentRect())(ExpandableTagsQuery)

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -25,13 +25,16 @@ let ExpandableTagsQuery = ({ measureRef, contentRect, collapse, ...props }) => (
         <Tags {..._.omit('measure', props)} />
       </div>
     </div>
-    {F.view(collapse)
-    && contentRect.entry.height > innerHeight
-    && !!props.node.tags.length && (
-      <div style={{ minHeight: 20 }}>
-        <ExpandArrow collapse={collapse} tagsLength={props.node.tags.length} />
-      </div>
-    )}
+    {F.view(collapse) &&
+      contentRect.entry.height > innerHeight &&
+      !!props.node.tags.length && (
+        <div style={{ minHeight: 20 }}>
+          <ExpandArrow
+            collapse={collapse}
+            tagsLength={props.node.tags.length}
+          />
+        </div>
+      )}
   </>
 )
 

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -1,15 +1,39 @@
 import React from 'react'
 import { contexturifyWithoutLoader } from '../../utils/hoc'
 import ExpandableTagsQuery from '../ExpandableTagsQuery'
+import OutsideClickHandler from 'react-outside-click-handler'
+import F from 'futil'
+import _ from 'lodash/fp'
+import ExpandableTagsInput, { Tags } from '../../greyVest/ExpandableTagsInput'
 
-let TagsQuery = ({ tree, node, actionWrapper, ...props }) => (
-  <div className="tags-query" style={{ marginBottom: 28 }}>
-    <ExpandableTagsQuery
-      {...{ tree, node, actionWrapper, ...props }}
-      Loader={({ children }) => <div>{children}</div>}
-      style={{ padding: '0 5px' }}
-    />
-  </div>
-)
+let TagsQuery = ({ tree, node, actionWrapper, ...props }) => {
+  let collapse = React.useState(true)
+  let isCollapsed = F.view(collapse) && !_.isEmpty(node.tags)
+  return (
+    <OutsideClickHandler
+      onOutsideClick={() => {
+        F.on(collapse)()
+      }}
+      useCapture={false}
+    >
+      <div
+        className="tags-query"
+        onClick={F.off(collapse)}
+        style={{ marginBottom: isCollapsed ? 28 : 10 }}
+      >
+        <ExpandableTagsQuery
+          {...{ tree, node, collapse, actionWrapper, ...props }}
+          autoFocus
+          onAddTag={F.off(collapse)}
+          Loader={({ children }) => <div>{children}</div>}
+          style={{ padding: '0 5px' }}
+          theme={{
+            TagsInput: isCollapsed ? Tags : ExpandableTagsInput,
+          }}
+        />
+      </div>
+    </OutsideClickHandler>
+  )
+}
 
 export default contexturifyWithoutLoader(TagsQuery)

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -1,120 +1,43 @@
 import React from 'react'
-import _ from 'lodash/fp'
-import { Grid, GridItem } from '../../greyVest'
 import { contexturifyWithoutLoader } from '../../utils/hoc'
-import { getTagStyle, tagValueField } from './utils'
-import TagActionsMenu from './TagActionsMenu'
-import ActionsMenu from './ActionsMenu'
-import { observer } from 'mobx-react'
-import { toNumber } from '../../utils/format'
-
-export let innerHeight = 40
+import ExpandableTagsQuery from '../ExpandableTagsQuery'
+import OutsideClickHandler from 'react-outside-click-handler'
+import F from 'futil'
+import _ from 'lodash/fp'
+import ExpandableTagsInput, { Tags } from '../../greyVest/ExpandableTagsInput'
 
 let TagsQuery = ({
   tree,
   node,
-  style,
   actionWrapper,
-  onAddTag = _.noop,
-  onTagsDropped = _.noop,
-  popoverPosition = 'bottom right',
-  popoverArrow,
-  popoverOffsetY,
-  theme: { Icon, TagsInput, Tag, Popover },
-  joinOptions,
-  wordsMatchPattern,
-  sanitizeTags = true,
-  splitCommas = true,
-  maxTags = 1000,
   ...props
 }) => {
-  let TagWithPopover = observer(props => {
-    let result = _.get(['context', 'results', props.value], node)
-    let tagProps = {
-      ...props,
-      ...(!_.isNil(result)
-        ? { label: `${props.value} (${toNumber(result)})` }
-        : {}),
-    }
-    return (
-      <Popover
-        position="right top"
-        closeOnPopoverClick={false}
-        trigger={<Tag {...tagProps} />}
-      >
-        <TagActionsMenu tag={props.value} {...{ node, tree }} />
-      </Popover>
-    )
-  })
-
+  let collapse = React.useState(true)
   return (
-    <Grid
-      className="tags-query"
-      rows={`${innerHeight}px minmax(0, auto)`}
-      columns="1fr auto"
-      style={style}
+    <OutsideClickHandler
+      onOutsideClick={() => {
+        F.on(collapse)()
+      }}
+      useCapture={false}
     >
-      <GridItem height={2} place="center stretch">
-        <TagsInput
-          splitCommas={splitCommas}
-          sanitizeTags={sanitizeTags}
-          maxTags={maxTags}
-          wordsMatchPattern={wordsMatchPattern}
-          tags={_.map(tagValueField, node.tags)}
-          onTagsDropped={onTagsDropped}
-          addTags={addedTags => {
-            let addedTagObjects = _.map(
-              tag => ({ [tagValueField]: tag, distance: 3 }),
-              addedTags
-            )
-            let tags = [...node.tags, ...addedTagObjects]
-            // Limit the number of tags to maxTags
-            if (_.size(tags) > maxTags) {
-              tags = _.take(maxTags, tags)
-              onTagsDropped(maxTags, tags)
-            }
-            tree.mutate(node.path, { tags })
-            onAddTag(tags)
+      <div onClick={F.off(collapse)} style={{
+        padding: 5,
+        marginBottom: 20,
+      }}>
+        <ExpandableTagsQuery
+          {...{ tree, node, collapse, actionWrapper, ...props }}
+          onAddTag={F.off(collapse)}
+          Loader={({ children }) => <div>{children}</div>}
+          theme={{
+            TagsInput:
+              F.view(collapse) && !_.isEmpty(node.tags)
+                ? Tags
+                : ExpandableTagsInput,
           }}
-          removeTag={tag => {
-            tree.mutate(node.path, {
-              tags: _.reject({ [tagValueField]: tag }, node.tags),
-            })
-          }}
-          tagStyle={getTagStyle(node, tagValueField)}
-          submit={tree.triggerUpdate}
-          Tag={TagWithPopover}
-          style={{ flex: 1, border: 0 }}
-          {...props}
+          autoFocus
         />
-      </GridItem>
-      <GridItem place="center">
-        <Popover
-          style={{ width: 'auto' }}
-          position={popoverPosition}
-          arrow={popoverArrow}
-          offsetY={popoverOffsetY}
-          closeOnPopoverClick={false}
-          trigger={
-            <div>
-              <Icon icon="TableColumnMenu" />
-            </div>
-          }
-        >
-          {close => (
-            <ActionsMenu
-              {...{
-                node,
-                tree,
-                close,
-                actionWrapper,
-                joinOptions,
-              }}
-            />
-          )}
-        </Popover>
-      </GridItem>
-    </Grid>
+      </div>
+    </OutsideClickHandler>
   )
 }
 

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -6,12 +6,7 @@ import F from 'futil'
 import _ from 'lodash/fp'
 import ExpandableTagsInput, { Tags } from '../../greyVest/ExpandableTagsInput'
 
-let TagsQuery = ({
-  tree,
-  node,
-  actionWrapper,
-  ...props
-}) => {
+let TagsQuery = ({ tree, node, actionWrapper, ...props }) => {
   let collapse = React.useState(true)
   return (
     <OutsideClickHandler
@@ -20,10 +15,13 @@ let TagsQuery = ({
       }}
       useCapture={false}
     >
-      <div onClick={F.off(collapse)} style={{
-        padding: 5,
-        marginBottom: 20,
-      }}>
+      <div
+        onClick={F.off(collapse)}
+        style={{
+          padding: 5,
+          marginBottom: 20,
+        }}
+      >
         <ExpandableTagsQuery
           {...{ tree, node, collapse, actionWrapper, ...props }}
           onAddTag={F.off(collapse)}

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -8,6 +8,7 @@ import ExpandableTagsInput, { Tags } from '../../greyVest/ExpandableTagsInput'
 
 let TagsQuery = ({ tree, node, actionWrapper, ...props }) => {
   let collapse = React.useState(true)
+  let isCollapsed = F.view(collapse) && !_.isEmpty(node.tags)
   return (
     <OutsideClickHandler
       onOutsideClick={() => {
@@ -18,7 +19,7 @@ let TagsQuery = ({ tree, node, actionWrapper, ...props }) => {
       <div
         className="tags-query"
         onClick={F.off(collapse)}
-        style={{ marginBottom: 10 }}
+        style={{ marginBottom: isCollapsed ? 28 : 10 }}
       >
         <ExpandableTagsQuery
           {...{ tree, node, collapse, actionWrapper, ...props }}
@@ -27,10 +28,7 @@ let TagsQuery = ({ tree, node, actionWrapper, ...props }) => {
           Loader={({ children }) => <div>{children}</div>}
           style={{ padding: '0 5px' }}
           theme={{
-            TagsInput:
-              F.view(collapse) && !_.isEmpty(node.tags)
-                ? Tags
-                : ExpandableTagsInput,
+            TagsInput: isCollapsed ? Tags : ExpandableTagsInput,
           }}
         />
       </div>

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -6,7 +6,12 @@ import F from 'futil'
 import _ from 'lodash/fp'
 import ExpandableTagsInput, { Tags } from '../../greyVest/ExpandableTagsInput'
 
-let TagsQuery = ({ tree, node, actionWrapper, ...props }) => {
+let TagsQuery = ({
+  tree,
+  node,
+  actionWrapper,
+  ...props
+}) => {
   let collapse = React.useState(true)
   return (
     <OutsideClickHandler
@@ -16,23 +21,22 @@ let TagsQuery = ({ tree, node, actionWrapper, ...props }) => {
       useCapture={false}
     >
       <div
+        className="tags-query"
         onClick={F.off(collapse)}
-        style={{
-          padding: 5,
-          marginBottom: 20,
-        }}
+        style={{ marginBottom: 10 }}
       >
         <ExpandableTagsQuery
           {...{ tree, node, collapse, actionWrapper, ...props }}
+          autoFocus
           onAddTag={F.off(collapse)}
           Loader={({ children }) => <div>{children}</div>}
+          style={{ padding: '0 5px' }}
           theme={{
             TagsInput:
               F.view(collapse) && !_.isEmpty(node.tags)
                 ? Tags
                 : ExpandableTagsInput,
           }}
-          autoFocus
         />
       </div>
     </OutsideClickHandler>

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -6,12 +6,7 @@ import F from 'futil'
 import _ from 'lodash/fp'
 import ExpandableTagsInput, { Tags } from '../../greyVest/ExpandableTagsInput'
 
-let TagsQuery = ({
-  tree,
-  node,
-  actionWrapper,
-  ...props
-}) => {
+let TagsQuery = ({ tree, node, actionWrapper, ...props }) => {
   let collapse = React.useState(true)
   return (
     <OutsideClickHandler

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -3,17 +3,13 @@ import { contexturifyWithoutLoader } from '../../utils/hoc'
 import ExpandableTagsQuery from '../ExpandableTagsQuery'
 
 let TagsQuery = ({ tree, node, actionWrapper, ...props }) => (
-  <div
-      className="tags-query"
-      style={{ marginBottom: 28 }}
-    >
-      <ExpandableTagsQuery
-        {...{ tree, node, actionWrapper, ...props }}
-        Loader={({ children }) => <div>{children}</div>}
-        style={{ padding: '0 5px' }}
-      />
-    </div>
+  <div className="tags-query" style={{ marginBottom: 28 }}>
+    <ExpandableTagsQuery
+      {...{ tree, node, actionWrapper, ...props }}
+      Loader={({ children }) => <div>{children}</div>}
+      style={{ padding: '0 5px' }}
+    />
+  </div>
 )
-
 
 export default contexturifyWithoutLoader(TagsQuery)

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -1,39 +1,19 @@
 import React from 'react'
 import { contexturifyWithoutLoader } from '../../utils/hoc'
 import ExpandableTagsQuery from '../ExpandableTagsQuery'
-import OutsideClickHandler from 'react-outside-click-handler'
-import F from 'futil'
-import _ from 'lodash/fp'
-import ExpandableTagsInput, { Tags } from '../../greyVest/ExpandableTagsInput'
 
-let TagsQuery = ({ tree, node, actionWrapper, ...props }) => {
-  let collapse = React.useState(true)
-  let isCollapsed = F.view(collapse) && !_.isEmpty(node.tags)
-  return (
-    <OutsideClickHandler
-      onOutsideClick={() => {
-        F.on(collapse)()
-      }}
-      useCapture={false}
+let TagsQuery = ({ tree, node, actionWrapper, ...props }) => (
+  <div
+      className="tags-query"
+      style={{ marginBottom: 28 }}
     >
-      <div
-        className="tags-query"
-        onClick={F.off(collapse)}
-        style={{ marginBottom: isCollapsed ? 28 : 10 }}
-      >
-        <ExpandableTagsQuery
-          {...{ tree, node, collapse, actionWrapper, ...props }}
-          autoFocus
-          onAddTag={F.off(collapse)}
-          Loader={({ children }) => <div>{children}</div>}
-          style={{ padding: '0 5px' }}
-          theme={{
-            TagsInput: isCollapsed ? Tags : ExpandableTagsInput,
-          }}
-        />
-      </div>
-    </OutsideClickHandler>
-  )
-}
+      <ExpandableTagsQuery
+        {...{ tree, node, actionWrapper, ...props }}
+        Loader={({ children }) => <div>{children}</div>}
+        style={{ padding: '0 5px' }}
+      />
+    </div>
+)
+
 
 export default contexturifyWithoutLoader(TagsQuery)

--- a/src/exampleTypes/TagsQuerySearchBar.js
+++ b/src/exampleTypes/TagsQuerySearchBar.js
@@ -1,11 +1,8 @@
 import React from 'react'
-import F from 'futil'
 import _ from 'lodash/fp'
 import { observer } from 'mobx-react'
-import OutsideClickHandler from 'react-outside-click-handler'
 import { withNode } from '../utils/hoc'
 import { Box, ButtonGroup, Button } from '../greyVest'
-import ExpandableTagsInput, { Tags } from '../greyVest/ExpandableTagsInput'
 import ExpandableTagsQuery from './ExpandableTagsQuery'
 
 let searchBarStyle = {
@@ -61,49 +58,33 @@ let SearchBar = ({
   actionWrapper,
   searchButtonProps,
   tagsQueryProps,
-}) => {
-  let collapse = React.useState(true)
-  return (
-    <OutsideClickHandler
-      onOutsideClick={() => {
-        F.on(collapse)()
-      }}
-      useCapture={false}
-    >
-      <ButtonGroup
-        style={searchBarStyle}
-        // The outside click handler listens for the onMouseUp event which takes priority over any onClick handlers in the children
-        // So we need to add this handler to ensure that the child events are triggered appropriately
-        onMouseUp={e => {
-          e.stopPropagation()
-        }}
-      >
-        <Box style={searchBarBoxStyle} onClick={F.off(collapse)}>
-          <ExpandableTagsQuery
-            {...{ tree, node, collapse, actionWrapper }}
-            onAddTag={F.off(collapse)}
-            Loader={({ children }) => <div>{children}</div>}
-            style={inputStyle}
-            theme={{
-              TagsInput:
-                F.view(collapse) && !_.isEmpty(node.tags)
-                  ? Tags
-                  : ExpandableTagsInput,
-            }}
-            autoFocus
-            {...tagsQueryProps}
-          />
-        </Box>
-        {tree.disableAutoUpdate && (
-          <SearchButton
-            tree={tree}
-            resultsPath={resultsPath}
-            searchButtonProps={searchButtonProps}
-          />
-        )}
-      </ButtonGroup>
-    </OutsideClickHandler>
-  )
-}
+}) => (
+  <ButtonGroup
+    style={searchBarStyle}
+    // The outside click handler listens for the onMouseUp event which takes priority over any onClick handlers in the children
+    // So we need to add this handler to ensure that the child events are triggered appropriately
+    onMouseUp={e => {
+      e.stopPropagation()
+    }}
+  >
+    <Box style={searchBarBoxStyle}>
+      <ExpandableTagsQuery
+        {...{ tree, node, actionWrapper }}
+        Loader={({ children }) => <div>{children}</div>}
+        style={inputStyle}
+        autoFocus
+        {...tagsQueryProps}
+      />
+    </Box>
+    {tree.disableAutoUpdate && (
+      <SearchButton
+        tree={tree}
+        resultsPath={resultsPath}
+        searchButtonProps={searchButtonProps}
+      />
+    )}
+  </ButtonGroup>
+)
+
 
 export default _.flow(observer, withNode)(SearchBar)

--- a/src/exampleTypes/TagsQuerySearchBar.js
+++ b/src/exampleTypes/TagsQuerySearchBar.js
@@ -86,5 +86,4 @@ let SearchBar = ({
   </ButtonGroup>
 )
 
-
 export default _.flow(observer, withNode)(SearchBar)

--- a/src/exampleTypes/TagsQuerySearchBar.js
+++ b/src/exampleTypes/TagsQuerySearchBar.js
@@ -1,8 +1,11 @@
 import React from 'react'
+import F from 'futil'
 import _ from 'lodash/fp'
 import { observer } from 'mobx-react'
+import OutsideClickHandler from 'react-outside-click-handler'
 import { withNode } from '../utils/hoc'
 import { Box, ButtonGroup, Button } from '../greyVest'
+import ExpandableTagsInput, { Tags } from '../greyVest/ExpandableTagsInput'
 import ExpandableTagsQuery from './ExpandableTagsQuery'
 
 let searchBarStyle = {
@@ -58,32 +61,49 @@ let SearchBar = ({
   actionWrapper,
   searchButtonProps,
   tagsQueryProps,
-}) => (
-  <ButtonGroup
-    style={searchBarStyle}
-    // The outside click handler listens for the onMouseUp event which takes priority over any onClick handlers in the children
-    // So we need to add this handler to ensure that the child events are triggered appropriately
-    onMouseUp={e => {
-      e.stopPropagation()
-    }}
-  >
-    <Box style={searchBarBoxStyle}>
-      <ExpandableTagsQuery
-        {...{ tree, node, actionWrapper }}
-        Loader={({ children }) => <div>{children}</div>}
-        style={inputStyle}
-        autoFocus
-        {...tagsQueryProps}
-      />
-    </Box>
-    {tree.disableAutoUpdate && (
-      <SearchButton
-        tree={tree}
-        resultsPath={resultsPath}
-        searchButtonProps={searchButtonProps}
-      />
-    )}
-  </ButtonGroup>
-)
+}) => {
+  let collapse = React.useState(true)
+  return (
+    <OutsideClickHandler
+      onOutsideClick={() => {
+        F.on(collapse)()
+      }}
+      useCapture={false}
+    >
+      <ButtonGroup
+        style={searchBarStyle}
+        // The outside click handler listens for the onMouseUp event which takes priority over any onClick handlers in the children
+        // So we need to add this handler to ensure that the child events are triggered appropriately
+        onMouseUp={e => {
+          e.stopPropagation()
+        }}
+      >
+        <Box style={searchBarBoxStyle} onClick={F.off(collapse)}>
+          <ExpandableTagsQuery
+            {...{ tree, node, collapse, actionWrapper }}
+            onAddTag={F.off(collapse)}
+            Loader={({ children }) => <div>{children}</div>}
+            style={inputStyle}
+            theme={{
+              TagsInput:
+                F.view(collapse) && !_.isEmpty(node.tags)
+                  ? Tags
+                  : ExpandableTagsInput,
+            }}
+            autoFocus
+            {...tagsQueryProps}
+          />
+        </Box>
+        {tree.disableAutoUpdate && (
+          <SearchButton
+            tree={tree}
+            resultsPath={resultsPath}
+            searchButtonProps={searchButtonProps}
+          />
+        )}
+      </ButtonGroup>
+    </OutsideClickHandler>
+  )
+}
 
 export default _.flow(observer, withNode)(SearchBar)

--- a/src/greyVest/Tag.js
+++ b/src/greyVest/Tag.js
@@ -22,7 +22,7 @@ let Tag = ({
     style={{
       display: 'inline-block',
       cursor: 'pointer',
-      margin: 3,
+      margin: '4px 3px',
       borderRadius: '3px',
       wordBreak: 'break-all',
       ...F.callOrReturn(tagStyle, value),


### PR DESCRIPTION
* [x] TagsQuery: making `TagsQuery` based on `ExpandableTagsQuery`
* [x] Refactor: old `TagsQuery` became a part of `ExpandableTagsQuery`. So new `TagsQuery` and `TagsQuerySearchBar` are thin wrappers around `ExpandableTagsQuery`

<img width="311" alt="Screen Shot 2021-07-22 at 2 13 14 PM (2)" src="https://user-images.githubusercontent.com/470292/126688480-91be7662-d22f-489d-8b6a-a142ce1d273e.png">
