### PR TITLE
Show field descriptions on FilterAdder.js

### DIFF
--- a/CHANGELOG.mdx
+++ b/CHANGELOG.mdx
@@ -1,3 +1,8 @@
+### 2.51.3
+* NestedPicker: add support for showing option description section/panel if at least one option has field `description` set
+* ModalPicker: add `modalClassName` prop to allow targeting for styling
+* FilterAdder: pass `modalClassName` prop as `filter-adder` by default to allow targeting for styling the modal within the FilterAdder
+
 ### 2.51.2
 * NestedPicker: add support for creating a Commonly Used Fields section if one or more field options have flag `isCommonlyUsed` set
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "contexture-react",
-  "version": "2.51.2",
+  "version": "2.51.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "contexture-react",
-      "version": "2.51.2",
-      "hasInstallScript": true,
+      "version": "2.51.3",
       "license": "MIT",
       "dependencies": {
         "futil": "^1.64.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.51.2",
+  "version": "2.51.3",
   "description": "React components for building contexture interfaces",
   "main": "dist/index.js",
   "scripts": {

--- a/src/FilterAdder.js
+++ b/src/FilterAdder.js
@@ -1,5 +1,6 @@
 import _ from 'lodash/fp'
 import React from 'react'
+import { defaultProps } from 'react-recompose'
 import { contexturifyWithoutLoader } from './utils/hoc'
 import { newNodeFromField } from './utils/search'
 import { ModalPicker } from './purgatory'
@@ -20,7 +21,7 @@ let FilterAdder = ({
   path,
   fields,
   uniqueFields,
-  Picker = ModalPicker,
+  Picker = defaultProps({ modalClassName: 'filter-adder' })(ModalPicker),
   theme: { Icon },
   ...props
 }) => {

--- a/src/purgatory/ModalPicker.js
+++ b/src/purgatory/ModalPicker.js
@@ -8,6 +8,7 @@ import { withTheme } from '../utils/theme'
 let ModalPicker = ({
   options = [],
   className = '',
+  modalClassName = '',
   onChange,
   label,
   theme: { Button, NestedPicker, Modal },
@@ -17,7 +18,7 @@ let ModalPicker = ({
   return (
     !!options.length && (
       <>
-        <Modal open={open}>
+        <Modal open={open} className={modalClassName}>
           <NestedPicker
             options={options}
             onChange={x => {

--- a/src/utils/stories.js
+++ b/src/utils/stories.js
@@ -99,12 +99,16 @@ export let options = [
     field: 'GroupA.GroupB.FieldC1',
     label: 'Commonly Used 1',
     typeDefault: 'number',
+    description:
+      'I tend to be pretty useful on my good days, but you never know really. I tend to be pretty useful on my good days, but you never know really.',
     isCommonlyUsed: true,
   },
   {
     value: 'GroupF.FieldE1',
     field: 'GroupF.FieldE1',
     label: 'Commonly Used 2',
+    description:
+      'This is a super-duper useful field, you should totally select it. This is a super-duper useful field, you should totally select it. This is a super-duper useful field, you should totally select it.',
     typeDefault: 'number',
     isCommonlyUsed: true,
   },
@@ -113,6 +117,7 @@ export let options = [
     field: 'GroupA.GroupC.FieldD1',
     label: 'Commonly Used 3',
     typeDefault: 'number',
+    description: 'You should pick me or suffer the consequences',
     isCommonlyUsed: true,
   },
 ]


### PR DESCRIPTION
* NestedPicker: add support for showing option description section/panel if at least one option has field `description` set
* ModalPicker: add `modalClassName` prop to allow targeting for styling
* FilterAdder: pass `modalClassName` prop as `filter-adder` by default to allow targeting for styling the modal within the FilterAdder

![Screen Shot 2022-09-01 at 5 43 33 PM](https://user-images.githubusercontent.com/532680/188018582-4e99c628-da16-49d1-928a-dc146c74fa2d.png)
![Screen Shot 2022-09-01 at 5 42 54 PM](https://user-images.githubusercontent.com/532680/188018584-7c7543aa-7c0b-4cf4-bdec-e5e11bdd07b8.png)

Used in Spark with some greyvest theme added style overrides

```
.filter-adder .default-modal-wrap {
  border: 0;
  max-width: 1000px;
}
.gv-picker-description-container {
  background: ${bg};
}
.gv-picker-description-container > em {
  color: ${muted};
}
.gv-picker-description-container > div {
  color: ${active};
}
```
![Screen Shot 2022-09-01 at 5 46 52 PM](https://user-images.githubusercontent.com/532680/188018893-6e8841aa-b5bf-4003-b501-a6e577012710.png)

