### PR TITLE
F/12208 button alignments

### DIFF
--- a/src/exampleTypes/Date.js
+++ b/src/exampleTypes/Date.js
@@ -71,7 +71,7 @@ let DateComponent = ({
         }}
       />
       {node.range === 'exact' ? (
-        <Flex style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+        <Flex style={{ justifyContent: 'start', alignItems: 'center' }}>
           <DateInput
             value={node.from}
             onChange={date =>

--- a/src/queryBuilder/Rule.js
+++ b/src/queryBuilder/Rule.js
@@ -43,7 +43,7 @@ let Rule = ({
           <div
             style={{
               ...(F.view(hover.rule) || { visibility: 'hidden' }),
-              minWidth: 82,
+              minWidth: 88,
             }}
           >
             <button

--- a/src/themes/greyVest/Style.js
+++ b/src/themes/greyVest/Style.js
@@ -178,7 +178,6 @@ export default () => (
       .modal-picker-button {
         display: block;
         width: 100%;
-        margin-top: 8px;
       }
 
       /* Filter Button List */


### PR DESCRIPTION
**Bug**

There are multiple alignment issues in the advanced filters screen
- The title of each section is margined lower 
- The date pickers appear quite far
- The close buttons are misaligned

This is with respect to the issue in Spart project 
https://github.com/smartprocure/spark/issues/12208
