### PR TITLE
Stop the cancel button from throwing an error if passing undefined

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.50.1
+* Stop onChange in Cancel function from throwing if `addedFields` is undefined.
+
 ### 2.50.0
 * Toggling layout modes is disabled if search layout mode setter is empty.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.50.0",
+  "version": "2.50.1",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/queryBuilder/FilterContents.js
+++ b/src/queryBuilder/FilterContents.js
@@ -35,6 +35,7 @@ let FilterContents = ({
         label={nodeField ? nodeLabel : 'Pick a Field'}
         options={fieldsToOptions(fields)}
         onChange={addedFields => {
+          addedFields = _.castArray(addedFields)
           // Replacing current node with the first added field
           if (addedFields[0])
             tree.replace(


### PR DESCRIPTION
Cast the addedFields to an array so that `onChange()` from `ModalPicker` does not throw before closing the modal