### PR TITLE
[fix] use contexturifyWithoutLoader for CheckableResultTable

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.47.1
+* CheckableResultTable: use contexturifyWithoutLoader to fix double loading animation
+
 ### 2.47.0
 * TagsQuery: making TagsQuery based on ExpandableTagsQuery
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.47.0",
+  "version": "2.47.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/CheckableResultTable.js
+++ b/src/exampleTypes/CheckableResultTable.js
@@ -4,7 +4,7 @@ import F from 'futil'
 import { setDisplayName } from 'recompose'
 import { observer } from 'mobx-react'
 import { getResults, getRecord } from '../utils/schema'
-import { contexturify } from '../utils/hoc'
+import { contexturifyWithoutLoader } from '../utils/hoc'
 import { withTheme } from '../utils/theme'
 import ResultTable from './ResultTable'
 import { selectedBinding } from './utils'
@@ -62,5 +62,5 @@ let CheckableResultTable = ({
 
 export default _.flow(
   expandProp('selected', selectedBinding),
-  contexturify
+  contexturifyWithoutLoader
 )(CheckableResultTable)


### PR DESCRIPTION
* CheckableResultTable: use `contexturifyWithoutLoader` to fix double loading animation

