### PR TITLE
fix: remove autoFocus from the TagsQuery component

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.48.2
+* TagsQuery: Remove 'autoFocus' to resolve unexpected focusing behavior
+
 ### 2.48.1
 * ExpandableTagsQuery: added mobx observer for the underlying TagsWrapper
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.48.0",
+  "version": "2.48.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.48.1",
+  "version": "2.48.2",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/TagsQuery/index.js
+++ b/src/exampleTypes/TagsQuery/index.js
@@ -23,7 +23,6 @@ let TagsQuery = ({ tree, node, actionWrapper, ...props }) => {
       >
         <ExpandableTagsQuery
           {...{ tree, node, collapse, actionWrapper, ...props }}
-          autoFocus
           onAddTag={F.off(collapse)}
           Loader={({ children }) => <div>{children}</div>}
           style={{ padding: '0 5px' }}


### PR DESCRIPTION
Fixes #518 