### PR TITLE
Revert package.json exports field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.54.12
+
+- Revert package.json exports field
+
 # 2.54.11
 
 - Add exports field to package.json

--- a/package.json
+++ b/package.json
@@ -1,15 +1,9 @@
 {
   "name": "contexture-react",
-  "version": "2.54.11",
+  "version": "2.54.12",
   "description": "React components for building contexture interfaces",
   "type": "module",
   "main": "dist/esm/index.js",
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
-    }
-  },
   "files": [
     "./dist"
   ],


### PR DESCRIPTION
We're importing from `dist` in quite a few places (which we shouldn't do) and the files do not get resolved by node because of the `exports` field. Proper fix is to re-export everything we need.