### PR TITLE
[fix] ExpandableTagsQuery: not loosing focus on new tag input

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,7 @@
+### 2.49.3
+* ExpandableTagsQuery: not loosing focus by contexturifyWithoutLoader avoiding component re-rendering
+* ExpandableTagsInput: handling autoFocus with react ref api
+
 ### 2.49.2
 * TagsQuery: removed outside click handler
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.49.2",
+  "version": "2.49.3",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -57,24 +57,26 @@ let TagsWrapper = observer(
     maxTags = 1000,
     ...props
   }) => {
-    let TagWithPopover = React.memo(observer(props => {
-      let result = _.get(['context', 'results', props.value], node)
-      let tagProps = {
-        ...props,
-        ...(!_.isNil(result)
-          ? { label: `${props.value} (${toNumber(result)})` }
-          : {}),
-      }
-      return (
-        <Popover
-          position="right top"
-          closeOnPopoverClick={false}
-          trigger={<Tag {...tagProps} />}
-        >
-          <TagActionsMenu tag={props.value} {...{ node, tree }} />
-        </Popover>
-      )
-    }))
+    let TagWithPopover = React.memo(
+      observer(props => {
+        let result = _.get(['context', 'results', props.value], node)
+        let tagProps = {
+          ...props,
+          ...(!_.isNil(result)
+            ? { label: `${props.value} (${toNumber(result)})` }
+            : {}),
+        }
+        return (
+          <Popover
+            position="right top"
+            closeOnPopoverClick={false}
+            trigger={<Tag {...tagProps} />}
+          >
+            <TagActionsMenu tag={props.value} {...{ node, tree }} />
+          </Popover>
+        )
+      })
+    )
 
     return (
       <Grid
@@ -147,4 +149,7 @@ let TagsWrapper = observer(
   }
 )
 
-export default _.flow(contexturifyWithoutLoader, withContentRect())(ExpandableTagsQuery)
+export default _.flow(
+  contexturifyWithoutLoader,
+  withContentRect()
+)(ExpandableTagsQuery)

--- a/src/exampleTypes/ExpandableTagsQuery/index.js
+++ b/src/exampleTypes/ExpandableTagsQuery/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import _ from 'lodash/fp'
 import F from 'futil'
 import { withContentRect } from 'react-measure'
-import { contexturify } from '../../utils/hoc'
+import { contexturifyWithoutLoader } from '../../utils/hoc'
 import ExpandArrow from './ExpandArrow'
 import { observer } from 'mobx-react'
 import { toNumber } from '../../utils/format'
@@ -57,7 +57,7 @@ let TagsWrapper = observer(
     maxTags = 1000,
     ...props
   }) => {
-    let TagWithPopover = observer(props => {
+    let TagWithPopover = React.memo(observer(props => {
       let result = _.get(['context', 'results', props.value], node)
       let tagProps = {
         ...props,
@@ -74,7 +74,7 @@ let TagsWrapper = observer(
           <TagActionsMenu tag={props.value} {...{ node, tree }} />
         </Popover>
       )
-    })
+    }))
 
     return (
       <Grid
@@ -147,4 +147,4 @@ let TagsWrapper = observer(
   }
 )
 
-export default _.flow(contexturify, withContentRect())(ExpandableTagsQuery)
+export default _.flow(contexturifyWithoutLoader, withContentRect())(ExpandableTagsQuery)

--- a/src/greyVest/ExpandableTagsInput.js
+++ b/src/greyVest/ExpandableTagsInput.js
@@ -45,6 +45,7 @@ let ExpandableTagsInput = ({
   placeholder = 'Search...',
   splitCommas,
   style,
+  autoFocus,
   onBlur = _.noop,
   onInputChange = _.noop,
   maxWordsPerTag = 100,
@@ -76,6 +77,7 @@ let ExpandableTagsInput = ({
       <span className="tags-input-container" columns="1fr auto" gap="8px 4px">
         <input
           style={{ flex: 1, border: 0 }}
+          ref={autoFocus && (input => input && input.focus())}
           onChange={e => {
             setCurrentInput(e.target.value)
             onInputChange()


### PR DESCRIPTION
* [x] ExpandableTagsQuery: not loosing focus by contexturifyWithoutLoader avoiding component re-rendering
* [x] ExpandableTagsInput: handling autoFocus with react ref api
