### PR TITLE
added a data-testid to the main search button

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,6 @@
+### 2.50.8
+* Adds a data-testid to the main search bar
+
 ### 2.50.7
 * Switch from `recompose` to `react-recompose`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contexture-react",
-  "version": "2.50.6",
+  "version": "2.50.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "contexture-react",
-      "version": "2.50.4",
+      "version": "2.50.8",
       "license": "MIT",
       "dependencies": {
         "futil": "^1.64.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.50.7",
+  "version": "2.50.8",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/exampleTypes/TagsQuerySearchBar.js
+++ b/src/exampleTypes/TagsQuerySearchBar.js
@@ -29,6 +29,7 @@ let buttonStyle = {
 
 let AnimatedButton = ({ disabled, style, className, ...props }) => (
   <Button
+    data-testid="button-main-search"
     className={`${disabled ? 'disabled' : 'animated pulse infinite'} ${
       className || ''
     }`}


### PR DESCRIPTION
Only added one data-testid to the main search button.
In addition to the id it updates package.json, package-lock.json, and the changelog.