### PR TITLE
Fix some query builder imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.54.15
+
+- Fix query builder imports
+
 # 2.54.14
 
 - Fix grey-vest publishing v2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture-react",
-  "version": "2.54.14",
+  "version": "2.54.15",
   "description": "React components for building contexture interfaces",
   "type": "module",
   "main": "dist/esm/index.js",

--- a/src/queryBuilder/DragDrop/DDContext.js
+++ b/src/queryBuilder/DragDrop/DDContext.js
@@ -1,4 +1,4 @@
-import dnd from 'react-dnd'
+import { DragDropContext } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 
-export default dnd.DragDropContext(HTML5Backend)
+export default DragDropContext(HTML5Backend)

--- a/src/queryBuilder/DragDrop/FilterDragSource.js
+++ b/src/queryBuilder/DragDrop/FilterDragSource.js
@@ -1,6 +1,6 @@
-import dnd from 'react-dnd'
+import { DragSource } from 'react-dnd'
 
-export default dnd.DragSource(
+export default DragSource(
   'filter',
   {
     beginDrag: (props) => ({

--- a/src/queryBuilder/DragDrop/FilterDropTarget.js
+++ b/src/queryBuilder/DragDrop/FilterDropTarget.js
@@ -1,7 +1,7 @@
-import dnd from 'react-dnd'
+import { DropTarget } from 'react-dnd'
 
 export let FilterDropTarget = (spec) =>
-  dnd.DropTarget('filter', spec, (connect, monitor) => ({
+  DropTarget('filter', spec, (connect, monitor) => ({
     connectDropTarget: connect.dropTarget(),
     isOver: monitor.isOver(),
     canDrop: monitor.canDrop(),


### PR DESCRIPTION
Looks like transpiled code doesn't like these default imports. This will all get sorted out once we upgrade react-dnd to the latest version since their package will be much saner then.