### PR TITLE
Allow search layout mode setter to be empty

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.50.0
+* Toggling layout modes is disabled if search layout mode setter is empty.
+
 ### 2.49.5
 * Fix wrapping node in AND/OR in advanced search
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.49.5",
+  "version": "2.50.0",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/SearchFilters.js
+++ b/src/SearchFilters.js
@@ -56,11 +56,13 @@ let BasicSearchFilters = withTheme(
               </DropdownItem>
             }
           >
-            <DropdownItem onClick={() => setMode('resultsOnly')}>
-              Hide Filters
-            </DropdownItem>
+            {setMode && (
+              <DropdownItem onClick={() => setMode('resultsOnly')}>
+                Hide Filters
+              </DropdownItem>
+            )}
             <TreePauseButton children={children} Component={DropdownItem} />
-            {!disableAdvancedMode && (
+            {setMode && !disableAdvancedMode && (
               <DropdownItem onClick={() => setMode('builder')}>
                 Advanced Search Builder
               </DropdownItem>
@@ -77,9 +79,9 @@ let BuilderSearchFilters = ({ setMode, trees, BuilderFilters }) => (
   <div>
     <Flex alignItems="center" justifyContent="space-between">
       <h1>Filters</h1>
-      <LinkButton onClick={() => setMode('basic')}>
+  {setMode && <LinkButton onClick={() => setMode('basic')}>
         Back to Regular Search
-      </LinkButton>
+      </LinkButton>}
     </Flex>
     <LabelledList list={trees} Component={BuilderFilters} />
   </div>

--- a/src/SearchFilters.js
+++ b/src/SearchFilters.js
@@ -79,9 +79,11 @@ let BuilderSearchFilters = ({ setMode, trees, BuilderFilters }) => (
   <div>
     <Flex alignItems="center" justifyContent="space-between">
       <h1>Filters</h1>
-  {setMode && <LinkButton onClick={() => setMode('basic')}>
-        Back to Regular Search
-      </LinkButton>}
+      {setMode && (
+        <LinkButton onClick={() => setMode('basic')}>
+          Back to Regular Search
+        </LinkButton>
+      )}
     </Flex>
     <LabelledList list={trees} Component={BuilderFilters} />
   </div>

--- a/src/ToggleFiltersHeader.js
+++ b/src/ToggleFiltersHeader.js
@@ -4,7 +4,7 @@ import { Flex } from './greyVest'
 
 let ToggleFiltersHeader = ({ mode, setMode, children }) => (
   <Flex style={{ alignItems: 'center' }}>
-    {mode === 'resultsOnly' && (
+    {setMode && mode === 'resultsOnly' && (
       <span style={{ marginRight: 5 }}>
         <ShowFiltersButton onClick={() => setMode('basic')} />
       </span>


### PR DESCRIPTION
This way, users can communicate the intention that the layout should not be toggleable from its current value.